### PR TITLE
Log tabular artifacts with log_text('name.csv'), not log_table('name.json')

### DIFF
--- a/mermaid_classifier/common/csv_utils.py
+++ b/mermaid_classifier/common/csv_utils.py
@@ -43,6 +43,10 @@ class CsvSpec(abc.ABC):
 
     def __init__(self, csv_file: typing.TextIO):
 
+        self.csv_text = csv_file.read()
+        # Set up for re-reading with pandas.
+        csv_file.seek(0)
+
         try:
             self.csv_dataframe = csv_to_dataframe(csv_file)
         except pd.errors.EmptyDataError:


### PR DESCRIPTION
I previously used `mlflow.log_table()` because on a surface level, it sounded like the right way to log tabular artifacts, but the fact that it outputs to JSON isn't great. Using `mlflow.log_text()` to output CSV instead allows the resulting artifact file to be inspected readily with an external program, such as Excel / LibreOffice Calc.

For a few of our tabular artifacts, we read in the data as CSV-text in the first place, so we just pass exactly that to log_text(). For most of the rest, we ended up with the data in pandas dataframe format (often a result of a DuckDB query); so I wrote a helper function to take a dataframe, convert it into CSV text, and pass that to log_text().

Incidentally, this change also makes the tabular artifacts quicker to load in the MLflow UI (although I think horizontal scrolling through the table columns has become more awkward, for some reason).

