### PR TITLE
MLflow connection timing

### DIFF
--- a/mermaid_classifier/pyspacer/annotation.py
+++ b/mermaid_classifier/pyspacer/annotation.py
@@ -43,9 +43,10 @@ MLFLOW_MODEL_ID_REGEX = re.compile(r'm-[a-f0-9]{30,32}')
 
 def mlflow_model_id_to_pkl_uri(model_id: str) -> str:
 
-    model_filename = 'model.pkl'
-    mlflow_connect()
+    time_taken = mlflow_connect()
+    print(f"Time to connect to MLflow tracking: {time_taken}")
 
+    model_filename = 'model.pkl'
     logged_model = mlflow.get_logged_model(model_id)
     return logged_model.artifact_location + '/' + model_filename
 

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -628,7 +628,9 @@ def run_training(
 
     else:
 
-        mlflow_connect()
+        time_taken = mlflow_connect()
+        logger.info(f"Time to connect to MLflow tracking: {time_taken}")
+
         mlflow.set_experiment(experiment_name)
 
         with mlflow.start_run(run_name=run_name):

--- a/mermaid_classifier/pyspacer/utils.py
+++ b/mermaid_classifier/pyspacer/utils.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 import logging
 
 import mlflow
@@ -41,11 +42,12 @@ def logging_config_for_script(name):
     return logging.getLogger(name)
 
 
-def mlflow_connect():
+def mlflow_connect() -> timedelta:
     mlflow.set_tracking_uri(uri=settings.mlflow_tracking_server)
 
     try:
         # Do something to test the server connection.
+        time_before_connect = datetime.now()
         mlflow.search_experiments(max_results=1)
     except mlflow.exceptions.MlflowException as e:
         # Note that this may take a long time to reach
@@ -59,3 +61,7 @@ def mlflow_connect():
         # If it's some other kind of MlflowException, just re-raise
         # for debugging purposes.
         raise e
+
+    time_after_connect = datetime.now()
+    # Return the time taken to connect.
+    return time_after_connect - time_before_connect


### PR DESCRIPTION
Logs/prints the time it takes to connect to MLflow tracking. That is, when an MLflow connection is required, it does a very simple operation that requires such a connection - `mlflow.search_experiments(max_results=1)` - and times how long it takes.

Note: `train.py` logs the time to file and console, while `annotation.py` just prints it to console, due to how logging is set up differently between the two scripts (since there are more concerns about performance, memory, etc. with training). Later I think it would be good to make the logging more generalized, so that both scripts have the same logging behaviors available to them, but just with different defaults.

While I was already in the `mlflow_connect()` function, I added an exception re-raise statement there which was mistakenly missing before.