### PR TITLE
Use pyspacer 0.13.0 instead of a feature branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,6 @@ dependencies = [
 [tool.hatch.build.targets.wheel]
 packages = ["mermaid_classifier"]
 
-# This allows getting pyspacer from an explicit repo URL.
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [project.optional-dependencies]
 pyspacer = [
     "beautifulsoup4",
@@ -28,11 +24,9 @@ pyspacer = [
     "pandas",
     "psutil",
     "pyarrow",
-    # This branch:
-    # - allows anonymous AWS access
-    # - allows train data to come from multiple buckets
-    # These improvements will be in a stable pyspacer version later.
-    "pyspacer@git+https://github.com/coralnet/pyspacer.git@train-data-source-flexibility",
+    # The core API of pyspacer is still ever-changing, and classifier
+    # compatibility can be tricky too, so specifying version is important.
+    "pyspacer==0.13.0",
     # python-dotenv by itself isn't explicit about what variable
     # names it accepts.
     # python-decouple and pydantic-settings are more explicit.


### PR DESCRIPTION
For months, mermaid-classifier has been using the `train-data-source-flexibility` feature branch of pyspacer to get the following:

- Most of the commits in this [AWS flexibility PR](https://github.com/coralnet/pyspacer/pull/128), except the last two commits. I think I only touched on this very briefly in MERMAID discussions, because it shouldn't affect the current SageMaker setup; it's mainly for connecting from a local machine.
- The commits in [this train data flexibility PR](https://github.com/coralnet/pyspacer/pull/134). The main changes here have been discussed with MERMAID team about 3 months ago, but if you read the PR description now, there are some details that I hadn't gotten around to explaining until now. But all of these changes have been used in mermaid-classifier for months already.

These commits hadn't been merged into pyspacer's main branch, let alone been released in a numbered version, largely because I was feeling pressed for time and wasn't sure if merging this right away would add to my coralnet workload. However, I've now found the opportunity to take care of loose feature-branches like these.

I just released pyspacer 0.13.0, which has everything from the above PRs as well as:

- A [numpy range update](https://github.com/coralnet/pyspacer/pull/130) (SageMaker's numpy 1.26 is still in-range, so it's unaffected)
- A [Pillow update](https://github.com/coralnet/pyspacer/pull/133)
- A [fix for torch 2.7+](https://github.com/coralnet/pyspacer/pull/129) (but SageMaker is unaffected as it's currently on 2.6)
- A [fix](https://github.com/coralnet/pyspacer/pull/132) to make an import more consistent

Overall, I'd say those points are pretty inconsequential for mermaid-classifier's current usage, so it should be safe to merge this whenever it's convenient.

It's still important to pin pyspacer to a specific version, but that's a step up from getting a branch of the repo (since it's customary to leave git version tags in the same place indefinitely, but not branches).