### PR TITLE
Precision, recall, and F1 as table/dict artifacts

### DIFF
--- a/mermaid_classifier/pyspacer/metrics.py
+++ b/mermaid_classifier/pyspacer/metrics.py
@@ -1,0 +1,201 @@
+from collections import Counter
+from contextlib import contextmanager
+import typing
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import sklearn
+from spacer.data_classes import ValResults
+
+
+@contextmanager
+def make_confusion_matrix(
+    val_results: ValResults,
+    normalize: bool,
+    ba_library: 'BenthicAttributeLibrary',
+    gf_library: 'GrowthFormLibrary',
+):
+    """
+    Make a confusion matrix out of the training evaluation results.
+    Return it in dataframe and matplotlib figure forms.
+    This is a context manager so that the figure can be closed to free memory.
+    """
+
+    matrix = sklearn.metrics.confusion_matrix(
+        y_true=val_results.gt,
+        y_pred=val_results.est,
+        labels=range(len(val_results.classes)),
+        # 'true': values between 0 and 1 for each cell.
+        # None: Each cell has a frequency.
+        normalize='true' if normalize else None,
+    )
+
+    if normalize:
+        # 0-to-1 values -> integer percents.
+        matrix = np.int64(np.floor(matrix * 100))
+
+    # Classes in order of their frequency in val_results true labels.
+    class_indexes_in_freq_order = [
+        class_index
+        for class_index, _ in Counter(val_results.gt).most_common()]
+    # Order columns by frequency.
+    matrix = matrix[:, class_indexes_in_freq_order]
+    # Order rows by frequency.
+    matrix = matrix[class_indexes_in_freq_order, :]
+
+    bagf_names = [
+        ba_library.bagf_id_to_name(
+            val_results.classes[class_index], gf_library)
+        for class_index in class_indexes_in_freq_order
+    ]
+
+    # Confusion matrix as a table.
+
+    # To dataframe, labeling each column with a BA-GF combo.
+    df = pd.DataFrame(data=matrix, columns=bagf_names)
+    # Add column to label each row with a BA-GF combo.
+    df.insert(loc=0, column='-', value=bagf_names)
+
+    # Confusion matrix as a figure.
+
+    # Create square figure, with size scaled to number of labels
+    num_labels = len(bagf_names)
+    fig_size = max(12, num_labels * 0.6)
+    fig, ax = plt.subplots(figsize=(fig_size, fig_size))
+
+    # Matplotlib visualization of the confusion matrix.
+    display = sklearn.metrics.ConfusionMatrixDisplay(
+        confusion_matrix=matrix, display_labels=bagf_names)
+    display.plot(
+        ax=ax,
+        cmap='Blues',
+        # Prevent "100" displaying as "1e+02".
+        values_format='d',
+        # A color legend feels unnecessary here.
+        colorbar=False,
+    )
+
+    # Move x-axis labels to the top.
+    ax.xaxis.set_label_position('top')
+    ax.xaxis.set_ticks_position('top')
+    # Rotate x-axis tick labels to prevent their texts from overlapping.
+    label_font_size = max(8, min(12, 150 / num_labels))
+    plt.setp(
+        ax.get_xticklabels(),
+        rotation=45,
+        ha='left',
+        rotation_mode='anchor',
+        fontsize=label_font_size,
+    )
+    # Match y-axis labels' font size with the x axis.
+    plt.setp(
+        ax.get_yticklabels(),
+        fontsize=label_font_size,
+    )
+
+    # Adjust layout to prevent label cutoff
+    plt.tight_layout()
+
+    yield df, fig
+
+    # Close figure to free memory
+    plt.close(fig)
+
+
+def precision_recall_f1(
+    val_results: ValResults,
+    format_func: typing.Callable[[float], typing.Any],
+    ba_library: 'BenthicAttributeLibrary',
+    gf_library: 'GrowthFormLibrary',
+) -> tuple[list[dict], dict]:
+    """
+    Given pyspacer ValResults and a metric-formatting function, return
+    per-label and overall precision, recall, and f1 metrics.
+    """
+
+    # Convert the valresults to a pandas dataframe.
+
+    actual_annotations = pd.Categorical(
+        [val_results.classes[i] for i in val_results.gt])
+    predicted_annotations = pd.Categorical(
+        [val_results.classes[i] for i in val_results.est])
+    annotations_df = pd.DataFrame({
+        'actual': actual_annotations,
+        'predicted': predicted_annotations,
+    })
+
+    # Precision, recall, F1: per label
+
+    per_label_metrics = []
+
+    for label in val_results.classes:
+
+        precision = sklearn.metrics.precision_score(
+            annotations_df['actual'],
+            annotations_df['predicted'],
+            # This makes it produce single-label metrics.
+            labels=[label],
+            # For single-label, micro and macro are the same, so it doesn't
+            # matter which we pass in for `average`.
+            average='micro',
+            # If any label is lacking true positives and false positives,
+            # or true positives and false negatives, either precision or
+            # recall may have zero in the denominator of the calculation.
+            # So we define what value we use in that situation.
+            zero_division=0.0,
+        )
+        recall = sklearn.metrics.recall_score(
+            annotations_df['actual'],
+            annotations_df['predicted'],
+            labels=[label],
+            average='micro',
+            zero_division=0.0,
+        )
+
+        if precision + recall == 0.0:
+            # Avoid division by zero.
+            f1_score = 0.0
+        else:
+            f1_score = 2 * (precision * recall) / (precision + recall)
+
+        per_label_metrics.append(dict(
+            bagf_name=ba_library.bagf_id_to_name(label, gf_library),
+            precision=format_func(precision),
+            recall=format_func(recall),
+            f1_score=format_func(f1_score),
+            bagf_id=label,
+        ))
+
+    # Precision, recall, F1: overall
+
+    overall_metrics = dict()
+
+    # average='macro' calculates precision for each class and then averages
+    # them, treating all classes equally irrespective of their frequency
+    # in the dataset.
+    # average='micro' does calculations globally without separating by class,
+    # but in this case precision, recall, f1 score, and accuracy are all the
+    # same result. And we already get accuracy from pyspacer. So, focus on
+    # macro here.
+    precision = sklearn.metrics.precision_score(
+        actual_annotations,
+        predicted_annotations,
+        average='macro',
+        zero_division=0.0,
+    )
+    recall = sklearn.metrics.recall_score(
+        actual_annotations,
+        predicted_annotations,
+        average='macro',
+        zero_division=0.0,
+    )
+    f1_score = 2 * (precision * recall) / (precision + recall)
+
+    overall_metrics |= dict(
+        precision_macro=format_func(precision),
+        recall_macro=format_func(recall),
+        f1_macro=format_func(f1_score),
+    )
+
+    return per_label_metrics, overall_metrics

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -15,17 +15,14 @@ import time
 import typing
 
 import duckdb
