### PR TITLE
Record pyspacer in the model manifest; align versioning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,11 @@ re-validates them (load + manifest gate), pushes
 `s3://mermaid-config/classifier/<vN>/{model.pt,model.json,efficientnet.pt}`, and cuts
 GitHub release `vN`. Versions are immutable — re-running an existing `vN` fails.
 
-- **Function image pairing (not a re-tag).** The inference image is model-agnostic
-  and versioned independently (mermaid-inference semver). When cutting model `vN`,
-  record in the GitHub release notes which function image version (`mermaid-inference-pyspacer:<semver>`)
-  the model was validated against. Do **not** tag the image with the model version.
+- **Inference image is built per model version.** Cutting model `vN` is followed
+  by building the inference image `vN-K` (model version + serving build) in
+  mermaid-inference, which bakes `CLASSIFIER_VERSION=vN` and pins the matching
+  pyspacer/sklearn. A code/library fix bumps the build `K`; a retrain bumps `vN`.
+  The deployed function serves exactly its `vN`.
 
 Required repo secrets: `AWS_RELEASE_ROLE_ARN` (OIDC assume-role with read on the
 MLflow artifact store + read/write on `s3://mermaid-config/classifier/*`) and

--- a/mermaid_classifier/pyspacer/inference/export.py
+++ b/mermaid_classifier/pyspacer/inference/export.py
@@ -75,6 +75,9 @@ def export_artifact(
             # the inference package) doesn't pull in sklearn — the serve path
             # needs only torch/numpy.
             "sklearn": sklearn_version,
+            # Read via importlib.metadata (no heavy import); the serving runtime
+            # validates this against its installed pyspacer before scoring.
+            "pyspacer": _pkg_version("pyspacer"),
         },
     }
 

--- a/tests/pyspacer/test_portable_artifact.py
+++ b/tests/pyspacer/test_portable_artifact.py
@@ -83,6 +83,10 @@ class ExportTest(unittest.TestCase):
             self.assertEqual(manifest["config"], {"patch_size": 224})
             self.assertIn("torch", manifest["trained_with"])
             self.assertIn("sklearn", manifest["trained_with"])
+            # trained_with must record pyspacer so the serving runtime can verify
+            # feature-extraction compatibility.
+            from importlib.metadata import version
+            self.assertEqual(manifest["trained_with"]["pyspacer"], version("pyspacer"))
 
             on_disk = json.loads((Path(d) / "model.json").read_text())
             self.assertEqual(on_disk, manifest)


### PR DESCRIPTION
## Summary

Record the pyspacer version in the model artifact manifest so the inference function can verify feature-extraction compatibility at load, and align the docs with the model-build (`vN-K`) versioning scheme.

## Changes

- Add `pyspacer` to `model.json`'s `trained_with` (alongside torch + sklearn), read via `importlib.metadata` (no heavy import).
- Update the release-runbook README note: the inference image is built per model version and tagged `vN-K` (model version + serving build) — supersedes the earlier "model-agnostic / don't re-tag with the model version" note.