### PR TITLE
handle automatic batch size in the training loop instead of up front

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,5 +143,5 @@ Key settings (set via `.env` or environment variables):
 | `AWS_ANONYMOUS` | `True` for public S3 access without credentials |
 | `MLFLOW_TRACKING_SERVER` | MLflow server URI (ARN or localhost) |
 | `SPACER_EXTRACTORS_CACHE_DIR` | Cache dir for downloaded weights |
-| `SPACER_BATCH_SIZE` | Training batch size for partial_fit calls (auto-calculated from RAM) |
+| `SPACER_BATCH_SIZE` | Override for training batch size; if unset, auto-calculated from available memory at training time |
 | `MLFLOW_HTTP_REQUEST_MAX_RETRIES` | Default 7 is slow; 2 recommended |

--- a/mermaid_classifier/pyspacer/README.md
+++ b/mermaid_classifier/pyspacer/README.md
@@ -15,7 +15,7 @@ Both sources are loaded into a shared DuckDB `annotations` table using SQL (not 
 
 **Memory-efficient streaming in trainer**: `MermaidTrainer` in `trainer.py` uses a streaming design -- reference accuracy and calibration both load features in batches from disk, accumulating only scalar predictions. Reference and training data are never held in memory simultaneously. This prevents OOM on large datasets.
 
-**Automatic batch size**: `Settings.automatic_batch_size()` reserves 3GB of overhead and assumes peak memory is batch size + 60% for sklearn buffers. These constants are tuned specifically for EfficientNet feature vectors and may need adjustment for different extractors.
+**Automatic batch size**: `training_batch_size()` in `settings.py` computes batch size from currently available memory at training time, after data-prep is complete. It accounts for EfficientNet feature vectors, sklearn copy overhead, and MLP activation buffers, with 20% headroom. Override via `SPACER_BATCH_SIZE` env var or `.env`.
 
 **Settings case convention**: Setting names are lowercase in Python code but UPPERCASE in `.env` files. The `.env` file is loaded from the current working directory (via pydantic-settings), not from the package location. This is intentional for installed-package usage.
 

--- a/mermaid_classifier/pyspacer/settings.py
+++ b/mermaid_classifier/pyspacer/settings.py
@@ -46,7 +46,10 @@ def training_batch_size(
         # (100,) for small ones; num_classes is the output layer.
         # Use the larger architecture as a conservative estimate.
         activation_units = 200 + 100 + num_classes
-        activation_bytes = activation_units * _BYTES_PER_FLOAT
+        # sklearn's backprop holds both forward activations and backprop
+        # deltas (plus gradient buffers) per layer, so the per-sample
+        # activation memory is roughly double the forward-pass size.
+        activation_bytes = 2 * activation_units * _BYTES_PER_FLOAT
     else:
         # SGDClassifier has negligible internal buffers.
         activation_bytes = 0
@@ -105,8 +108,10 @@ class Settings(BaseSettings):
     training_inputs_percent_missing_allowed: int = 0
     spacer_extractors_cache_dir: str | None = None
     # Override for training batch size. If None (default),
-    # training_batch_size() auto-calculates at runtime.
-    spacer_batch_size: str | None = None
+    # training_batch_size() auto-calculates at runtime. Typed as int so
+    # Pydantic validates the env var at startup rather than failing
+    # mid-run, after the (expensive) data-prep step.
+    spacer_batch_size: int | None = None
     feature_cache_dir: str | None = None
     download_max_workers: int = 50
     mlflow_http_request_max_retries: str | None = None

--- a/mermaid_classifier/pyspacer/settings.py
+++ b/mermaid_classifier/pyspacer/settings.py
@@ -5,35 +5,60 @@ import psutil
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-def automatic_batch_size() -> int:
+# EfficientNet feature vector dimensionality (4096 floats).
+_FEATURE_DIM = 4096
+# Bytes per float64 element (numpy / sklearn default).
+_BYTES_PER_FLOAT = 8
+_FEATURE_BYTES = _FEATURE_DIM * _BYTES_PER_FLOAT
+
+# Minimum batch size — don't go lower than pyspacer's default.
+_MIN_BATCH_SIZE = 5000
+
+
+def training_batch_size(
+    clf_type: str = 'MLP',
+    num_classes: int = 300,
+) -> tuple[int, float]:
     """
-    Calculate a rough batch size for training, based on the amount of
-    memory on the system.
-    This calculation is based on training test-runs that used pyspacer's
-    EfficientNetExtractor.
+    Calculate batch size based on *currently available* memory.
 
-    This value is the default for SPACER_BATCH_SIZE: the batch size for
-    training partial_fit calls and calibration. Controls memory usage
-    during every training epoch and during calibration score computation.
+    Call after data-prep is complete so that
+    psutil.virtual_memory().available reflects what the OS actually
+    has free — including DuckDB tables, ImageLabels structures, and
+    everything else already allocated.
 
-    Peak memory during training is dominated by one batch of feature
-    vectors + sklearn internal buffers (~60% of batch).
+    Accounts for sklearn copy overhead and MLP activation buffers.
+
+    Returns (batch_size, available_gb) so callers can log the memory
+    snapshot that was actually used in the calculation.
     """
-    total_ram_bytes = psutil.virtual_memory().total
+    available_bytes = psutil.virtual_memory().available
+    available_gb = available_bytes / 1e9
 
-    # Reserve 3GB for OS, Python runtime, DuckDB tables, data prep
-    # intermediates (ImageLabels, train_test_split copies), and heap
-    # fragmentation. 
-    base_overhead_bytes = 3e9
-    rough_available_ram_bytes = max(total_ram_bytes - base_overhead_bytes, 0)
+    # Per-point peak memory during partial_fit:
+    #   1. Feature vector loaded from disk:  4096 × 8 bytes
+    #   2. sklearn copies to C-contiguous float64: 4096 × 8 bytes
+    #   3. MLP forward/backward activation buffers per layer
+    sklearn_copy_bytes = _FEATURE_BYTES  # worst-case full copy
 
-    ref_size = int(rough_available_ram_bytes * (50000 / 3e9))
+    if clf_type == 'MLP':
+        # MLP hidden_layer_sizes is (200, 100) for large datasets or
+        # (100,) for small ones; num_classes is the output layer.
+        # Use the larger architecture as a conservative estimate.
+        activation_units = 200 + 100 + num_classes
+        activation_bytes = activation_units * _BYTES_PER_FLOAT
+    else:
+        # SGDClassifier has negligible internal buffers.
+        activation_bytes = 0
 
-    if ref_size < 5000:
-        # Don't go lower than the pyspacer default.
-        ref_size = 5000
+    bytes_per_point = _FEATURE_BYTES + sklearn_copy_bytes + activation_bytes
 
-    return ref_size
+    # Reserve 20% headroom for heap fragmentation, Python GC peaks, and
+    # any other transient allocations.
+    usable_bytes = available_bytes * 0.80
+
+    batch_size = int(usable_bytes / bytes_per_point)
+    return max(batch_size, _MIN_BATCH_SIZE), available_gb
 
 
 class Settings(BaseSettings):
@@ -79,9 +104,9 @@ class Settings(BaseSettings):
     mlflow_tracking_server: str | None = None
     training_inputs_percent_missing_allowed: int = 0
     spacer_extractors_cache_dir: str | None = None
-    # Yes, this is str. After it gets through the settings machinery,
-    # pyspacer will convert to int.
-    spacer_batch_size: str | None = str(automatic_batch_size())
+    # Override for training batch size. If None (default),
+    # training_batch_size() auto-calculates at runtime.
+    spacer_batch_size: str | None = None
     feature_cache_dir: str | None = None
     download_max_workers: int = 50
     mlflow_http_request_max_retries: str | None = None

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -35,6 +35,7 @@ from spacer.task_utils import preprocess_labels, SplitMode
 
 from spacer.tasks import train_classifier as spacer_train_classifier
 
+from mermaid_classifier.pyspacer.settings import training_batch_size
 from mermaid_classifier.pyspacer.trainer import MermaidTrainer
 
 from mermaid_classifier.common.benthic_attributes import (
@@ -1462,8 +1463,21 @@ class TrainingRunner:
             model_loc = DataLocation('memory', key='classifier.pkl')
             valresult_loc = DataLocation('memory', key='valresult.json')
 
-            batch_size = int(settings.spacer_batch_size)
-            logger.info(f"Batch size: {batch_size}")
+            clf_type = 'MLP'
+            num_classes = len(self.dataset.labels.ref.classes_set)
+
+            if settings.spacer_batch_size is not None:
+                batch_size = int(settings.spacer_batch_size)
+                logger.info(
+                    f"Batch size: {batch_size} (from SPACER_BATCH_SIZE)")
+            else:
+                batch_size, available_gb = training_batch_size(
+                    clf_type=clf_type, num_classes=num_classes)
+                logger.info(
+                    f"Batch size: {batch_size}"
+                    f" (auto, based on {available_gb:.1f} GB"
+                    f" available memory, {num_classes} classes,"
+                    f" clf_type={clf_type})")
 
             trainer = MermaidTrainer(
                 batch_size=batch_size,
@@ -1474,7 +1488,7 @@ class TrainingRunner:
                 job_token=f'experiment_run_{run_name}',
                 trainer=trainer,
                 nbr_epochs=self.training_options.epochs,
-                clf_type='MLP',
+                clf_type=clf_type,
                 labels=self.dataset.labels,
                 previous_model_locs=[],
                 model_loc=model_loc,

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -1474,7 +1474,7 @@ class TrainingRunner:
             num_classes = len(self.dataset.labels.ref.classes_set)
 
             if settings.spacer_batch_size is not None:
-                batch_size = int(settings.spacer_batch_size)
+                batch_size = settings.spacer_batch_size
                 logger.info(
                     f"Batch size: {batch_size} (from SPACER_BATCH_SIZE)")
             else:


### PR DESCRIPTION
The previous batch size calculation was failing once scaled to all coralnet sources (up to 2023), resulting in OOM failures in Sagemaker.

This reworks that logic by calculating batch size in the training loop after initialization is complete, and we no longer need to guess how much overhead memory was used for everything else, which avoids estimating a significant unknown in memory use calculations. Batch size is then estimated by making an estimate of memory needed only for training, which should be much more accurate.

Testing in Sagemaker has shown that I can train the classifier on all coralnet sources (up to 2023), where memory spikes up to 80%, but generally sits around 65% ro 70% during training. We could probably decrease the safety net from 20% to 10% if necessary in the future.