-import matplotlib.pyplot as plt
 try:
     import mlflow
     MLFLOW_IMPORT_ERROR = None
 except ImportError as err:
     MLFLOW_IMPORT_ERROR = err
-import numpy as np
 import pandas as pd
 import psutil
 from s3fs.core import S3FileSystem
-import sklearn
 from spacer.data_classes import DataLocation, ImageLabels, ValResults
 from spacer.messages import TrainClassifierMsg
 from spacer.storage import load_classifier
@@ -49,6 +46,8 @@ from mermaid_classifier.common.duckdb_utils import (
     duckdb_temp_table_name,
     duckdb_transform_column,
 )
+from mermaid_classifier.pyspacer.metrics import (
+    make_confusion_matrix, precision_recall_f1)
 from mermaid_classifier.pyspacer.settings import settings
 from mermaid_classifier.pyspacer.utils import (
     logging_config_for_script, mlflow_connect)
@@ -1443,7 +1442,7 @@ class MLflowTrainingRunner(TrainingRunner):
             )
 
             per_label_prf, overall_metrics = precision_recall_f1(
-                val_results, self.format_metric)
+                val_results, self.format_metric, ba_library, gf_library)
             overall_metrics['accuracy'] = self.format_metric(return_msg.acc)
 
             # Log overall metrics with log_metric(). Note that this method
@@ -1632,197 +1631,9 @@ class MLflowTrainingRunner(TrainingRunner):
     def log_confusion_matrix(
         self, val_results: ValResults, normalize: bool, filestem: str
     ):
-        """
-        Make a confusion matrix out of the training evaluation results.
-        """
-        matrix = sklearn.metrics.confusion_matrix(
-            y_true=val_results.gt,
-            y_pred=val_results.est,
-            labels=range(len(val_results.classes)),
-            # 'true': values between 0 and 1 for each cell.
-            # None: Each cell has a frequency.
-            normalize='true' if normalize else None,
-        )
+        with make_confusion_matrix(
+            val_results, normalize, ba_library, gf_library,
+        ) as (df, fig):
 
