### PR TITLE
Faster training by pre-downloading feature vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+uv.lock
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -160,3 +161,10 @@ cython_debug/
 .idea/
 
 .python-version
+
+# mlflow 
+mlruns/
+mlflow.db
+
+# AI
+CLAUDE.md

--- a/mermaid_classifier/pyspacer/settings.py
+++ b/mermaid_classifier/pyspacer/settings.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     # Yes, this is str. After it gets through the settings machinery,
     # pyspacer will convert to int.
     spacer_batch_size: str | None = str(automatic_batch_size())
+    download_max_workers: int = 50
     mlflow_http_request_max_retries: str | None = None
     mlflow_default_experiment_name: str | None = None
 

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -27,6 +27,7 @@ import psutil
 from s3fs.core import S3FileSystem
 from mlflow.tracking.fluent import run_id_to_system_metrics_monitor
 from mermaid_classifier.pyspacer.swap_monitor import SwapMonitor
+from spacer.aws import get_s3_resource
 from spacer.data_classes import DataLocation, ImageLabels, ValResults
 from spacer.messages import TrainClassifierMsg
 from spacer.storage import load_classifier
@@ -111,7 +112,7 @@ def section_profiling(profiled_sections: list[dict], section_name: str):
 def download_features_parallel(
     s3_keys: dict[tuple[str, str], str],
     max_workers: int = 50,
-) -> tuple[int, list[str]]:
+) -> set[tuple[str, str]]:
     """
     Download feature vectors from S3 in parallel.
 
@@ -121,26 +122,29 @@ def download_features_parallel(
         max_workers: Number of concurrent download threads.
 
     Returns:
-        (success_count, list_of_failed_keys)
+        Set of (bucket, key) tuples that failed to download.
     """
-    import boto3
-
     total = len(s3_keys)
     if total == 0:
-        return 0, []
+        return set()
 
     logger.info(
         f"Downloading {total} feature vectors"
         f" with {max_workers} workers...")
 
-    failed = []
+    # Pre-create all unique parent directories.
+    unique_dirs = {os.path.dirname(local_path)
+                   for local_path in s3_keys.values()}
+    for d in unique_dirs:
+        os.makedirs(d, exist_ok=True)
+
+    failed: set[tuple[str, str]] = set()
     succeeded = 0
 
     def _download(item):
         (bucket, key), local_path = item
-        os.makedirs(os.path.dirname(local_path), exist_ok=True)
-        s3_client = boto3.client('s3')
-        s3_client.download_file(bucket, key, local_path)
+        s3 = get_s3_resource()
+        s3.Object(bucket, key).download_file(local_path)
 
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=max_workers
@@ -157,7 +161,7 @@ def download_features_parallel(
                 future.result()
                 succeeded += 1
             except Exception as e:
-                failed.append(f"{bucket}/{key}")
+                failed.add((bucket, key))
                 logger.warning(
                     f"Failed to download s3://{bucket}/{key}: {e}")
             if i % 1000 == 0 or i == total:
@@ -165,7 +169,7 @@ def download_features_parallel(
                     f"Download progress: {i}/{total}"
                     f" ({succeeded} ok, {len(failed)} failed)")
 
-    return succeeded, failed
+    return failed
 
 
 class LabelFilter(CsvSpec):
@@ -1033,21 +1037,21 @@ class TrainingDataset:
 
         # Parallel download of all feature vectors from S3.
         with self.section_profiling("Downloading feature vectors"):
-            succeeded, failed = download_features_parallel(s3_keys, max_workers=settings.download_max_workers)
+            failed_keys = download_features_parallel(s3_keys, max_workers=settings.download_max_workers)
 
-        if failed:
+        if failed_keys:
             logger.warning(
-                f"{len(failed)} feature vector download(s) failed.")
+                f"{len(failed_keys)} feature vector download(s) failed.")
 
         # Build ImageLabels with filesystem DataLocations.
         labels_data = ImageLabels()
 
         for bucket, feature_bucket_path, image_annotations in image_data:
-            local_path = s3_keys[(bucket, feature_bucket_path)]
-
             # Skip images whose feature file failed to download.
-            if not os.path.exists(local_path):
+            if (bucket, feature_bucket_path) in failed_keys:
                 continue
+
+            local_path = s3_keys[(bucket, feature_bucket_path)]
 
             feature_loc = DataLocation(
                 storage_type='filesystem',
@@ -1427,9 +1431,9 @@ class TrainingRunner:
             run_name = self.current_time_str()
         logger.info(f"Run: {run_name}")
 
-        self.dataset = TrainingDataset(self.dataset_options)
-
         try:
+            self.dataset = TrainingDataset(self.dataset_options)
+
             # The dataset's profiled sections are done. The runner will
             # add the remaining profiled sections.
             self.profiled_sections = self.dataset.profiled_sections.copy()
@@ -1487,7 +1491,8 @@ class TrainingRunner:
 
             return return_msg, model_loc, valresult_loc
         finally:
-            self.dataset.cleanup()
+            if self.dataset is not None:
+                self.dataset.cleanup()
 
     def _on_epoch_end(self, metrics: dict):
         """Called after each training epoch. Override for logging."""

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -1033,7 +1033,7 @@ class TrainingDataset:
 
         # Parallel download of all feature vectors from S3.
         with self.section_profiling("Downloading feature vectors"):
-            succeeded, failed = download_features_parallel(s3_keys)
+            succeeded, failed = download_features_parallel(s3_keys, max_workers=settings.download_max_workers)
 
         if failed:
             logger.warning(

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -2,12 +2,14 @@
 Train a classifier using feature vectors and annotations
 provided on S3.
 """
+import concurrent.futures
 from contextlib import contextmanager
 import dataclasses
 from datetime import datetime, timedelta
 import enum
 from io import StringIO
 import math
+import os
 from pathlib import Path
 import re
 import tempfile
@@ -104,6 +106,66 @@ def section_profiling(profiled_sections: list[dict], section_name: str):
         f" Elapsed time = {section_profile['hms']},"
         f" Memory usage at end = {section_profile['memory_usage_at_end']}"
     )
+
+
+def download_features_parallel(
+    s3_keys: dict[tuple[str, str], str],
+    max_workers: int = 50,
+) -> tuple[int, list[str]]:
+    """
+    Download feature vectors from S3 in parallel.
+
+    Args:
+        s3_keys: Mapping of (bucket, key) → local_path for each file
+            to download.
+        max_workers: Number of concurrent download threads.
+
+    Returns:
+        (success_count, list_of_failed_keys)
+    """
+    import boto3
+
+    total = len(s3_keys)
+    if total == 0:
+        return 0, []
+
+    logger.info(
+        f"Downloading {total} feature vectors"
+        f" with {max_workers} workers...")
+
+    failed = []
+    succeeded = 0
+
+    def _download(item):
+        (bucket, key), local_path = item
+        os.makedirs(os.path.dirname(local_path), exist_ok=True)
+        s3_client = boto3.client('s3')
+        s3_client.download_file(bucket, key, local_path)
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=max_workers
+    ) as executor:
+        futures = {
+            executor.submit(_download, item): item
+            for item in s3_keys.items()
+        }
+        for i, future in enumerate(
+            concurrent.futures.as_completed(futures), 1
+        ):
+            (bucket, key), local_path = futures[future]
+            try:
+                future.result()
+                succeeded += 1
+            except Exception as e:
+                failed.append(f"{bucket}/{key}")
+                logger.warning(
+                    f"Failed to download s3://{bucket}/{key}: {e}")
+            if i % 1000 == 0 or i == total:
+                logger.info(
+                    f"Download progress: {i}/{total}"
+                    f" ({succeeded} ok, {len(failed)} failed)")
+
+    return succeeded, failed
 
 
 class LabelFilter(CsvSpec):
@@ -445,6 +507,8 @@ class TrainingDataset:
         self.options = options
         self.artifacts = Artifacts()
         self.profiled_sections = []
+        self._feature_temp_dir = tempfile.TemporaryDirectory(
+            prefix='mermaid_features_')
 
 
 
@@ -615,6 +679,10 @@ class TrainingDataset:
         self.set_train_summary_stats()
 
 
+
+    def cleanup(self):
+        """Clean up temporary feature vector files."""
+        self._feature_temp_dir.cleanup()
 
     @contextmanager
     def section_profiling(self, section_name: str):
@@ -926,7 +994,11 @@ class TrainingDataset:
             grouping_column_names=['bucket', 'feature_vector'],
         )
 
-        labels_data = ImageLabels()
+        # First pass: collect annotations and unique S3 keys.
+        s3_keys: dict[tuple[str, str], str] = {}
+        tmp_root = self._feature_temp_dir.name
+        # image_data: list of (bucket, key, annotations)
+        image_data = []
 
         for rows in annotations_by_image:
 
@@ -951,10 +1023,35 @@ class TrainingDataset:
                 )
                 image_annotations.append(annotation)
 
+            s3_key = (bucket, feature_bucket_path)
+            if s3_key not in s3_keys:
+                local_path = os.path.join(
+                    tmp_root, bucket, feature_bucket_path)
+                s3_keys[s3_key] = local_path
+
+            image_data.append((bucket, feature_bucket_path, image_annotations))
+
+        # Parallel download of all feature vectors from S3.
+        with self.section_profiling("Downloading feature vectors"):
+            succeeded, failed = download_features_parallel(s3_keys)
+
+        if failed:
+            logger.warning(
+                f"{len(failed)} feature vector download(s) failed.")
+
+        # Build ImageLabels with filesystem DataLocations.
+        labels_data = ImageLabels()
+
+        for bucket, feature_bucket_path, image_annotations in image_data:
+            local_path = s3_keys[(bucket, feature_bucket_path)]
+
+            # Skip images whose feature file failed to download.
+            if not os.path.exists(local_path):
+                continue
+
             feature_loc = DataLocation(
-                storage_type='s3',
-                bucket_name=bucket,
-                key=feature_bucket_path,
+                storage_type='filesystem',
+                key=local_path,
             )
             labels_data.add_image(feature_loc, image_annotations)
 
@@ -1332,58 +1429,65 @@ class TrainingRunner:
 
         self.dataset = TrainingDataset(self.dataset_options)
 
-        # The dataset's profiled sections are done. The runner will add the
-        # remaining profiled sections.
-        self.profiled_sections = self.dataset.profiled_sections.copy()
+        try:
+            # The dataset's profiled sections are done. The runner will
+            # add the remaining profiled sections.
+            self.profiled_sections = self.dataset.profiled_sections.copy()
 
-        # Log dataset artifacts now, so they can be inspected during
-        # training.
-        with self.section_profiling("Logging dataset artifacts"):
-            self.log_dataset_artifacts()
+            # Log dataset artifacts now, so they can be inspected during
+            # training.
+            with self.section_profiling("Logging dataset artifacts"):
+                self.log_dataset_artifacts()
 
-        logger.info("Proceeding to train with:")
-        logger.info(self.dataset.describe_train_summary_stats())
+            logger.info("Proceeding to train with:")
+            logger.info(self.dataset.describe_train_summary_stats())
 
-        # Not sure about saving these anywhere other than memory
-        # for now.
-        model_loc = DataLocation('memory', key='classifier.pkl')
-        valresult_loc = DataLocation('memory', key='valresult.json')
+            # Not sure about saving these anywhere other than memory
+            # for now.
+            model_loc = DataLocation('memory', key='classifier.pkl')
+            valresult_loc = DataLocation('memory', key='valresult.json')
 
-        batch_size = int(settings.spacer_batch_size)
-        logger.info(f"Batch size: {batch_size}")
+            batch_size = int(settings.spacer_batch_size)
+            logger.info(f"Batch size: {batch_size}")
 
-        trainer = MermaidTrainer(
-            batch_size=batch_size,
-            on_epoch_end=self._on_epoch_end,
-        )
+            trainer = MermaidTrainer(
+                batch_size=batch_size,
+                on_epoch_end=self._on_epoch_end,
+            )
 
-        train_msg = TrainClassifierMsg(
-            job_token=f'experiment_run_{run_name}',
-            trainer=trainer,
-            nbr_epochs=self.training_options.epochs,
-            clf_type='MLP',
-            labels=self.dataset.labels,
-            previous_model_locs=[],
-            model_loc=model_loc,
-            valresult_loc=valresult_loc,
-            feature_cache_dir=TrainClassifierMsg.FeatureCache.AUTO,
-        )
+            train_msg = TrainClassifierMsg(
+                job_token=f'experiment_run_{run_name}',
+                trainer=trainer,
+                nbr_epochs=self.training_options.epochs,
+                clf_type='MLP',
+                labels=self.dataset.labels,
+                previous_model_locs=[],
+                model_loc=model_loc,
+                valresult_loc=valresult_loc,
+                feature_cache_dir=TrainClassifierMsg.FeatureCache.DISABLED,
+            )
 
-        with self.section_profiling("PySpacer training call"):
-            return_msg = spacer_train_classifier(train_msg)
+            with self.section_profiling("PySpacer training call"):
+                return_msg = spacer_train_classifier(train_msg)
 
-        logger.info(
-            f"Train time (from return msg): {return_msg.runtime:.1f} s")
+            logger.info(
+                f"Train time (from return msg):"
+                f" {return_msg.runtime:.1f} s")
 
-        logger.info(
-            f"New model's accuracy: {self.format_metric(return_msg.acc)}")
+            logger.info(
+                f"New model's accuracy:"
+                f" {self.format_metric(return_msg.acc)}")
 
-        ref_accs_str = ", ".join(
-            [str(self.format_metric(acc)) for acc in return_msg.ref_accs])
-        logger.debug(
-            f"Accuracy progression during training epochs: {ref_accs_str}")
+            ref_accs_str = ", ".join(
+                [str(self.format_metric(acc))
+                 for acc in return_msg.ref_accs])
+            logger.debug(
+                f"Accuracy progression during training epochs:"
+                f" {ref_accs_str}")
 
-        return return_msg, model_loc, valresult_loc
+            return return_msg, model_loc, valresult_loc
+        finally:
+            self.dataset.cleanup()
 
     def _on_epoch_end(self, metrics: dict):
         """Called after each training epoch. Override for logging."""

--- a/pyspacer_example/.env
+++ b/pyspacer_example/.env
@@ -67,6 +67,9 @@ TRAINING_INPUTS_PERCENT_MISSING_ALLOWED=0
 # Default is auto-calculated from system RAM.
 SPACER_BATCH_SIZE=50000
 
+# Number of concurrent threads for downloading feature vectors from S3.
+DOWNLOAD_MAX_WORKERS=50
+
 # When retrieving or saving models, this is the number of
 # exponential-backoff retries that MLflow will attempt when it's
 # having trouble connecting.

--- a/tests/pyspacer/test_train.py
+++ b/tests/pyspacer/test_train.py
@@ -67,6 +67,7 @@ class NoInitDataset(TrainingDataset):
     def __init__(self):
         self._duck_conn = None
         self.artifacts = Artifacts()
+        self._feature_temp_dir = tempfile.TemporaryDirectory(prefix='mermaid_features_')
 
 
 class BaseTrainTest(unittest.TestCase):


### PR DESCRIPTION
Closes: #24 

Current training is significantly slower because it pulls featurevectors associated with each training image from S3 one at a time.

These changes allow pre-fetching of the featurevectors needed for training as the first step. Subsequent steps use those cached files to avoid needing to pull from S3.

Local testing changed training time from > 4 hours for 1.1 million annotations to ~45 minutes.