-        if normalize:
-            # 0-to-1 values -> integer percents.
-            matrix = np.int64(np.floor(matrix * 100))
-
-        # Sort by frequency.
-        bagf_ids_in_freq_order = []
-        # This artifact already has BA-GF combos sorted by frequency
-        # in the whole dataset (which should be pretty much the same
-        # order as frequency in val, due to stratification); highest
-        # frequency first.
-        for _, row in self.dataset.artifacts.bagf_counts.iterrows():
-            bagf_id = combine_ba_gf(
-                row['benthic_attribute_id'], row['growth_form_id'])
-            if bagf_id not in val_results.classes:
-                # This BA-GF combo must have gotten dropped entirely due
-                # to not enough annotations.
-                continue
-            bagf_ids_in_freq_order.append(bagf_id)
-        # For each ID in the frequency order, give it 0 if it appears 1st
-        # in val_results.classes, 1 if it appears 2nd, 2 if 3rd, etc.
-        class_indexes_of_freq_ranking = [
-            val_results.classes.index(bagf_id)
-            for bagf_id in bagf_ids_in_freq_order]
-        # Order columns by frequency.
-        matrix = matrix[:, class_indexes_of_freq_ranking]
-        # Order rows by frequency.
-        matrix = matrix[class_indexes_of_freq_ranking, :]
-
-        bagf_names = [
-            ba_library.bagf_id_to_name(bagf_id, gf_library)
-            for bagf_id in bagf_ids_in_freq_order
-        ]
-
-        # Log the confusion matrix as a table.
-
-        # To dataframe, labeling each column with a BA-GF combo.
-        df = pd.DataFrame(data=matrix, columns=bagf_names)
-        # Add column to label each row with a BA-GF combo.
-        df.insert(loc=0, column='-', value=bagf_names)
-        self.log_dataframe(df, filestem)
-
-        # Log the confusion matrix as a figure.
-
-        # Create square figure, with size scaled to number of labels
-        num_labels = len(bagf_names)
-        fig_size = max(12, num_labels * 0.6)
-        fig, ax = plt.subplots(figsize=(fig_size, fig_size))
-
-        # Matplotlib visualization of the confusion matrix.
-        display = sklearn.metrics.ConfusionMatrixDisplay(
-            confusion_matrix=matrix, display_labels=bagf_names)
-        display.plot(
-            ax=ax,
-            cmap='Blues',
-            # Prevent "100" displaying as "1e+02".
-            values_format='d',
-            # A color legend feels unnecessary here.
-            colorbar=False,
-        )
-
-        # Move x-axis labels to the top.
-        ax.xaxis.set_label_position('top')
-        ax.xaxis.set_ticks_position('top')
-        # Rotate x-axis tick labels to prevent their texts from overlapping.
-        label_font_size = max(8, min(12, 150 / num_labels))
-        plt.setp(
-            ax.get_xticklabels(),
-            rotation=45,
-            ha='left',
-            rotation_mode='anchor',
-            fontsize=label_font_size,
-        )
-        # Match y-axis labels' font size with the x axis.
-        plt.setp(
-            ax.get_yticklabels(),
-            fontsize=label_font_size,
-        )
-
-        # Adjust layout to prevent label cutoff
-        plt.tight_layout()
-
-        # Log as figure
-        mlflow.log_figure(fig, filestem + '.png')
-
-        # Close figure to free memory
-        plt.close(fig)
-
-
-def precision_recall_f1(
-    val_results: ValResults,
-    format_func: typing.Callable[[float], typing.Any],
-) -> tuple[list[dict], dict]:
-    """
-    Given pyspacer ValResults and a metric-formatting function, return
-    per-label and overall precision, recall, and f1 metrics.
-    """
-
-    # Convert the valresults to a pandas dataframe.
-
-    actual_annotations = pd.Categorical(
-        [val_results.classes[i] for i in val_results.gt])
-    predicted_annotations = pd.Categorical(
-        [val_results.classes[i] for i in val_results.est])
-    annotations_df = pd.DataFrame({
-        'actual': actual_annotations,
-        'predicted': predicted_annotations,
-    })
-
-    # Precision, recall, F1: per label
-
-    per_label_metrics = []
-
-    for label in val_results.classes:
-
-        precision = sklearn.metrics.precision_score(
-            annotations_df['actual'],
-            annotations_df['predicted'],
-            # This makes it produce single-label metrics.
-            labels=[label],
-            # For single-label, micro and macro are the same, so it doesn't
-            # matter which we pass in for `average`.
-            average='micro',
-            # If any label is lacking true positives and false positives,
-            # or true positives and false negatives, either precision or
-            # recall may have zero in the denominator of the calculation.
-            # So we define what value we use in that situation.
-            zero_division=0.0,
-        )
-        recall = sklearn.metrics.recall_score(
-            annotations_df['actual'],
-            annotations_df['predicted'],
-            labels=[label],
-            average='micro',
-            zero_division=0.0,
-        )
-
-        if precision + recall == 0.0:
-            # Avoid division by zero.
-            f1_score = 0.0
-        else:
-            f1_score = 2 * (precision * recall) / (precision + recall)
-
-        per_label_metrics.append(dict(
-            bagf_name=ba_library.bagf_id_to_name(label, gf_library),
-            precision=format_func(precision),
-            recall=format_func(recall),
-            f1_score=format_func(f1_score),
-            bagf_id=label,
-        ))
-
-    # Precision, recall, F1: overall
-
-    overall_metrics = dict()
-
-    # average='macro' calculates precision for each class and then averages
-    # them, treating all classes equally irrespective of their frequency
-    # in the dataset.
-    # average='micro' does calculations globally without separating by class,
-    # but in this case precision, recall, f1 score, and accuracy are all the
-    # same result. And we already get accuracy from pyspacer. So, focus on
-    # macro here.
-    precision = sklearn.metrics.precision_score(
-        actual_annotations,
-        predicted_annotations,
-        average='macro',
-        zero_division=0.0,
-    )
-    recall = sklearn.metrics.recall_score(
-        actual_annotations,
-        predicted_annotations,
-        average='macro',
-        zero_division=0.0,
-    )
-    f1_score = 2 * (precision * recall) / (precision + recall)
-
-    overall_metrics |= dict(
-        precision_macro=format_func(precision),
-        recall_macro=format_func(recall),
-        f1_macro=format_func(f1_score),
-    )
-
-    return per_label_metrics, overall_metrics
+            self.log_dataframe(df, filestem)
+            mlflow.log_figure(fig, filestem + '.png')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ pyspacer = [
     # are in an installed package, which is our intended usage.
     "pydantic-settings",
     "s3fs",
+    # pyspacer uses scikit-learn, but we also use it directly for metrics.
+    "scikit-learn",
 ]
 jupyterlab = [
     # For interactive matplotlib in JupyterLab. After installation, the


### PR DESCRIPTION
This includes a `metrics_overall.yaml` artifact which looks like:

```yaml
accuracy: 0.694
f1_macro: 0.544
precision_macro: 0.553
recall_macro: 0.535
```

And a `metrics_per_label.csv` artifact like:

|        bagf_name       |precision|recall|f1_score|                bagf_id               |
|------------------------|---------|------|--------|--------------------------------------|
|       Macroalgae       |  0.707  | 0.763|  0.734 |09226989-50e7-4c40-bd36-5bcef32ee7a1::|
|       Turf algae       |  0.444  | 0.235|  0.308 |20090bf4-868e-431b-974c-ab9be5bbdb5f::|
|      Cyanobacteria     |   0.0   |  0.0 |   0.0  |3218e7ea-8827-4262-96a1-104e5ec50ffc::|
|       Hard coral       |  0.802  | 0.855|  0.828 |350e9eb4-5e6b-48f5-aeb8-0bfdf023bf1c::|

A 0.0 indicates a lack of either true positives, false positives, or false negatives for that label.

From what I understand so far (but I'm new to this, correct me if I'm wrong):

- Per-label micro and macro are the same, which is why I made that artifact not specify micro/macro.
- For overall metrics, micro and macro are different, but micro precision/recall/F1/accuracy are the same. At least as long as each point is only labeled with a single label (not multiple labels). So I just kept the 'accuracy' metric, and added macro p/r/f.

Lauren's `read_pyspacer_results.qmd` in the v1 directory got me started with all this. Some notes about that .qmd:

- The document goes through overall metrics, but I don't believe it shows how to get per-label metrics. But by looking at the scikit-learn docs for `precision_score()` etc., I learned how to do it (`labels=[label]` keyword-arg).

- I left out the Dask usage for now, but it seems fairly simple to add back if it would help (and the package seems lightweight). It would be something like `ddf = dd.from_pandas(df, npartitions=100)` to go from a pandas dataframe to a Dask one, and then usage is mostly the same, except that you likely need to stop the lazy operations and force computations with `compute()` at some point.

- This demonstrates at least one other option besides micro and macro, `weighted`. Not sure if that would also be useful. That also may not be all the options in scikit-learn.

- Also demonstrates a `balanced_accuracy` metric.

Bar plots are not included here. That part had been done in R, not Python, at least going by this document: https://ircaldwell.github.io/mermaid_image_class/

- A key R library used here is ggplot. It may be possible to bridge Python and ggplot, like with [lets-plot](https://github.com/JetBrains/lets-plot?tab=readme-ov-file#grammar-of-graphics-for-python-). But, it's looking like work for a later PR if anything.

A couple of changes to highlight in this PR:

- Since precision, recall, and F1 seem to be most commonly expressed as values from 0.0 to 1.0, I also changed accuracy from a percentage to a 0-to-1 in the MLflow artifacts/metrics. So for example, it would now show as 0.707 instead of 70.7%.

- I put the p/r/f computations in a new file, `mermaid_classifier/pyspacer/metrics.py`. I also moved the confusion matrix computation from `train.py` to this `metrics.py`. The idea so far is that `metrics.py` would have some computations, but not the MLflow interfacing details. `train.py` has been getting very large, and this seemed like a sensible way to start splitting it up.