### PR TITLE
Enforce formatting, linting & type checking (#67)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,47 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel in-progress runs when a PR is updated.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: ruff + basedpyright (Linux, Python 3.12)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: '3.12'
+          enable-cache: true
+
+      - name: Install package with training extras and lint group
+        # Real deps must be installed so basedpyright can resolve imports
+        # (torch, pyspacer, scikit-learn, mlflow, duckdb, …).
+        # --frozen fails CI if uv.lock is out of sync with pyproject.toml.
+        run: uv sync --frozen --extra training --group lint
+
+      - name: Check lockfile is in sync
+        run: uv lock --check
+
+      - name: Ruff lint
+        run: uv run --no-sync ruff check .
+
+      - name: Ruff format check
+        run: uv run --no-sync ruff format --check .
+
+      - name: basedpyright (strict)
+        run: uv run --no-sync basedpyright

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ CLAUDE.md
 
 # Generated HTML training reports (scripts/generate_report.py)
 report_*.html
+
+# Ruff cache
+.ruff_cache/

--- a/README.md
+++ b/README.md
@@ -111,6 +111,25 @@ Set up this project as an [editable install](https://pip.pypa.io/en/stable/topic
 
 These can be run by, for example, changing the working directory to `tests` and then running `python -m unittest`.
 
+### Linting, formatting & type checking
+
+These are enforced on every PR by `.github/workflows/lint.yml` (alongside the
+unittest workflow in `tests.yml`); both must pass to merge. There are no
+pre-commit hooks — a forgotten local check simply fails the PR.
+
+Run the checks locally with the `lint` dependency group:
+
+    uv run --group lint ruff check .          # lint
+    uv run --group lint ruff format .         # auto-format
+    uv run --group lint ruff format --check . # CI's format gate (no writes)
+    uv run --group lint basedpyright          # type check
+
+basedpyright runs in strict mode over `mermaid_classifier/` + `scripts/`, with
+the "unknown type" rules that fire on untyped third-party libraries
+(torch/pyspacer/duckdb/mlflow/sklearn) disabled — see `[tool.basedpyright]` in
+`pyproject.toml`. `tests/` are linted and formatted but not type-checked; the
+legacy `v1/` directory is excluded from all checks.
+
 ### Design notes
 
 This project is set up as a Python package with a [flat project layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).

--- a/mermaid_classifier/common/benthic_attributes.py
+++ b/mermaid_classifier/common/benthic_attributes.py
@@ -75,17 +75,17 @@ class BenthicAttributeLibrary:
             self.by_name[result["name"]] = result
             self.by_parent[result["parent"]].append(result)
 
-    def id_to_name(self, ba_id):
+    def id_to_name(self, ba_id: str) -> str:
         if ba_id == "":
             return ""
         return self.by_id[ba_id]["name"]
 
-    def name_to_id(self, ba_name):
+    def name_to_id(self, ba_name: str) -> str:
         if ba_name == "":
             return ""
         return self.by_name[ba_name]["id"]
 
-    def bagf_id_to_name(self, bagf_id, gf_library):
+    def bagf_id_to_name(self, bagf_id: str, gf_library: "GrowthFormLibrary") -> str:
         ba_id, gf_id = split_ba_gf(bagf_id)
         ba_name = self.by_id[ba_id]["name"]
         if gf_id == "":
@@ -94,7 +94,7 @@ class BenthicAttributeLibrary:
             return ba_name
         return BAGF_SEP.join([ba_name, gf_library.by_id[gf_id]])
 
-    def get_ancestor_ids(self, ba_id):
+    def get_ancestor_ids(self, ba_id: str) -> list[str]:
         """
         Get ancestor IDs, ordered earliest (closest to root) first.
         """
@@ -103,7 +103,7 @@ class BenthicAttributeLibrary:
             return []
         return self.get_ancestor_ids(parent) + [parent]
 
-    def get_descendants(self, ba_id):
+    def get_descendants(self, ba_id: str | None) -> list[dict[str, object]]:
         """
         Get descendants as a list that's ordered by parent, with parents
         being in a depth-first-search order.
@@ -130,13 +130,16 @@ class GrowthFormLibrary:
     def __init__(self):
         download_response = urllib.request.urlopen("https://api.datamermaid.org/v1/choices/")
         response_json = json.loads(download_response.read())
+        data = None
         for item in response_json:
             if item["name"] == "growthforms":
                 data = item["data"]
                 break
+        if data is None:
+            raise ValueError("'growthforms' not found in /v1/choices/ response")
         self.by_id = {gf["id"]: gf["name"] for gf in data}
 
-    def id_to_name(self, gf_id):
+    def id_to_name(self, gf_id: str) -> str:
         if gf_id == "":
             return ""
         return self.by_id[gf_id]
@@ -197,15 +200,15 @@ class CoralNetMermaidMapping:
 
     def __init__(
         self,
-        mapping_endpoint="https://api.datamermaid.org/v1/classification/labelmappings/?provider=CoralNet",
+        mapping_endpoint: str = "https://api.datamermaid.org/v1/classification/labelmappings/?provider=CoralNet",
     ):
-        self._mapping = None
+        self._mapping: dict[str, LabelMappingEntry] | None = None
         self._endpoint = mapping_endpoint
 
-    def __contains__(self, cn_label_id):
+    def __contains__(self, cn_label_id: str) -> bool:
         return cn_label_id in self.mapping
 
-    def __getitem__(self, cn_label_id):
+    def __getitem__(self, cn_label_id: str) -> LabelMappingEntry:
         try:
             return self.mapping[cn_label_id]
         except KeyError as e:
@@ -213,13 +216,14 @@ class CoralNetMermaidMapping:
                 f"{e} - Make sure you're passing the CoralNet label ID (not name), as a string (not int)."
             ) from e
 
-    def get_dataframe(self):
+    def get_dataframe(self) -> pd.DataFrame:
         return pd.DataFrame(self.mapping.values())
 
     @property
-    def mapping(self):
+    def mapping(self) -> dict[str, LabelMappingEntry]:
         if self._mapping is None:
             self._load_mapping()
+        assert self._mapping is not None  # invariant: _load_mapping sets _mapping
         return self._mapping
 
     def _load_mapping(self):
@@ -278,7 +282,7 @@ def output_ba_csvs():
             if result["parent"] is None:
                 parent_name = None
             else:
-                parent_name = benthic_attrs.id_to_name(result["parent"])
+                parent_name = benthic_attrs.id_to_name(str(result["parent"]))
             writer.writerow(
                 {
                     "name": result["name"],

--- a/mermaid_classifier/common/benthic_attributes.py
+++ b/mermaid_classifier/common/benthic_attributes.py
@@ -1,22 +1,22 @@
 # Utilities related to benthic attribute info from the MERMAID API.
 
-from collections import defaultdict
 import csv
 import dataclasses
 import functools
 import json
 import operator
 import urllib.request
+from collections import defaultdict
 
 import pandas as pd
 
-
 # MERMAID API uses :: as the BA-GF separator.
-BAGF_SEP = '::'
+BAGF_SEP = "::"
 
 
 def combine_ba_gf(
-    benthic_attribute: str, growth_form: str,
+    benthic_attribute: str,
+    growth_form: str,
 ) -> str:
     """
     Combine string representations of a benthic attribute and a growth form
@@ -39,13 +39,15 @@ def split_ba_gf(bagf: str) -> tuple[str, str]:
     except ValueError:
         raise ValueError(
             f"'{bagf}' is not a valid BA-GF combo string."
-            f" The separator {BAGF_SEP} should appear exactly once.")
+            f" The separator {BAGF_SEP} should appear exactly once."
+        ) from None
 
-    if benthic_attribute == '':
+    if benthic_attribute == "":
         raise ValueError(
             f"'{bagf}' is not a valid BA-GF combo string."
             f" There should be characters to the left of the"
-            f" separator {BAGF_SEP}.")
+            f" separator {BAGF_SEP}."
+        )
 
     return benthic_attribute, growth_form
 
@@ -56,46 +58,47 @@ class BenthicAttributeLibrary:
     various lookups.
     This is intended to be a singleton class.
     """
+
     def __init__(self):
         download_response = urllib.request.urlopen(
-            'https://api.datamermaid.org/v1/benthicattributes/?limit=5000')
+            "https://api.datamermaid.org/v1/benthicattributes/?limit=5000"
+        )
         response_json = json.loads(download_response.read())
-        self.raw_results = response_json['results']
+        self.raw_results = response_json["results"]
 
-        self.by_id = dict()
-        self.by_name = dict()
+        self.by_id = {}
+        self.by_name = {}
         self.by_parent = defaultdict(list)
 
         for result in self.raw_results:
-            self.by_id[result['id']] = result
-            self.by_name[result['name']] = result
-            self.by_parent[result['parent']].append(result)
+            self.by_id[result["id"]] = result
+            self.by_name[result["name"]] = result
+            self.by_parent[result["parent"]].append(result)
 
     def id_to_name(self, ba_id):
-        if ba_id == '':
-            return ''
-        return self.by_id[ba_id]['name']
+        if ba_id == "":
+            return ""
+        return self.by_id[ba_id]["name"]
 
     def name_to_id(self, ba_name):
-        if ba_name == '':
-            return ''
-        return self.by_name[ba_name]['id']
+        if ba_name == "":
+            return ""
+        return self.by_name[ba_name]["id"]
 
     def bagf_id_to_name(self, bagf_id, gf_library):
         ba_id, gf_id = split_ba_gf(bagf_id)
-        ba_name = self.by_id[ba_id]['name']
-        if gf_id == '':
+        ba_name = self.by_id[ba_id]["name"]
+        if gf_id == "":
             # Unlike IDs where we represent BA-only as <BA><separator>,
             # for readable names BA-only will have no separator.
             return ba_name
-        else:
-            return BAGF_SEP.join([ba_name, gf_library.by_id[gf_id]])
+        return BAGF_SEP.join([ba_name, gf_library.by_id[gf_id]])
 
     def get_ancestor_ids(self, ba_id):
         """
         Get ancestor IDs, ordered earliest (closest to root) first.
         """
-        parent = self.by_id[ba_id]['parent']
+        parent = self.by_id[ba_id]["parent"]
         if parent is None:
             return []
         return self.get_ancestor_ids(parent) + [parent]
@@ -110,13 +113,11 @@ class BenthicAttributeLibrary:
             return []
 
         children = self.by_parent[ba_id]
-        children_ordered_by_name = sorted(
-            children, key=operator.itemgetter('name'))
+        children_ordered_by_name = sorted(children, key=operator.itemgetter("name"))
 
         children_results = []
         for child in children_ordered_by_name:
-            children_results.extend(
-                self.get_descendants(child['id']))
+            children_results.extend(self.get_descendants(child["id"]))
         return children_ordered_by_name + children_results
 
 
@@ -125,19 +126,19 @@ class GrowthFormLibrary:
     Information about MERMAID growth forms, primarily an id-to-name lookup.
     This is intended to be a singleton class.
     """
+
     def __init__(self):
-        download_response = urllib.request.urlopen(
-            'https://api.datamermaid.org/v1/choices/')
+        download_response = urllib.request.urlopen("https://api.datamermaid.org/v1/choices/")
         response_json = json.loads(download_response.read())
         for item in response_json:
-            if item['name'] == 'growthforms':
-                data = item['data']
+            if item["name"] == "growthforms":
+                data = item["data"]
                 break
-        self.by_id = {gf['id']: gf['name'] for gf in data}
+        self.by_id = {gf["id"]: gf["name"] for gf in data}
 
     def id_to_name(self, gf_id):
-        if gf_id == '':
-            return ''
+        if gf_id == "":
+            return ""
         return self.by_id[gf_id]
 
 
@@ -196,7 +197,7 @@ class CoralNetMermaidMapping:
 
     def __init__(
         self,
-        mapping_endpoint='https://api.datamermaid.org/v1/classification/labelmappings/?provider=CoralNet',
+        mapping_endpoint="https://api.datamermaid.org/v1/classification/labelmappings/?provider=CoralNet",
     ):
         self._mapping = None
         self._endpoint = mapping_endpoint
@@ -208,7 +209,9 @@ class CoralNetMermaidMapping:
         try:
             return self.mapping[cn_label_id]
         except KeyError as e:
-            raise KeyError(f"{e} - Make sure you're passing the CoralNet label ID (not name), as a string (not int).")
+            raise KeyError(
+                f"{e} - Make sure you're passing the CoralNet label ID (not name), as a string (not int)."
+            ) from e
 
     def get_dataframe(self):
         return pd.DataFrame(self.mapping.values())
@@ -223,14 +226,14 @@ class CoralNetMermaidMapping:
         api_mapping = self._download_mapping()
 
         self._mapping = {
-            entry['provider_id']: LabelMappingEntry(
-                benthic_attribute_id=entry['benthic_attribute_id'],
+            entry["provider_id"]: LabelMappingEntry(
+                benthic_attribute_id=entry["benthic_attribute_id"],
                 # Use '' as the empty value for GFs, not null/None.
-                growth_form_id=entry['growth_form_id'] or '',
-                benthic_attribute_name=entry['benthic_attribute_name'],
-                growth_form_name=entry['growth_form_name'] or '',
-                provider_id=entry['provider_id'],
-                provider_label=entry['provider_label'],
+                growth_form_id=entry["growth_form_id"] or "",
+                benthic_attribute_name=entry["benthic_attribute_name"],
+                growth_form_name=entry["growth_form_name"] or "",
+                provider_id=entry["provider_id"],
+                provider_label=entry["provider_label"],
             )
             for entry in api_mapping
         }
@@ -238,12 +241,12 @@ class CoralNetMermaidMapping:
     def _download_mapping(self):
         endpoint_response = urllib.request.urlopen(self._endpoint)
         response_json = json.loads(endpoint_response.read())
-        api_mapping = response_json['results']
+        api_mapping = response_json["results"]
 
-        while response_json['next']:
-            endpoint_response = urllib.request.urlopen(response_json['next'])
+        while response_json["next"]:
+            endpoint_response = urllib.request.urlopen(response_json["next"])
             response_json = json.loads(endpoint_response.read())
-            api_mapping.extend(response_json['results'])
+            api_mapping.extend(response_json["results"])
 
         return api_mapping
 
@@ -255,29 +258,30 @@ def output_ba_csvs():
     """
     benthic_attrs = BenthicAttributeLibrary()
 
-    raw_path = 'benthic_attributes_raw.csv'
-    fieldnames = ['id', 'name', 'parent']
+    raw_path = "benthic_attributes_raw.csv"
+    fieldnames = ["id", "name", "parent"]
     print(f"Writing to: {raw_path}")
-    with open(raw_path, 'w', newline='', encoding='utf-8') as raw_f:
+    with open(raw_path, "w", newline="", encoding="utf-8") as raw_f:
         writer = csv.DictWriter(raw_f, fieldnames=fieldnames)
         writer.writeheader()
         for result in benthic_attrs.raw_results:
-            writer.writerow(
-                {k: v for k, v in result.items() if k in fieldnames})
+            writer.writerow({k: v for k, v in result.items() if k in fieldnames})
 
     results_ordered_by_parent = benthic_attrs.get_descendants(None)
-    ordered_path = 'benthic_attributes_ordered_by_parent.csv'
-    fieldnames = ['name', 'parent_name']
+    ordered_path = "benthic_attributes_ordered_by_parent.csv"
+    fieldnames = ["name", "parent_name"]
     print(f"Writing to: {ordered_path}")
-    with open(ordered_path, 'w', newline='', encoding='utf-8') as ordered_f:
+    with open(ordered_path, "w", newline="", encoding="utf-8") as ordered_f:
         writer = csv.DictWriter(ordered_f, fieldnames=fieldnames)
         writer.writeheader()
         for result in results_ordered_by_parent:
-            if result['parent'] is None:
+            if result["parent"] is None:
                 parent_name = None
             else:
-                parent_name = benthic_attrs.id_to_name(result['parent'])
-            writer.writerow(dict(
-                name=result['name'],
-                parent_name=parent_name,
-            ))
+                parent_name = benthic_attrs.id_to_name(result["parent"])
+            writer.writerow(
+                {
+                    "name": result["name"],
+                    "parent_name": parent_name,
+                }
+            )

--- a/mermaid_classifier/common/csv_utils.py
+++ b/mermaid_classifier/common/csv_utils.py
@@ -94,5 +94,5 @@ class CsvSpec(abc.ABC):
 
             self.per_row_init_action(values)
 
-    def per_row_init_action(self, row: dict):
+    def per_row_init_action(self, row: dict[str, str | None]) -> None:
         raise NotImplementedError

--- a/mermaid_classifier/common/csv_utils.py
+++ b/mermaid_classifier/common/csv_utils.py
@@ -39,6 +39,7 @@ class CsvSpec(abc.ABC):
     - per_item_init_action(): This base class's __init__() will call
       this method for every row in the CSV.
     """
+
     column_specs: list[ColumnSpec]
 
     def __init__(self, csv_file: typing.TextIO):
@@ -56,7 +57,7 @@ class CsvSpec(abc.ABC):
             self.csv_dataframe = pd.DataFrame()
             return
 
-        csv_filename = getattr(csv_file, 'name', "<File-like obj>")
+        csv_filename = getattr(csv_file, "name", "<File-like obj>")
 
         column_names = []
 
@@ -65,9 +66,7 @@ class CsvSpec(abc.ABC):
                 if column_spec.name in self.csv_dataframe.columns:
                     column_name = column_spec.name
                 else:
-                    raise ValueError(
-                        f"{csv_filename}: must have the column"
-                        f" {column_spec.name}")
+                    raise ValueError(f"{csv_filename}: must have the column {column_spec.name}")
             else:
                 # List of str
                 column_name = None
@@ -78,20 +77,18 @@ class CsvSpec(abc.ABC):
                 if column_name is None:
                     candidates_str = ", ".join(column_spec.name)
                     raise ValueError(
-                        f"{csv_filename}: must have at least"
-                        f" one of these columns: {candidates_str}")
+                        f"{csv_filename}: must have at least one of these columns: {candidates_str}"
+                    )
             column_names.append(column_name)
 
         for row_i, (_, row) in enumerate(self.csv_dataframe.iterrows()):
-            values = dict()
-            for spec, name in zip(self.column_specs, column_names):
+            values = {}
+            for spec, name in zip(self.column_specs, column_names, strict=False):
                 # Ensure absent values are None, not ''.
                 value = row.get(name) or None
 
                 if not spec.allow_blank and not value:
-                    raise ValueError(
-                        f"{csv_filename}:"
-                        f"{name} not found in row {row_i + 1}")
+                    raise ValueError(f"{csv_filename}:{name} not found in row {row_i + 1}")
 
                 values[name] = value
 

--- a/mermaid_classifier/common/duckdb_utils.py
+++ b/mermaid_classifier/common/duckdb_utils.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 
 import duckdb
 import pandas as pd
+from pandas import Series
 
 
 @contextmanager
@@ -42,7 +43,7 @@ def _duckdb_temp_transform_table(
     duck_table_name: str,
     source_column_name: str,
     target_column_name: str,
-    transform_func: typing.Callable,
+    transform_func: typing.Callable[..., object],
 ):
     """
     Internal helper: given an existing DuckDB table and column, creates a
@@ -61,7 +62,7 @@ def _duckdb_temp_transform_table(
     # Build mapping DataFrame using pandas. This is more efficient and less
     # error-prone for inserting values compared to building a large
     # INSERT INTO statement.
-    mapping_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+    mapping_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning  # pyright: ignore[reportUnusedVariable]
         {
             source_column_name: unique_values,
             target_column_name: [transform_func(v) for v in unique_values],
@@ -209,8 +210,8 @@ def duckdb_filter_on_column(
 
 
 def duckdb_batched_rows(
-    rows: duckdb.DuckDBPyRelation,
-) -> typing.Generator[pd.core.series.Series, None, None]:
+    rows: duckdb.DuckDBPyRelation | duckdb.DuckDBPyConnection,
+) -> typing.Generator[Series, None, None]:
     """
     Reads from a DuckDB relation (chunkifying to avoid memory issues),
     and generates pandas dataframe rows.
@@ -246,7 +247,7 @@ def duckdb_grouped_rows(
     duck_conn: duckdb.DuckDBPyConnection,
     duck_table_name: str,
     grouping_column_names: list[str],
-) -> typing.Generator[pd.core.series.Series, None, None]:
+) -> typing.Generator[list[Series], None, None]:
     """
     Fetch rows from the given DuckDB table in groups, with each group
     consisting of all rows that have a particular set of values in the

--- a/mermaid_classifier/common/duckdb_utils.py
+++ b/mermaid_classifier/common/duckdb_utils.py
@@ -1,6 +1,6 @@
-from contextlib import contextmanager
 import typing
 import uuid
+from contextlib import contextmanager
 
 import duckdb
 import pandas as pd
@@ -54,24 +54,22 @@ def _duckdb_temp_transform_table(
     """
     # Get all unique values of the existing column.
     tuples_with_unique_values = list(
-        duck_conn.execute(
-            f"SELECT DISTINCT {source_column_name} FROM {duck_table_name}"
-        ).fetchall()
+        duck_conn.execute(f"SELECT DISTINCT {source_column_name} FROM {duck_table_name}").fetchall()
     )
     unique_values = [tup[0] for tup in tuples_with_unique_values]
 
     # Build mapping DataFrame using pandas. This is more efficient and less
     # error-prone for inserting values compared to building a large
     # INSERT INTO statement.
-    mapping_df = pd.DataFrame({
-        source_column_name: unique_values,
-        target_column_name: [transform_func(v) for v in unique_values]
-    })
+    mapping_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+        {
+            source_column_name: unique_values,
+            target_column_name: [transform_func(v) for v in unique_values],
+        }
+    )
 
     with duckdb_temp_table_name(duck_conn) as temp_table_name:
-        duck_conn.execute(
-            f"CREATE TABLE {temp_table_name} AS SELECT * FROM mapping_df"
-        )
+        duck_conn.execute(f"CREATE TABLE {temp_table_name} AS SELECT * FROM mapping_df")
         yield temp_table_name
 
 
@@ -87,13 +85,10 @@ def duckdb_replace_column(
     """
     # Drop the original column.
     # https://duckdb.org/docs/stable/sql/statements/alter_table
-    duck_conn.execute(
-        f"ALTER TABLE {duck_table_name} DROP {column_name}"
-    )
+    duck_conn.execute(f"ALTER TABLE {duck_table_name} DROP {column_name}")
     # New-values column becomes the new column.
     duck_conn.execute(
-        f"ALTER TABLE {duck_table_name}"
-        f" RENAME {new_values_column_name} TO {column_name}"
+        f"ALTER TABLE {duck_table_name} RENAME {new_values_column_name} TO {column_name}"
     )
 
 
@@ -101,7 +96,7 @@ def duckdb_transform_column(
     duck_conn: duckdb.DuckDBPyConnection,
     duck_table_name: str,
     column_name: str,
-    transform_func: typing.Callable[[str|None], str|None],
+    transform_func: typing.Callable[[str | None], str | None],
 ):
     """
     Transform the values of the specified DuckDB column using the given
@@ -111,10 +106,9 @@ def duckdb_transform_column(
         duck_conn,
         duck_table_name,
         column_name,
-        f'transformed_{column_name}',
+        f"transformed_{column_name}",
         transform_func,
     ) as transform_table_name:
-
         # Use JOIN ... USING to apply the transform.
         duck_conn.execute(
             f"CREATE OR REPLACE TABLE {duck_table_name} AS"
@@ -129,7 +123,7 @@ def duckdb_transform_column(
         duck_conn,
         duck_table_name,
         column_name,
-        f'transformed_{column_name}',
+        f"transformed_{column_name}",
     )
 
 
@@ -137,21 +131,14 @@ def duckdb_replace_value_in_column(
     duck_conn: duckdb.DuckDBPyConnection,
     duck_table_name: str,
     column_name: str,
-    old_value: str|None,
-    new_value: str|None,
+    old_value: str | None,
+    new_value: str | None,
 ):
     """
     Replace old_value with new_value in the column_name column.
     """
-    if old_value is None:
-        where_predicate = "IS NULL"
-    else:
-        where_predicate = f"= '{old_value}'"
-
-    if new_value is None:
-        new_value_sql = "NULL"
-    else:
-        new_value_sql = f"'{new_value}'"
+    where_predicate = "IS NULL" if old_value is None else f"= '{old_value}'"
+    new_value_sql = "NULL" if new_value is None else f"'{new_value}'"
 
     duck_conn.execute(
         f"UPDATE {duck_table_name}"
@@ -165,7 +152,7 @@ def duckdb_add_column(
     duck_table_name: str,
     base_column_name: str,
     new_column_name: str,
-    base_to_new_func: typing.Callable[[str|None], str|None],
+    base_to_new_func: typing.Callable[[str | None], str | None],
 ):
     """
     Transform the values of the specified DuckDB 'base column' into
@@ -178,7 +165,6 @@ def duckdb_add_column(
         new_column_name,
         base_to_new_func,
     ) as transform_table_name:
-
         # Use JOIN ... USING to add the new column.
         # https://duckdb.org/docs/stable/sql/query_syntax/from#conditional-joins
         duck_conn.execute(
@@ -194,7 +180,7 @@ def duckdb_filter_on_column(
     duck_conn: duckdb.DuckDBPyConnection,
     duck_table_name: str,
     column_name: str,
-    inclusion_func: typing.Callable[[str|None], bool],
+    inclusion_func: typing.Callable[[str | None], bool],
 ):
     """
     Filter the rows of the specified DuckDB table by passing the
@@ -204,10 +190,9 @@ def duckdb_filter_on_column(
         duck_conn,
         duck_table_name,
         column_name,
-        'included',
+        "included",
         inclusion_func,
     ) as transform_table_name:
-
         # Use JOIN to determine which annotations to keep, and
         # WHERE to filter things down.
         #
@@ -272,10 +257,7 @@ def duckdb_grouped_rows(
     # for those columns, all the rows with that set of values are all
     # together - which is our goal here.
     columns_str = ", ".join(grouping_column_names)
-    rows = duck_conn.execute(
-        f"SELECT * FROM {duck_table_name}"
-        f" ORDER BY {columns_str}"
-    )
+    rows = duck_conn.execute(f"SELECT * FROM {duck_table_name} ORDER BY {columns_str}")
 
     grouping_values = None
     group_rows = []

--- a/mermaid_classifier/common/plots.py
+++ b/mermaid_classifier/common/plots.py
@@ -1,11 +1,15 @@
-from collections import defaultdict
 import colorsys
+from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+import numpy as np
 from matplotlib import patheffects
 from matplotlib.lines import Line2D
-import numpy as np
+
+if TYPE_CHECKING:
+    import matplotlib
+    from matplotlib.axes import Axes
 
 
 @dataclass
@@ -25,6 +29,7 @@ class PointMarker:
     text
     Text to write next to the point marker using Axes.annotate().
     """
+
     row: int
     col: int
     color: Any
@@ -32,11 +37,11 @@ class PointMarker:
     text: str = None
 
 
-EDGE_COLOR = 'black'
+EDGE_COLOR = "black"
 EDGE_WIDTH = 0.5
 
 
-def plot_point_markers(ax: 'Axes', markers: list[PointMarker]):
+def plot_point_markers(ax: "Axes", markers: list[PointMarker]):
 
     marker_groups = defaultdict(list)
     marker_size = 100.0
@@ -44,27 +49,21 @@ def plot_point_markers(ax: 'Axes', markers: list[PointMarker]):
     text_offset = 4.0
 
     for marker in markers:
-        if (
-            isinstance(marker.color, list)
-            or isinstance(marker.color, np.ndarray)
-        ):
+        if isinstance(marker.color, (list, np.ndarray)):
             hashable_color = tuple(marker.color)
         else:
             hashable_color = marker.color
 
         # Group the markers according to their common properties other
         # than row, col, text.
-        group_identifying_dict = dict(
-            color=hashable_color,
-            shape=marker.shape,
-        )
-        group_hash = tuple(
-            (k, v) for k, v in group_identifying_dict.items()
-        )
+        group_identifying_dict = {
+            "color": hashable_color,
+            "shape": marker.shape,
+        }
+        group_hash = tuple((k, v) for k, v in group_identifying_dict.items())
         marker_groups[group_hash].append(marker)
 
     for group_hash, markers in marker_groups.items():
-
         xs = [marker.col for marker in markers]
         ys = [marker.row for marker in markers]
         group_dict = dict(group_hash)
@@ -73,15 +72,16 @@ def plot_point_markers(ax: 'Axes', markers: list[PointMarker]):
         ax.scatter(
             xs,
             ys,
-            marker=group_dict['shape'],
-            color=group_dict['color'],
+            marker=group_dict["shape"],
+            color=group_dict["color"],
             # Bit of transparency helps to make the marker not stand
             # out too much.
             alpha=0.8,
             s=marker_size,
             # Marker edges make the markers easier to see when the
             # marker color is similar to the image color.
-            edgecolors=EDGE_COLOR, linewidths=EDGE_WIDTH,
+            edgecolors=EDGE_COLOR,
+            linewidths=EDGE_WIDTH,
         )
 
         # Text
@@ -90,11 +90,11 @@ def plot_point_markers(ax: 'Axes', markers: list[PointMarker]):
             ax.annotate(
                 marker.text,
                 (marker.col, marker.row),
-                color=group_dict['color'],
+                color=group_dict["color"],
                 alpha=0.8,
                 fontsize=font_size,
                 # https://matplotlib.org/stable/api/text_api.html#matplotlib.text.Text.set_fontweight
-                fontweight='semibold',
+                fontweight="semibold",
                 # textcoords in offset units allow the text to be a
                 # consistent distance from the point marker, regardless
                 # of image scale or zoom level.
@@ -106,7 +106,7 @@ def plot_point_markers(ax: 'Axes', markers: list[PointMarker]):
                 #  values here doesn't do it; probably also need to adjust the
                 #  anchor.
                 xytext=(text_offset, text_offset),
-                textcoords='offset points',
+                textcoords="offset points",
                 # Border/outline around the text for better visibility when
                 # the marker color is similar to the image color.
                 # https://github.com/has2k1/plotnine/discussions/898
@@ -128,20 +128,21 @@ class LegendSpecElement:
 
 
 def plot_legend(
-    ax: 'Axes',
-    spec: list[LegendSpecElement],
-    title: str = None,
-    position_kwargs: dict = None
-) -> 'matplotlib.legend.Legend':
+    ax: "Axes", spec: list[LegendSpecElement], title: str = None, position_kwargs: dict = None
+) -> "matplotlib.legend.Legend":
 
     legend_artists = [
         Line2D(
             # We don't care about this numeric data; this is
             # just a placeholder for the legend.
-            [0],[0],
-            marker=spec_element.shape, linestyle='None', markersize=8,
+            [0],
+            [0],
+            marker=spec_element.shape,
+            linestyle="None",
+            markersize=8,
             markerfacecolor=spec_element.color,
-            markeredgecolor=EDGE_COLOR, markeredgewidth=EDGE_WIDTH,
+            markeredgecolor=EDGE_COLOR,
+            markeredgewidth=EDGE_WIDTH,
             label=spec_element.label,
         )
         for spec_element in spec
@@ -149,7 +150,7 @@ def plot_legend(
 
     if position_kwargs is None:
         # Put the legend outside the plot, to the upper right.
-        position_kwargs = dict(loc='upper left', bbox_to_anchor=(1.0, 1.0))
+        position_kwargs = {"loc": "upper left", "bbox_to_anchor": (1.0, 1.0)}
 
     # This call already adds the legend to the axes, but the legend
     # handle may be needed for things like adding multiple legends, so
@@ -159,7 +160,7 @@ def plot_legend(
         # Spacing between the legend items
         labelspacing=1,
         title=title,
-        **position_kwargs
+        **position_kwargs,
     )
 
 
@@ -169,13 +170,13 @@ def adjust_lightness(rgba, l_factor):
     https://stackoverflow.com/a/60562502
     """
     r, g, b, a = rgba
-    h, l, s = colorsys.rgb_to_hls(r, g, b)
-    new_rgb = colorsys.hls_to_rgb(h, min(1.0, l * l_factor), s=s)
+    h, lightness, s = colorsys.rgb_to_hls(r, g, b)
+    new_rgb = colorsys.hls_to_rgb(h, min(1.0, lightness * l_factor), s=s)
     return [*new_rgb, a]
 
 
 def adjust_saturation(rgba, s_factor):
     r, g, b, a = rgba
-    h, l, s = colorsys.rgb_to_hls(r, g, b)
-    new_rgb = colorsys.hls_to_rgb(h, l, s=min(1.0, s * s_factor))
+    h, lightness, s = colorsys.rgb_to_hls(r, g, b)
+    new_rgb = colorsys.hls_to_rgb(h, lightness, s=min(1.0, s * s_factor))
     return [*new_rgb, a]

--- a/mermaid_classifier/common/plots.py
+++ b/mermaid_classifier/common/plots.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from matplotlib import patheffects
+from matplotlib.legend import Legend
 from matplotlib.lines import Line2D
 
 if TYPE_CHECKING:
-    import matplotlib
     from matplotlib.axes import Axes
 
 
@@ -34,7 +34,7 @@ class PointMarker:
     col: int
     color: Any
     shape: Any
-    text: str = None
+    text: str | None = None
 
 
 EDGE_COLOR = "black"
@@ -86,6 +86,8 @@ def plot_point_markers(ax: "Axes", markers: list[PointMarker]):
 
         # Text
         for marker in markers:
+            if marker.text is None:
+                continue
             # https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.annotate.html
             ax.annotate(
                 marker.text,
@@ -128,8 +130,11 @@ class LegendSpecElement:
 
 
 def plot_legend(
-    ax: "Axes", spec: list[LegendSpecElement], title: str = None, position_kwargs: dict = None
-) -> "matplotlib.legend.Legend":
+    ax: "Axes",
+    spec: list[LegendSpecElement],
+    title: str | None = None,
+    position_kwargs: dict[str, Any] | None = None,
+) -> Legend:
 
     legend_artists = [
         Line2D(
@@ -164,7 +169,7 @@ def plot_legend(
     )
 
 
-def adjust_lightness(rgba, l_factor):
+def adjust_lightness(rgba: tuple[float, float, float, float], l_factor: float) -> list[float]:
     """
     Adjust lightness of a matplotlib rgba color.
     https://stackoverflow.com/a/60562502
@@ -175,7 +180,7 @@ def adjust_lightness(rgba, l_factor):
     return [*new_rgb, a]
 
 
-def adjust_saturation(rgba, s_factor):
+def adjust_saturation(rgba: tuple[float, float, float, float], s_factor: float) -> list[float]:
     r, g, b, a = rgba
     h, lightness, s = colorsys.rgb_to_hls(r, g, b)
     new_rgb = colorsys.hls_to_rgb(h, lightness, s=min(1.0, s * s_factor))

--- a/mermaid_classifier/pyspacer/annotation.py
+++ b/mermaid_classifier/pyspacer/annotation.py
@@ -1,48 +1,47 @@
 """
 Get/generate and show annotations for a specified image.
 """
+
 import atexit
-from collections import defaultdict
 import csv
-from io import BytesIO, StringIO
-from operator import itemgetter
 import os
-from pathlib import Path
 import re
 import shutil
 import tempfile
-from urllib.parse import urlparse
 import urllib.request
+from collections import defaultdict
+from io import BytesIO, StringIO
+from operator import itemgetter
+from pathlib import Path
+from urllib.parse import urlparse
 
-from bs4 import BeautifulSoup
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import mlflow
 import numpy as np
+from bs4 import BeautifulSoup
 from spacer.data_classes import DataLocation
 from spacer.extractors import EfficientNetExtractor
 from spacer.storage import load_image, storage_factory
 from spacer.task_utils import check_extract_inputs
 
-from mermaid_classifier.common.benthic_attributes import (
-    BenthicAttributeLibrary, GrowthFormLibrary)
+from mermaid_classifier.common.benthic_attributes import BenthicAttributeLibrary, GrowthFormLibrary
 from mermaid_classifier.common.plots import (
     LegendSpecElement,
+    PointMarker,
     plot_legend,
     plot_point_markers,
-    PointMarker,
 )
 from mermaid_classifier.pyspacer.inference import load_predictor
 from mermaid_classifier.pyspacer.settings import settings
 from mermaid_classifier.pyspacer.utils import mlflow_connect
-
 
 # A model ID is m- followed by 32 hex digits, but we'll assume 30-32
 # hex digits is meant to be an MLflow run ID.
 # That way, if the user accidentally copies only 31 digits and
 # pastes it into this script, it'll try to find the run ID instead of
 # trying it as a filesystem path.
-MLFLOW_MODEL_ID_REGEX = re.compile(r'm-[a-f0-9]{30,32}')
+MLFLOW_MODEL_ID_REGEX = re.compile(r"m-[a-f0-9]{30,32}")
 
 
 def mlflow_model_id_to_artifact_uris(model_id: str) -> tuple[str, str]:
@@ -54,19 +53,20 @@ def mlflow_model_id_to_artifact_uris(model_id: str) -> tuple[str, str]:
     base = logged_model.artifact_location
     # #57's log_artifact_model logs model_pt/model_json as pyfunc artifacts,
     # which MLflow stores under the model's artifacts/ subdirectory.
-    return f'{base}/artifacts/model.pt', f'{base}/artifacts/model.json'
+    return f"{base}/artifacts/model.pt", f"{base}/artifacts/model.json"
 
 
 def _download_pair_to_tempdir(
-    pt_loc: DataLocation, json_loc: DataLocation,
+    pt_loc: DataLocation,
+    json_loc: DataLocation,
 ) -> tuple[Path, Path]:
     """Download an S3 model.pt + model.json pair into one temp dir."""
-    tmp_dir = Path(tempfile.mkdtemp(prefix='clf_artifact_'))
+    tmp_dir = Path(tempfile.mkdtemp(prefix="clf_artifact_"))
     # mkdtemp() isn't auto-cleaned, and the pair must outlive this call (the
     # caller loads them immediately after), so reclaim the dir at process exit.
     atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
     paths = []
-    for loc, name in [(pt_loc, 'model.pt'), (json_loc, 'model.json')]:
+    for loc, name in [(pt_loc, "model.pt"), (json_loc, "model.json")]:
         storage = storage_factory(loc.storage_type, loc.bucket_name)
         stream = storage.load(loc.key)
         dest = tmp_dir / name
@@ -90,17 +90,16 @@ def resolve_classifier_artifact(location: str) -> tuple[Path, Path]:
         return Path(local_pt), Path(local_json)
 
     # Directory mode: S3 URI or local filesystem directory.
-    base = location.rstrip('/')
-    pt_loc = AnnotationRun.parse_location_str(f'{base}/model.pt')
-    json_loc = AnnotationRun.parse_location_str(f'{base}/model.json')
+    base = location.rstrip("/")
+    pt_loc = AnnotationRun.parse_location_str(f"{base}/model.pt")
+    json_loc = AnnotationRun.parse_location_str(f"{base}/model.json")
 
-    if pt_loc.storage_type == 's3':
+    if pt_loc.storage_type == "s3":
         return _download_pair_to_tempdir(pt_loc, json_loc)
     return Path(pt_loc.key), Path(json_loc.key)
 
 
 class AnnotationRun:
-
     def __init__(
         self,
         image: str,
@@ -178,8 +177,7 @@ class AnnotationRun:
         self.num_predictions_to_save = num_predictions_to_save
         self.coralnet_cache_dir = coralnet_cache_dir
 
-        weights_location = (
-            weights or settings.weights_location)
+        weights_location = weights or settings.weights_location
 
         annotations: dict[tuple[int, int], list] = defaultdict(list)
         scores: dict[tuple[int, int], list] = defaultdict(list)
@@ -189,14 +187,14 @@ class AnnotationRun:
         with open(self.points_csv_path) as points_csv:
             reader = csv.DictReader(points_csv)
             for csv_row in reader:
-                row = int(csv_row['row'])
-                column = int(csv_row['column'])
+                row = int(csv_row["row"])
+                column = int(csv_row["column"])
                 # Optional cells could not be in the dict or they could be ''.
                 # Default label is 'None'. Default score is nothing (not added
                 # to dict).
-                annotations[(row, column)].append(csv_row.get('label', 'None'))
-                if csv_row.get('score'):
-                    scores[(row, column)].append(float(csv_row['score']))
+                annotations[(row, column)].append(csv_row.get("label", "None"))
+                if csv_row.get("score"):
+                    scores[(row, column)].append(float(csv_row["score"]))
 
         try:
             image_id = int(image)
@@ -212,14 +210,13 @@ class AnnotationRun:
         if classifier:
             auto_plot_title += f"\nClassified by: {classifier}"
         else:
-            auto_plot_title += f"\nAnnotations from CSV file"
+            auto_plot_title += "\nAnnotations from CSV file"
 
         self.plot_title = plot_title or auto_plot_title
 
         weights_loc = self.parse_location_str(weights_location)
 
         if classifier:
-
             # Classify with the portable artifact: extract features with
             # pyspacer's EfficientNet extractor, then predict with the loaded
             # TorchScript head (no classifier pickle, no pyspacer classify call).
@@ -230,7 +227,7 @@ class AnnotationRun:
             print("Extracting features and classifying...")
             loaded_image = load_image(self.image_loc)
             extractor = EfficientNetExtractor(
-                data_locations=dict(weights=weights_loc),
+                data_locations={"weights": weights_loc},
             )
             rowcols = list(annotations.keys())
             check_extract_inputs(loaded_image, rowcols, self.image_loc.key)
@@ -243,37 +240,32 @@ class AnnotationRun:
             # call instead of once per point.
             labels = predictor.classes
             if rowcols:
-                feature_batch = np.vstack(
-                    [features.get_array(rowcol) for rowcol in rowcols])
+                feature_batch = np.vstack([features.get_array(rowcol) for rowcol in rowcols])
                 proba_batch = predictor.predict_proba(feature_batch).tolist()
-                for (row, column), proba in zip(rowcols, proba_batch):
+                for (row, column), proba in zip(rowcols, proba_batch, strict=False):
                     top_predictions = sorted(
-                        zip(labels, proba), key=itemgetter(1), reverse=True)
+                        zip(labels, proba, strict=False), key=itemgetter(1), reverse=True
+                    )
                     annotations[(row, column)] = [
-                        label for label, score
-                        in top_predictions[:predictions_per_point]]
+                        label for label, score in top_predictions[:predictions_per_point]
+                    ]
                     scores[(row, column)] = [
-                        score for label, score
-                        in top_predictions[:predictions_per_point]]
+                        score for label, score in top_predictions[:predictions_per_point]
+                    ]
             print("Finished classifying")
 
         else:
-
-            print(
-                "No classifier specified, so points_csv must specify"
-                " all annotations.")
+            print("No classifier specified, so points_csv must specify all annotations.")
 
         # Number 1 prediction for each point.
-        self.top_annotations = dict(
-            (rowcol, labels[0]) for rowcol, labels in annotations.items())
-        self.top_scores = dict(
-            (rowcol, score_vals[0]) for rowcol, score_vals in scores.items())
+        self.top_annotations = {rowcol: labels[0] for rowcol, labels in annotations.items()}
+        self.top_scores = {rowcol: score_vals[0] for rowcol, score_vals in scores.items()}
 
         # All points must have labels specified by now - either through the
         # points CSV, or using the classifier (the latter takes precedence if
         # specified).
         for rowcol, top_label in self.top_annotations.items():
-            if top_label == 'None':
+            if top_label == "None":
                 raise ValueError(f"Point {rowcol} doesn't have a label.")
 
         if self.num_predictions_to_save > 0 and classifier:
@@ -281,23 +273,22 @@ class AnnotationRun:
             # since a classifier is being used.
             self.write_predictions(annotations, scores)
 
-        unique_top_labels = set(
-            label for label in self.top_annotations.values())
+        unique_top_labels = set(self.top_annotations.values())
 
         if labelset_csv:
             # Read in the label IDs to names mapping.
             with open(labelset_csv) as csv_f:
                 reader = csv.DictReader(csv_f)
                 self.label_ids_to_names = {
-                    csv_row['id']: csv_row['name']
+                    csv_row["id"]: csv_row["name"]
                     for csv_row in reader
-                    if csv_row['id'] in unique_top_labels
+                    if csv_row["id"] in unique_top_labels
                 }
         else:
             # Use MERMAID's API to get the names.
             ba_library = BenthicAttributeLibrary()
             gf_library = GrowthFormLibrary()
-            self.label_ids_to_names = dict()
+            self.label_ids_to_names = {}
             for bagf_id in unique_top_labels:
                 name = ba_library.bagf_id_to_name(bagf_id, gf_library)
                 self.label_ids_to_names[bagf_id] = name
@@ -314,32 +305,32 @@ class AnnotationRun:
         # MLflow probably has 5 ways of un-proxying such artifact URIs, but
         # none have worked for us for some reason, so we un-proxy it manually.
         uri = urlparse(location)
-        if uri.scheme == 'mlflow-artifacts':
+        if uri.scheme == "mlflow-artifacts":
             # So far we only handle the case where artifacts are stored in
             # the local filesystem cwd.
             # If other cases come up in practice, add to this code to handle
             # those cases.
-            location = 'mlartifacts' + uri.path
+            location = "mlartifacts" + uri.path
 
         try:
             # S3 URI
             # Example:
             # s3://my-bucket/my-folder/model.pkl
             uri = urlparse(location)
-            if uri.scheme == 's3':
+            if uri.scheme == "s3":
                 return DataLocation(
-                    's3',
+                    "s3",
                     bucket_name=uri.netloc,
                     # url.path probably begins with a slash, which isn't
                     # what we want when ultimately passing this to boto's
                     # Object().
-                    key=uri.path.strip('/'),
+                    key=uri.path.strip("/"),
                 )
         except ValueError:
             pass
 
         # Default to assuming a filesystem path
-        return DataLocation('filesystem', key=location)
+        return DataLocation("filesystem", key=location)
 
     def get_coralnet_image(self, image_id: int) -> DataLocation:
         """
@@ -350,26 +341,25 @@ class AnnotationRun:
             # We don't know the file suffix, so look for any file that has the
             # expected filename without the suffix.
             for filename in os.listdir(self.coralnet_cache_dir):
-                if Path(filename).stem == f'i{image_id}':
+                if Path(filename).stem == f"i{image_id}":
                     print("CoralNet image found in the cache dir")
                     image_path = Path(self.coralnet_cache_dir, filename)
-                    return DataLocation('filesystem', str(image_path))
+                    return DataLocation("filesystem", str(image_path))
 
-        image_view_url = f'https://coralnet.ucsd.edu/image/{image_id}/view/'
+        image_view_url = f"https://coralnet.ucsd.edu/image/{image_id}/view/"
         image_view_response = urllib.request.urlopen(image_view_url)
-        response_soup = BeautifulSoup(
-            image_view_response.read(), 'html.parser')
+        response_soup = BeautifulSoup(image_view_response.read(), "html.parser")
 
-        original_img_elements = response_soup.select(
-            'div#original_image_container > img')
+        original_img_elements = response_soup.select("div#original_image_container > img")
         if not original_img_elements:
             # This only happens on a private source. If the image is
             # nonexistent, then the response is 404, causing urlopen() to
             # fail with an HTTPError.
             raise ValueError(
                 f"CoralNet image {image_id}: couldn't find image on the"
-                f" image-view page. Maybe it's in a private source.")
-        image_url = original_img_elements[0].attrs.get('src')
+                f" image-view page. Maybe it's in a private source."
+            )
+        image_url = original_img_elements[0].attrs.get("src")
         file_suffix = Path(urlparse(image_url).path).suffix
 
         print("Downloading CoralNet image...")
@@ -377,25 +367,21 @@ class AnnotationRun:
         print("Finished download")
 
         if self.coralnet_cache_dir:
-            image_path = Path(
-                self.coralnet_cache_dir, f'i{image_id}{file_suffix}')
-            with open(image_path, 'wb') as image_file:
+            image_path = Path(self.coralnet_cache_dir, f"i{image_id}{file_suffix}")
+            with open(image_path, "wb") as image_file:
                 image_file.write(download_response.read())
-            return DataLocation('filesystem', str(image_path))
-        else:
-            # No cache
-            image_loc = DataLocation('memory', 'image')
-            memory_storage = storage_factory('memory')
-            memory_storage.store(
-                image_loc.key, BytesIO(download_response.read()))
+            return DataLocation("filesystem", str(image_path))
+        # No cache
+        image_loc = DataLocation("memory", "image")
+        memory_storage = storage_factory("memory")
+        memory_storage.store(image_loc.key, BytesIO(download_response.read()))
         return image_loc
 
     @staticmethod
     def prediction_column_names(prediction_num):
         if prediction_num == 1:
-            return 'label', 'score'
-        else:
-            return f'label{prediction_num}', f'score{prediction_num}'
+            return "label", "score"
+        return f"label{prediction_num}", f"score{prediction_num}"
 
     def write_predictions(self, annotations, scores):
 
@@ -407,14 +393,14 @@ class AnnotationRun:
             reader = csv.DictReader(points_csv)
 
             # Output CSV will have these columns first.
-            writer_fieldnames = ['row', 'column']
+            writer_fieldnames = ["row", "column"]
             for num in range(1, self.num_predictions_to_save + 1):
                 writer_fieldnames += self.prediction_column_names(num)
             # Then, any additional columns that the original CSV happens
             # to have.
             writer_fieldnames += [
-                name for name in reader.fieldnames
-                if name not in writer_fieldnames]
+                name for name in reader.fieldnames if name not in writer_fieldnames
+            ]
             writer = csv.DictWriter(writer_stream, writer_fieldnames)
             writer.writeheader()
 
@@ -423,25 +409,22 @@ class AnnotationRun:
             for old_csv_row in reader:
                 new_csv_row = old_csv_row.copy()
 
-                row = int(old_csv_row['row'])
-                column = int(old_csv_row['column'])
+                row = int(old_csv_row["row"])
+                column = int(old_csv_row["column"])
 
                 for index in range(self.num_predictions_to_save):
                     prediction_num = index + 1
                     annotation = annotations[(row, column)][index]
-                    score_str = format(scores[(row, column)][index], '.4f')
+                    score_str = format(scores[(row, column)][index], ".4f")
 
-                    label_col_name, score_col_name = \
-                        self.prediction_column_names(prediction_num)
+                    label_col_name, score_col_name = self.prediction_column_names(prediction_num)
                     new_csv_row[label_col_name] = annotation
                     new_csv_row[score_col_name] = score_str
 
                 writer.writerow(new_csv_row)
 
         # Write that memory stream back to the points-csv file.
-        with open(
-            self.points_csv_path, 'w', newline='', encoding='utf-8'
-        ) as points_csv:
+        with open(self.points_csv_path, "w", newline="", encoding="utf-8") as points_csv:
             points_csv.write(writer_stream.getvalue())
 
     def show(self):
@@ -449,10 +432,7 @@ class AnnotationRun:
         unique_top_labels = list(self.label_ids_to_names.keys())
         color_list = mpl.cm.tab10(range(len(unique_top_labels)))
         # Map the labelset to colors in the color set.
-        label_ids_to_colors = dict(zip(
-            unique_top_labels,
-            color_list,
-        ))
+        label_ids_to_colors = dict(zip(unique_top_labels, color_list, strict=False))
 
         fig = plt.gcf()
         ax = fig.add_subplot(111)
@@ -469,47 +449,45 @@ class AnnotationRun:
         for rowcol, top_label in self.top_annotations.items():
             if rowcol in self.top_scores:
                 raw_top_score = self.top_scores[rowcol]
-                score_as_percent = round(raw_top_score*100)
+                score_as_percent = round(raw_top_score * 100)
                 # TODO: Score text optional; maybe shape is enough
                 score_text = str(score_as_percent)
                 # https://matplotlib.org/stable/api/markers_api.html
                 if score_as_percent >= 70:
-                    shape = 'o'
+                    shape = "o"
                 elif score_as_percent >= 50:
-                    shape = 's'
+                    shape = "s"
                 else:
-                    shape = '^'
+                    shape = "^"
             else:
                 score_text = None
-                shape = 'o'
-            point_markers.append(PointMarker(
-                row=rowcol[0],
-                col=rowcol[1],
-                color=label_ids_to_colors[top_label],
-                shape=shape,
-                text=score_text,
-            ))
+                shape = "o"
+            point_markers.append(
+                PointMarker(
+                    row=rowcol[0],
+                    col=rowcol[1],
+                    color=label_ids_to_colors[top_label],
+                    shape=shape,
+                    text=score_text,
+                )
+            )
 
         plot_point_markers(ax, point_markers)
 
-        label_names = [
-            self.label_ids_to_names[str(label_id)]
-            for label_id in unique_top_labels
-        ]
+        label_names = [self.label_ids_to_names[str(label_id)] for label_id in unique_top_labels]
         # Color legend
         legend_spec = [
-            LegendSpecElement(color=color, shape='o', label=label)
-            for color, label in zip(color_list, label_names)
+            LegendSpecElement(color=color, shape="o", label=label)
+            for color, label in zip(color_list, label_names, strict=False)
         ]
 
         # Shape legend; only show this if there are scores
         if len(self.top_scores) > 0:
             # TODO: DRY with the thresholds defined above
             legend_spec += [
-                LegendSpecElement(
-                    color='white', shape='o', label="70% or more confidence"),
-                LegendSpecElement(color='white', shape='s', label="50-69%"),
-                LegendSpecElement(color='white', shape='^', label="49% or less"),
+                LegendSpecElement(color="white", shape="o", label="70% or more confidence"),
+                LegendSpecElement(color="white", shape="s", label="50-69%"),
+                LegendSpecElement(color="white", shape="^", label="49% or less"),
             ]
         plot_legend(ax, legend_spec)
 

--- a/mermaid_classifier/pyspacer/annotation.py
+++ b/mermaid_classifier/pyspacer/annotation.py
@@ -15,9 +15,10 @@ from operator import itemgetter
 from pathlib import Path
 from urllib.parse import urlparse
 
-import matplotlib as mpl
+import matplotlib.cm
 import matplotlib.pyplot as plt
 import mlflow
+import mlflow.artifacts
 import numpy as np
 from bs4 import BeautifulSoup
 from spacer.data_classes import DataLocation
@@ -68,10 +69,10 @@ def _download_pair_to_tempdir(
     paths = []
     for loc, name in [(pt_loc, "model.pt"), (json_loc, "model.json")]:
         storage = storage_factory(loc.storage_type, loc.bucket_name)
-        stream = storage.load(loc.key)
+        stream = storage.load(loc.key)  # pyright: ignore[reportOptionalMemberAccess]  # storage_factory always returns Storage for valid storage types; None is unreachable
         dest = tmp_dir / name
         # getbuffer() writes the stream's bytes without an extra full copy.
-        dest.write_bytes(stream.getbuffer())
+        dest.write_bytes(stream.getbuffer())  # pyright: ignore[reportOptionalMemberAccess]  # storage.load returns BytesIO, not None
         paths.append(dest)
     return paths[0], paths[1]
 
@@ -93,6 +94,7 @@ def resolve_classifier_artifact(location: str) -> tuple[Path, Path]:
     base = location.rstrip("/")
     pt_loc = AnnotationRun.parse_location_str(f"{base}/model.pt")
     json_loc = AnnotationRun.parse_location_str(f"{base}/model.json")
+    assert pt_loc is not None and json_loc is not None  # guaranteed: non-empty strings passed
 
     if pt_loc.storage_type == "s3":
         return _download_pair_to_tempdir(pt_loc, json_loc)
@@ -104,12 +106,12 @@ class AnnotationRun:
         self,
         image: str,
         points_csv: str,
-        classifier: str = None,
-        weights: str = None,
-        labelset_csv: str = None,
+        classifier: str | None = None,
+        weights: str | None = None,
+        labelset_csv: str | None = None,
         num_predictions_to_save: int = 0,
-        coralnet_cache_dir: str = None,
-        plot_title: str = None,
+        coralnet_cache_dir: str | None = None,
+        plot_title: str | None = None,
     ):
         """
         image
@@ -179,13 +181,13 @@ class AnnotationRun:
 
         weights_location = weights or settings.weights_location
 
-        annotations: dict[tuple[int, int], list] = defaultdict(list)
-        scores: dict[tuple[int, int], list] = defaultdict(list)
+        annotations: dict[tuple[int, int], list[str]] = defaultdict(list)
+        scores: dict[tuple[int, int], list[float]] = defaultdict(list)
 
         # Read in CSV points.
         # Labels and scores may or may not be present.
-        with open(self.points_csv_path) as points_csv:
-            reader = csv.DictReader(points_csv)
+        with open(self.points_csv_path) as points_csv_f:
+            reader = csv.DictReader(points_csv_f)
             for csv_row in reader:
                 row = int(csv_row["row"])
                 column = int(csv_row["column"])
@@ -200,7 +202,9 @@ class AnnotationRun:
             image_id = int(image)
         except ValueError:
             # Non-numeric arg; interpret as file path/URI
-            self.image_loc = self.parse_location_str(image)
+            parsed = self.parse_location_str(image)
+            assert parsed is not None  # image is a required non-empty str parameter
+            self.image_loc = parsed
             auto_plot_title = image
         else:
             # Numeric arg; interpret as CoralNet image ID
@@ -220,6 +224,9 @@ class AnnotationRun:
             # Classify with the portable artifact: extract features with
             # pyspacer's EfficientNet extractor, then predict with the loaded
             # TorchScript head (no classifier pickle, no pyspacer classify call).
+            assert weights_loc is not None, (
+                "weights_location must be set when classifier is provided"
+            )
 
             model_pt, model_json = resolve_classifier_artifact(classifier)
             predictor = load_predictor(model_pt, model_json)
@@ -230,8 +237,8 @@ class AnnotationRun:
                 data_locations={"weights": weights_loc},
             )
             rowcols = list(annotations.keys())
-            check_extract_inputs(loaded_image, rowcols, self.image_loc.key)
-            features, _ = extractor(loaded_image, rowcols)
+            check_extract_inputs(loaded_image, rowcols, self.image_loc.key)  # pyright: ignore[reportArgumentType]  # pyspacer stubs use PIL.Image module, not PIL.Image.Image
+            features, _ = extractor(loaded_image, rowcols)  # pyright: ignore[reportArgumentType]  # same PIL stub issue
 
             predictions_per_point = max(num_predictions_to_save, 1)
 
@@ -247,10 +254,10 @@ class AnnotationRun:
                         zip(labels, proba, strict=False), key=itemgetter(1), reverse=True
                     )
                     annotations[(row, column)] = [
-                        label for label, score in top_predictions[:predictions_per_point]
+                        label for label, _ in top_predictions[:predictions_per_point]
                     ]
                     scores[(row, column)] = [
-                        score for label, score in top_predictions[:predictions_per_point]
+                        score for _, score in top_predictions[:predictions_per_point]
                     ]
             print("Finished classifying")
 
@@ -294,7 +301,7 @@ class AnnotationRun:
                 self.label_ids_to_names[bagf_id] = name
 
     @staticmethod
-    def parse_location_str(location: str) -> DataLocation:
+    def parse_location_str(location: str | None) -> DataLocation | None:
 
         if not location:
             return None
@@ -360,6 +367,8 @@ class AnnotationRun:
                 f" image-view page. Maybe it's in a private source."
             )
         image_url = original_img_elements[0].attrs.get("src")
+        if not isinstance(image_url, str):
+            raise ValueError(f"CoralNet image {image_id}: couldn't parse image URL from page.")
         file_suffix = Path(urlparse(image_url).path).suffix
 
         print("Downloading CoralNet image...")
@@ -374,16 +383,20 @@ class AnnotationRun:
         # No cache
         image_loc = DataLocation("memory", "image")
         memory_storage = storage_factory("memory")
-        memory_storage.store(image_loc.key, BytesIO(download_response.read()))
+        memory_storage.store(image_loc.key, BytesIO(download_response.read()))  # pyright: ignore[reportOptionalMemberAccess]  # memory storage_factory always returns MemoryStorage singleton
         return image_loc
 
     @staticmethod
-    def prediction_column_names(prediction_num):
+    def prediction_column_names(prediction_num: int) -> tuple[str, str]:
         if prediction_num == 1:
             return "label", "score"
         return f"label{prediction_num}", f"score{prediction_num}"
 
-    def write_predictions(self, annotations, scores):
+    def write_predictions(
+        self,
+        annotations: dict[tuple[int, int], list[str]],
+        scores: dict[tuple[int, int], list[float]],
+    ) -> None:
 
         writer_stream = StringIO()
 
@@ -397,9 +410,11 @@ class AnnotationRun:
             for num in range(1, self.num_predictions_to_save + 1):
                 writer_fieldnames += self.prediction_column_names(num)
             # Then, any additional columns that the original CSV happens
-            # to have.
+            # to have. (reader.fieldnames is None before the first row is read,
+            # but DictReader populates it lazily from the header; fall back to
+            # empty so pyright knows the iterable is always valid.)
             writer_fieldnames += [
-                name for name in reader.fieldnames if name not in writer_fieldnames
+                name for name in (reader.fieldnames or []) if name not in writer_fieldnames
             ]
             writer = csv.DictWriter(writer_stream, writer_fieldnames)
             writer.writeheader()
@@ -430,7 +445,7 @@ class AnnotationRun:
     def show(self):
 
         unique_top_labels = list(self.label_ids_to_names.keys())
-        color_list = mpl.cm.tab10(range(len(unique_top_labels)))
+        color_list = matplotlib.cm.tab10(range(len(unique_top_labels)))  # pyright: ignore[reportAttributeAccessIssue]  # matplotlib.cm colormaps are dynamic attributes not in stubs
         # Map the labelset to colors in the color set.
         label_ids_to_colors = dict(zip(unique_top_labels, color_list, strict=False))
 

--- a/mermaid_classifier/pyspacer/inference/__init__.py
+++ b/mermaid_classifier/pyspacer/inference/__init__.py
@@ -34,11 +34,18 @@ class SklearnPinError(Exception):
 
 from mermaid_classifier.pyspacer.inference.export import export_artifact  # noqa: E402
 from mermaid_classifier.pyspacer.inference.loader import (  # noqa: E402
-    Predictor, load_predictor,
+    Predictor,
+    load_predictor,
 )
 
 __all__ = [
-    "SCHEMA_VERSION", "TASK_NAME", "PARITY_PROVEN_SKLEARN",
-    "ParityError", "ManifestError", "SklearnPinError",
-    "export_artifact", "Predictor", "load_predictor",
+    "SCHEMA_VERSION",
+    "TASK_NAME",
+    "PARITY_PROVEN_SKLEARN",
+    "ParityError",
+    "ManifestError",
+    "SklearnPinError",
+    "export_artifact",
+    "Predictor",
+    "load_predictor",
 ]

--- a/mermaid_classifier/pyspacer/inference/export.py
+++ b/mermaid_classifier/pyspacer/inference/export.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import torch
@@ -21,15 +22,15 @@ from mermaid_classifier.pyspacer.inference.head import build_calibrated_head
 
 
 def export_artifact(
-    model,
-    output_dir,
-    reference_features,
+    model: Any,
+    output_dir: str | Path,
+    reference_features: Any,
     *,
-    config: dict | None = None,
+    config: dict[str, Any] | None = None,
     task: str = TASK_NAME,
     tol: float = 1e-6,
     enforce_sklearn_pin: bool = True,
-):
+) -> tuple[Path, dict[str, Any], float]:
     """Build, freeze, parity-gate, and persist the portable artifact.
 
     Returns (model_pt_path, manifest_dict, max_abs_diff). Raises ParityError

--- a/mermaid_classifier/pyspacer/inference/export.py
+++ b/mermaid_classifier/pyspacer/inference/export.py
@@ -1,5 +1,6 @@
 """export_artifact: freeze the calibrated head to TorchScript, parity-gate it
 against the source model, and write the generated manifest."""
+
 from __future__ import annotations
 
 import json
@@ -10,7 +11,11 @@ import numpy as np
 import torch
 
 from mermaid_classifier.pyspacer.inference import (
-    SCHEMA_VERSION, TASK_NAME, PARITY_PROVEN_SKLEARN, ParityError, SklearnPinError,
+    PARITY_PROVEN_SKLEARN,
+    SCHEMA_VERSION,
+    TASK_NAME,
+    ParityError,
+    SklearnPinError,
 )
 from mermaid_classifier.pyspacer.inference.head import build_calibrated_head
 

--- a/mermaid_classifier/pyspacer/inference/head.py
+++ b/mermaid_classifier/pyspacer/inference/head.py
@@ -14,6 +14,8 @@ annotations at import time; PEP 563 turns those annotations into strings
 (``'int'`` instead of ``int``), causing "Unknown type annotation: 'int'".
 """
 
+from typing import Any
+
 import numpy as np
 import torch
 import torch.nn as nn
@@ -22,6 +24,8 @@ import torch.nn.functional as F
 
 class CalibratedHead(nn.Module):
     n_classes: int
+    a: torch.Tensor
+    b: torch.Tensor
 
     def __init__(
         self,
@@ -85,7 +89,7 @@ class CalibratedHead(nn.Module):
         )
 
 
-def build_calibrated_head(model) -> CalibratedHead:
+def build_calibrated_head(model: Any) -> CalibratedHead:
     """Construct a CalibratedHead from a fitted CalibratedClassifierCV that
     wraps a TorchMLPClassifier with cv='prefit' and method='sigmoid'."""
     calibrated = model.calibrated_classifiers_

--- a/mermaid_classifier/pyspacer/inference/head.py
+++ b/mermaid_classifier/pyspacer/inference/head.py
@@ -49,7 +49,7 @@ class CalibratedHead(nn.Module):
         if len(weights) == 0:
             raise ValueError("weights must contain at least one layer.")
         self.linears = nn.ModuleList()
-        for w, bias in zip(weights, biases):
+        for w, bias in zip(weights, biases, strict=False):
             layer = nn.Linear(int(w.shape[1]), int(w.shape[0]))
             with torch.no_grad():
                 layer.weight.copy_(w)
@@ -62,12 +62,10 @@ class CalibratedHead(nn.Module):
     def forward(self, features: torch.Tensor) -> torch.Tensor:
         x = features
         n = len(self.linears)
-        i = 0
-        for linear in self.linears:
+        for i, linear in enumerate(self.linears):
             x = linear(x)
             if i < n - 1:
                 x = F.relu(x)
-            i += 1
         # Computed in float32, matching TorchMLPClassifier._forward_probs; the ~1e-7 residual
         # vs sklearn's float64 path is expected and bounded by the export-time parity gate.
         p = F.softmax(x, dim=1)
@@ -80,12 +78,11 @@ class CalibratedHead(nn.Module):
         safe_denom = torch.where(nonzero, denom, torch.ones_like(denom))
         uniform = torch.full_like(c, 1.0 / float(self.n_classes))
         proba = torch.where(nonzero, c / safe_denom, uniform)
-        proba = torch.where(
+        return torch.where(
             (proba > 1.0) & (proba <= 1.0 + 1e-5),
             torch.ones_like(proba),
             proba,
         )
-        return proba
 
 
 def build_calibrated_head(model) -> CalibratedHead:
@@ -94,8 +91,7 @@ def build_calibrated_head(model) -> CalibratedHead:
     calibrated = model.calibrated_classifiers_
     if len(calibrated) != 1:
         raise ValueError(
-            f"Expected exactly one calibrated classifier (cv='prefit'), got"
-            f" {len(calibrated)}."
+            f"Expected exactly one calibrated classifier (cv='prefit'), got {len(calibrated)}."
         )
     inner = calibrated[0]
     estimator = inner.estimator
@@ -113,10 +109,7 @@ def build_calibrated_head(model) -> CalibratedHead:
             f" K={n_classes}. sklearn stores a single calibrator for K == 2."
         )
     if len(calibrators) != n_classes:
-        raise ValueError(
-            f"Expected {n_classes} per-class calibrators, got"
-            f" {len(calibrators)}."
-        )
+        raise ValueError(f"Expected {n_classes} per-class calibrators, got {len(calibrators)}.")
 
     module = estimator._module
     weights = [lin.weight.detach().clone().float() for lin in module.linears]

--- a/mermaid_classifier/pyspacer/inference/loader.py
+++ b/mermaid_classifier/pyspacer/inference/loader.py
@@ -1,5 +1,6 @@
 """load_predictor: serve-time loader for the portable artifact, with loud
 load-time validation of the graph against its manifest."""
+
 from __future__ import annotations
 
 import json
@@ -28,9 +29,7 @@ class Predictor:
     def predict_proba(self, features) -> np.ndarray:
         arr = np.asarray(features, dtype=np.float32)
         if arr.ndim != 2 or arr.shape[1] != self.input_dim:
-            raise ValueError(
-                f"features must be (N, {self.input_dim}); got {arr.shape}."
-            )
+            raise ValueError(f"features must be (N, {self.input_dim}); got {arr.shape}.")
         with torch.no_grad():
             return self._graph(torch.from_numpy(arr)).numpy().astype(np.float64)
 
@@ -63,8 +62,7 @@ def load_predictor(model_pt_path, model_json_path) -> Predictor:
             probe = graph(torch.zeros(1, input_dim, dtype=torch.float32))
     except Exception as exc:  # noqa: BLE001 - re-raise loudly as ManifestError
         raise ManifestError(
-            f"graph rejects input_dim={input_dim} declared in model.json:"
-            f" {exc}"
+            f"graph rejects input_dim={input_dim} declared in model.json: {exc}"
         ) from exc
 
     if probe.shape[1] != len(classes):

--- a/mermaid_classifier/pyspacer/inference/loader.py
+++ b/mermaid_classifier/pyspacer/inference/loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import torch
@@ -15,18 +16,18 @@ from mermaid_classifier.pyspacer.inference import SCHEMA_VERSION, ManifestError
 class Predictor:
     """A loaded classifier head: feature batch -> calibrated probabilities."""
 
-    def __init__(self, graph, classes: list[str], input_dim: int):
+    def __init__(self, graph: Any, classes: list[str], input_dim: int) -> None:
         self._graph = graph
         self.classes = classes
         self.input_dim = input_dim
 
     @property
-    def classes_(self):
+    def classes_(self) -> list[str]:
         """Alias for ``classes`` so a Predictor is a drop-in for the former
         pickled classifier in metrics code that reads ``clf.classes_``."""
         return self.classes
 
-    def predict_proba(self, features) -> np.ndarray:
+    def predict_proba(self, features: Any) -> np.ndarray:
         arr = np.asarray(features, dtype=np.float32)
         if arr.ndim != 2 or arr.shape[1] != self.input_dim:
             raise ValueError(f"features must be (N, {self.input_dim}); got {arr.shape}.")
@@ -34,7 +35,7 @@ class Predictor:
             return self._graph(torch.from_numpy(arr)).numpy().astype(np.float64)
 
 
-def load_predictor(model_pt_path, model_json_path) -> Predictor:
+def load_predictor(model_pt_path: str | Path, model_json_path: str | Path) -> Predictor:
     """Load model.pt + model.json, validating compatibility loudly.
 
     Raises ManifestError on schema-version, class-count, or input_dim

--- a/mermaid_classifier/pyspacer/metrics/__init__.py
+++ b/mermaid_classifier/pyspacer/metrics/__init__.py
@@ -4,6 +4,6 @@ from mermaid_classifier.pyspacer.metrics._context import MetricsContext
 from mermaid_classifier.pyspacer.metrics.coordinator import MetricsCoordinator
 
 __all__ = [
-    'MetricsContext',
-    'MetricsCoordinator',
+    "MetricsContext",
+    "MetricsCoordinator",
 ]

--- a/mermaid_classifier/pyspacer/metrics/_context.py
+++ b/mermaid_classifier/pyspacer/metrics/_context.py
@@ -32,7 +32,7 @@ class MetricsContext:
     dataset: "TrainingDataset | None" = None
     clf: typing.Any = None
     val_proba: "np.ndarray | None" = None
-    val_gt_labels: "list | None" = None
+    val_gt_labels: "list[typing.Any] | None" = None
     ba_to_top: "dict[str, str] | None" = None
     ba_paths: "dict[str, list[str]] | None" = None
 
@@ -56,7 +56,7 @@ class MetricsContext:
         # by ba_library
         for class_id in self.val_results.classes:
             try:
-                self.ba_library.bagf_id_to_name(class_id, self.gf_library)
+                self.ba_library.bagf_id_to_name(class_id, self.gf_library)  # pyright: ignore[reportArgumentType]  # LabelId is int|str; MERMAID uses str
             except Exception as e:
                 raise MetricsContextError(
                     f"Class ID {class_id!r} not found in ba_library: {e}"

--- a/mermaid_classifier/pyspacer/metrics/_context.py
+++ b/mermaid_classifier/pyspacer/metrics/_context.py
@@ -26,15 +26,15 @@ class MetricsContext:
     """
 
     val_results: ValResults
-    ba_library: 'BenthicAttributeLibrary'
-    gf_library: 'GrowthFormLibrary'
+    ba_library: "BenthicAttributeLibrary"
+    gf_library: "GrowthFormLibrary"
     format_func: typing.Callable[[float], typing.Any]
-    dataset: 'TrainingDataset | None' = None
+    dataset: "TrainingDataset | None" = None
     clf: typing.Any = None
-    val_proba: 'np.ndarray | None' = None
-    val_gt_labels: 'list | None' = None
-    ba_to_top: 'dict[str, str] | None' = None
-    ba_paths: 'dict[str, list[str]] | None' = None
+    val_proba: "np.ndarray | None" = None
+    val_gt_labels: "list | None" = None
+    ba_to_top: "dict[str, str] | None" = None
+    ba_paths: "dict[str, list[str]] | None" = None
 
     def validate(self):
         """Check that inputs are valid for metric computation.
@@ -42,16 +42,15 @@ class MetricsContext:
         Raises MetricsContextError if validation fails.
         """
         if not self.val_results.gt or not self.val_results.est:
-            raise MetricsContextError(
-                "val_results has no predictions (gt or est is empty)")
+            raise MetricsContextError("val_results has no predictions (gt or est is empty)")
 
         # Check all class IDs used in gt/est exist in val_results.classes
         num_classes = len(self.val_results.classes)
         for idx in set(self.val_results.gt) | set(self.val_results.est):
             if idx < 0 or idx >= num_classes:
                 raise MetricsContextError(
-                    f"Class index {idx} out of range for "
-                    f"{num_classes} classes")
+                    f"Class index {idx} out of range for {num_classes} classes"
+                )
 
         # Check all class IDs in val_results.classes can be resolved
         # by ba_library
@@ -63,7 +62,7 @@ class MetricsContext:
                     f"Class ID {class_id!r} not found in ba_library: {e}"
                 ) from e
 
-        if self.clf is not None:
-            if not hasattr(self.clf, 'classes_') or len(self.clf.classes_) == 0:
-                raise MetricsContextError(
-                    "clf has no classes_ attribute or it is empty")
+        if self.clf is not None and (
+            not hasattr(self.clf, "classes_") or len(self.clf.classes_) == 0
+        ):
+            raise MetricsContextError("clf has no classes_ attribute or it is empty")

--- a/mermaid_classifier/pyspacer/metrics/_logging.py
+++ b/mermaid_classifier/pyspacer/metrics/_logging.py
@@ -21,12 +21,12 @@ def log_dataframe(
     produce a proper .csv instead.
     """
     with duckdb_temp_table_name(duck_conn) as table_name:
-        duck_conn.execute(
-            f"CREATE TABLE {table_name} AS SELECT * FROM df"
-        )
+        duck_conn.execute(f"CREATE TABLE {table_name} AS SELECT * FROM df")
 
         with tempfile.NamedTemporaryFile(
-            mode='w+t', suffix='.csv', delete_on_close=False,
+            mode="w+t",
+            suffix=".csv",
+            delete_on_close=False,
         ) as f:
             # DuckDB will reopen the file, so close first.
             f.close()
@@ -34,7 +34,7 @@ def log_dataframe(
 
             # Need to open yet again to get the DuckDB-written contents.
             with open(f.name) as f_new:
-                mlflow.log_text(f_new.read(), filestem + '.csv')
+                mlflow.log_text(f_new.read(), filestem + ".csv")
 
             # As this context manager finishes, the temp file will be
             # deleted.

--- a/mermaid_classifier/pyspacer/metrics/_results.py
+++ b/mermaid_classifier/pyspacer/metrics/_results.py
@@ -9,6 +9,7 @@ from matplotlib.figure import Figure
 @dataclasses.dataclass
 class ScalarMetric:
     """A single named numeric metric."""
+
     name: str
     value: float
 
@@ -16,6 +17,7 @@ class ScalarMetric:
 @dataclasses.dataclass
 class FigureResult:
     """A matplotlib figure to log as an artifact."""
+
     fig: Figure
     artifact_path: str
 
@@ -23,6 +25,7 @@ class FigureResult:
 @dataclasses.dataclass
 class DataFrameResult:
     """A DataFrame to log as a CSV artifact."""
+
     df: pd.DataFrame
     artifact_path: str
 
@@ -30,6 +33,7 @@ class DataFrameResult:
 @dataclasses.dataclass
 class DictResult:
     """A dict to log as a YAML/JSON artifact."""
+
     data: dict
     artifact_path: str
 
@@ -37,6 +41,7 @@ class DictResult:
 @dataclasses.dataclass
 class MetricGroupResult:
     """Collection of results from a single metric group."""
+
     scalars: list[ScalarMetric] = dataclasses.field(default_factory=list)
     figures: list[FigureResult] = dataclasses.field(default_factory=list)
     dataframes: list[DataFrameResult] = dataclasses.field(default_factory=list)

--- a/mermaid_classifier/pyspacer/metrics/_results.py
+++ b/mermaid_classifier/pyspacer/metrics/_results.py
@@ -1,6 +1,7 @@
 """Structured output types returned by metric functions."""
 
 import dataclasses
+import typing
 
 import pandas as pd
 from matplotlib.figure import Figure
@@ -34,7 +35,7 @@ class DataFrameResult:
 class DictResult:
     """A dict to log as a YAML/JSON artifact."""
 
-    data: dict
+    data: dict[str, typing.Any]
     artifact_path: str
 
 

--- a/mermaid_classifier/pyspacer/metrics/_taxonomy_helpers.py
+++ b/mermaid_classifier/pyspacer/metrics/_taxonomy_helpers.py
@@ -20,7 +20,8 @@ def top_level_ancestor(ba_id: str, ba_library: BenthicAttributeLibrary) -> str:
 
 
 def build_ba_to_top(
-    classes: list[str], ba_library: BenthicAttributeLibrary,
+    classes: list[str],
+    ba_library: BenthicAttributeLibrary,
 ) -> dict[str, str]:
     """Map each BA ID (extracted from BAGF class IDs) to its top-level ancestor."""
     ba_to_top: dict[str, str] = {}
@@ -32,7 +33,8 @@ def build_ba_to_top(
 
 
 def build_ba_paths(
-    classes: list[str], ba_library: BenthicAttributeLibrary,
+    classes: list[str],
+    ba_library: BenthicAttributeLibrary,
 ) -> dict[str, list[str]]:
     """Map each BA ID to its root-to-leaf path [root, ..., parent, self]."""
     ba_paths: dict[str, list[str]] = {}
@@ -44,7 +46,9 @@ def build_ba_paths(
 
 
 def find_lca(
-    ba_a: str, ba_b: str, ba_paths: dict[str, list[str]],
+    ba_a: str,
+    ba_b: str,
+    ba_paths: dict[str, list[str]],
 ) -> str | None:
     """Walk both root-to-leaf paths in parallel, return last matching node.
 
@@ -53,7 +57,7 @@ def find_lca(
     path_a = ba_paths[ba_a]
     path_b = ba_paths[ba_b]
     lca = None
-    for a, b in zip(path_a, path_b):
+    for a, b in zip(path_a, path_b, strict=False):
         if a == b:
             lca = a
         else:
@@ -105,10 +109,12 @@ def group_by_top_level(
     for top_ba_id, indices in category_indices.items():
         if len(indices) < min_samples:
             continue
-        groups.append({
-            'top_ba_id': top_ba_id,
-            'name': ba_library.id_to_name(top_ba_id),
-            'indices': indices,
-            'n_samples': len(indices),
-        })
+        groups.append(
+            {
+                "top_ba_id": top_ba_id,
+                "name": ba_library.id_to_name(top_ba_id),
+                "indices": indices,
+                "n_samples": len(indices),
+            }
+        )
     return groups

--- a/mermaid_classifier/pyspacer/metrics/_taxonomy_helpers.py
+++ b/mermaid_classifier/pyspacer/metrics/_taxonomy_helpers.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import typing
 from collections import defaultdict
 
+# LabelId is `int | str` in pyspacer; MERMAID always uses str labels.
+# These helpers are typed str-only since they parse BAGF strings internally.
 from mermaid_classifier.common.benthic_attributes import split_ba_gf
 
 if typing.TYPE_CHECKING:
@@ -93,7 +95,7 @@ def group_by_top_level(
     ba_to_top: dict[str, str],
     ba_library: BenthicAttributeLibrary,
     min_samples: int = 30,
-) -> list[dict]:
+) -> list[dict[str, typing.Any]]:
     """Group samples by ground-truth top-level BA category.
 
     Returns list of dicts with keys: top_ba_id, name, indices, n_samples.

--- a/mermaid_classifier/pyspacer/metrics/calibration.py
+++ b/mermaid_classifier/pyspacer/metrics/calibration.py
@@ -11,7 +11,10 @@ Uses val_results.scores (max probabilities) — no clf needed.
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
 from matplotlib.patches import Patch
+from numpy.typing import ArrayLike
 
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
 from mermaid_classifier.pyspacer.metrics._results import (
@@ -26,7 +29,12 @@ from mermaid_classifier.pyspacer.metrics._taxonomy_helpers import (
 )
 
 
-def _adaptive_ece(confidences, gt_indices, est_indices, n_bins=20):
+def _adaptive_ece(
+    confidences: ArrayLike,
+    gt_indices: ArrayLike,
+    est_indices: ArrayLike,
+    n_bins: int = 20,
+) -> tuple[float, list[dict[str, float | int]]]:
     """Compute ECE using adaptive (equal-mass) binning.
 
     Returns (ece, bin_data) where bin_data is a list of dicts with
@@ -110,10 +118,12 @@ def compute_calibration(ctx: MetricsContext) -> MetricGroupResult:
     )
 
     # Per-category ECE.
-    ba_to_top = ctx.ba_to_top or build_ba_to_top(val_results.classes, ctx.ba_library)
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes_str: list[str] = val_results.classes  # pyright: ignore[reportAssignmentType]
+    ba_to_top = ctx.ba_to_top or build_ba_to_top(classes_str, ctx.ba_library)
     all_indices = list(range(len(val_results.gt)))
     groups = group_by_top_level(
-        all_indices, val_results.gt, val_results.classes, ba_to_top, ctx.ba_library, min_samples=30
+        all_indices, val_results.gt, classes_str, ba_to_top, ctx.ba_library, min_samples=30
     )
 
     scores = np.asarray(val_results.scores)
@@ -144,7 +154,7 @@ def compute_calibration(ctx: MetricsContext) -> MetricGroupResult:
             df=pd.DataFrame(cat_rows)
             if cat_rows
             else pd.DataFrame(
-                columns=["category", "ece", "accuracy", "avg_confidence", "n_samples"]
+                columns=["category", "ece", "accuracy", "avg_confidence", "n_samples"]  # pyright: ignore[reportArgumentType]
             ),
             artifact_path="calibration/per_category_ece",
         )
@@ -153,7 +163,10 @@ def compute_calibration(ctx: MetricsContext) -> MetricGroupResult:
     return result
 
 
-def _plot_reliability_diagram(ece, bin_data):
+def _plot_reliability_diagram(
+    ece: float,
+    bin_data: list[dict[str, float | int]],
+) -> Figure:
     """Plot reliability diagram with accuracy bars + overconfidence gap."""
     fig, ax = plt.subplots(figsize=(7, 5))
 
@@ -194,7 +207,7 @@ def _plot_reliability_diagram(ece, bin_data):
         handles=[
             Patch(facecolor="#1976d2", alpha=0.8, label="Accuracy"),
             Patch(facecolor="#d32f2f", alpha=0.3, label="Overconfidence gap"),
-            plt.Line2D([], [], color="k", linestyle="--", label="Perfect calibration"),
+            Line2D([], [], color="k", linestyle="--", label="Perfect calibration"),
         ],
         loc="upper left",
     )
@@ -206,7 +219,7 @@ def _plot_reliability_diagram(ece, bin_data):
     ax.set_aspect("equal")
 
     # Inset: sample count per bin.
-    inset = ax.inset_axes([0.55, 0.05, 0.4, 0.25])
+    inset = ax.inset_axes((0.55, 0.05, 0.4, 0.25))
     inset.bar(range(len(counts)), counts, color="#666666", alpha=0.6)
     inset.set_ylabel("n", fontsize=8)
     inset.set_xlabel("Bin", fontsize=8)

--- a/mermaid_classifier/pyspacer/metrics/calibration.py
+++ b/mermaid_classifier/pyspacer/metrics/calibration.py
@@ -58,13 +58,15 @@ def _adaptive_ece(confidences, gt_indices, est_indices, n_bins=20):
         count = end - start
 
         ece += abs(avg_acc - avg_conf) * count / n
-        bin_data.append({
-            'avg_confidence': float(avg_conf),
-            'avg_accuracy': float(avg_acc),
-            'count': int(count),
-            'conf_min': float(bin_conf.min()),
-            'conf_max': float(bin_conf.max()),
-        })
+        bin_data.append(
+            {
+                "avg_confidence": float(avg_conf),
+                "avg_accuracy": float(avg_acc),
+                "count": int(count),
+                "conf_min": float(bin_conf.min()),
+                "conf_max": float(bin_conf.max()),
+            }
+        )
 
     return ece, bin_data
 
@@ -75,40 +77,44 @@ def compute_calibration(ctx: MetricsContext) -> MetricGroupResult:
     result = MetricGroupResult()
 
     # Overall adaptive ECE.
-    ece, bin_data = _adaptive_ece(
-        val_results.scores, val_results.gt, val_results.est, n_bins=20)
+    ece, bin_data = _adaptive_ece(val_results.scores, val_results.gt, val_results.est, n_bins=20)
 
-    result.scalars.append(ScalarMetric(name='ece', value=ece))
+    result.scalars.append(ScalarMetric(name="ece", value=ece))
 
     # Per-bin details DataFrame.
     rows = []
     for i, b in enumerate(bin_data):
-        gap = b['avg_confidence'] - b['avg_accuracy']
-        rows.append({
-            'bin': i + 1,
-            'conf_min': b['conf_min'],
-            'conf_max': b['conf_max'],
-            'avg_confidence': b['avg_confidence'],
-            'avg_accuracy': b['avg_accuracy'],
-            'gap': gap,
-            'count': b['count'],
-        })
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(rows),
-        artifact_path='calibration/per_bin_details',
-    ))
+        gap = b["avg_confidence"] - b["avg_accuracy"]
+        rows.append(
+            {
+                "bin": i + 1,
+                "conf_min": b["conf_min"],
+                "conf_max": b["conf_max"],
+                "avg_confidence": b["avg_confidence"],
+                "avg_accuracy": b["avg_accuracy"],
+                "gap": gap,
+                "count": b["count"],
+            }
+        )
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(rows),
+            artifact_path="calibration/per_bin_details",
+        )
+    )
 
     # Reliability diagram figure.
     fig = _plot_reliability_diagram(ece, bin_data)
-    result.figures.append(FigureResult(
-        fig=fig, artifact_path='calibration/reliability_diagram.png'))
+    result.figures.append(
+        FigureResult(fig=fig, artifact_path="calibration/reliability_diagram.png")
+    )
 
     # Per-category ECE.
     ba_to_top = ctx.ba_to_top or build_ba_to_top(val_results.classes, ctx.ba_library)
     all_indices = list(range(len(val_results.gt)))
     groups = group_by_top_level(
-        all_indices, val_results.gt, val_results.classes,
-        ba_to_top, ctx.ba_library, min_samples=30)
+        all_indices, val_results.gt, val_results.classes, ba_to_top, ctx.ba_library, min_samples=30
+    )
 
     scores = np.asarray(val_results.scores)
     gt_arr = np.asarray(val_results.gt)
@@ -116,28 +122,33 @@ def compute_calibration(ctx: MetricsContext) -> MetricGroupResult:
 
     cat_rows = []
     for group in groups:
-        idx = np.array(group['indices'])
-        n = group['n_samples']
+        idx = np.array(group["indices"])
+        n = group["n_samples"]
         n_bins_cat = min(20, max(2, n // 10))
-        cat_ece, _ = _adaptive_ece(
-            scores[idx], gt_arr[idx], est_arr[idx], n_bins=n_bins_cat)
+        cat_ece, _ = _adaptive_ece(scores[idx], gt_arr[idx], est_arr[idx], n_bins=n_bins_cat)
         cat_acc = float((est_arr[idx] == gt_arr[idx]).mean())
         cat_conf = float(scores[idx].mean())
-        cat_rows.append({
-            'category': group['name'],
-            'ece': cat_ece,
-            'accuracy': cat_acc,
-            'avg_confidence': cat_conf,
-            'n_samples': n,
-        })
+        cat_rows.append(
+            {
+                "category": group["name"],
+                "ece": cat_ece,
+                "accuracy": cat_acc,
+                "avg_confidence": cat_conf,
+                "n_samples": n,
+            }
+        )
 
-    cat_rows.sort(key=lambda r: r['ece'], reverse=True)
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(cat_rows) if cat_rows else pd.DataFrame(
-            columns=['category', 'ece', 'accuracy', 'avg_confidence',
-                     'n_samples']),
-        artifact_path='calibration/per_category_ece',
-    ))
+    cat_rows.sort(key=lambda r: r["ece"], reverse=True)
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(cat_rows)
+            if cat_rows
+            else pd.DataFrame(
+                columns=["category", "ece", "accuracy", "avg_confidence", "n_samples"]
+            ),
+            artifact_path="calibration/per_category_ece",
+        )
+    )
 
     return result
 
@@ -146,46 +157,61 @@ def _plot_reliability_diagram(ece, bin_data):
     """Plot reliability diagram with accuracy bars + overconfidence gap."""
     fig, ax = plt.subplots(figsize=(7, 5))
 
-    confs = [b['avg_confidence'] for b in bin_data]
-    accs = [b['avg_accuracy'] for b in bin_data]
-    counts = [b['count'] for b in bin_data]
-    widths = [b['conf_max'] - b['conf_min'] for b in bin_data]
-    lefts = [b['conf_min'] for b in bin_data]
+    confs = [b["avg_confidence"] for b in bin_data]
+    accs = [b["avg_accuracy"] for b in bin_data]
+    counts = [b["count"] for b in bin_data]
+    widths = [b["conf_max"] - b["conf_min"] for b in bin_data]
+    lefts = [b["conf_min"] for b in bin_data]
 
     # Accuracy bars.
-    ax.bar(lefts, accs, width=widths, align='edge',
-           color='#1976d2', edgecolor='white', alpha=0.8, label='Accuracy')
+    ax.bar(
+        lefts,
+        accs,
+        width=widths,
+        align="edge",
+        color="#1976d2",
+        edgecolor="white",
+        alpha=0.8,
+        label="Accuracy",
+    )
 
     # Overconfidence gap overlay.
-    for left, w, acc, conf in zip(lefts, widths, accs, confs):
+    for left, w, acc, conf in zip(lefts, widths, accs, confs, strict=False):
         if conf > acc:
-            ax.bar(left, conf - acc, bottom=acc, width=w, align='edge',
-                   color='#d32f2f', alpha=0.3, edgecolor='white')
+            ax.bar(
+                left,
+                conf - acc,
+                bottom=acc,
+                width=w,
+                align="edge",
+                color="#d32f2f",
+                alpha=0.3,
+                edgecolor="white",
+            )
 
-    ax.plot([0, 1], [0, 1], 'k--', linewidth=1, label='Perfect calibration')
+    ax.plot([0, 1], [0, 1], "k--", linewidth=1, label="Perfect calibration")
     ax.legend(
         handles=[
-            Patch(facecolor='#1976d2', alpha=0.8, label='Accuracy'),
-            Patch(facecolor='#d32f2f', alpha=0.3, label='Overconfidence gap'),
-            plt.Line2D([], [], color='k', linestyle='--',
-                       label='Perfect calibration'),
+            Patch(facecolor="#1976d2", alpha=0.8, label="Accuracy"),
+            Patch(facecolor="#d32f2f", alpha=0.3, label="Overconfidence gap"),
+            plt.Line2D([], [], color="k", linestyle="--", label="Perfect calibration"),
         ],
-        loc='upper left',
+        loc="upper left",
     )
-    ax.set_xlabel('Confidence')
-    ax.set_ylabel('Accuracy')
-    ax.set_title(f'Reliability Diagram — ECE = {ece:.4f}')
+    ax.set_xlabel("Confidence")
+    ax.set_ylabel("Accuracy")
+    ax.set_title(f"Reliability Diagram — ECE = {ece:.4f}")
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
-    ax.set_aspect('equal')
+    ax.set_aspect("equal")
 
     # Inset: sample count per bin.
     inset = ax.inset_axes([0.55, 0.05, 0.4, 0.25])
-    inset.bar(range(len(counts)), counts, color='#666666', alpha=0.6)
-    inset.set_ylabel('n', fontsize=8)
-    inset.set_xlabel('Bin', fontsize=8)
+    inset.bar(range(len(counts)), counts, color="#666666", alpha=0.6)
+    inset.set_ylabel("n", fontsize=8)
+    inset.set_xlabel("Bin", fontsize=8)
     inset.tick_params(labelsize=7)
-    inset.set_title('Samples per bin', fontsize=8)
+    inset.set_title("Samples per bin", fontsize=8)
 
     plt.tight_layout()
     return fig

--- a/mermaid_classifier/pyspacer/metrics/classification.py
+++ b/mermaid_classifier/pyspacer/metrics/classification.py
@@ -2,6 +2,7 @@
 balanced accuracy, and Matthews Correlation Coefficient."""
 
 from collections import Counter
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -21,6 +22,12 @@ from mermaid_classifier.pyspacer.metrics._results import (
     MetricGroupResult,
     ScalarMetric,
 )
+
+if TYPE_CHECKING:
+    from mermaid_classifier.common.benthic_attributes import (
+        BenthicAttributeLibrary,
+        GrowthFormLibrary,
+    )
 
 
 def _hierarchical_class_order(val_results: ValResults) -> list[int]:
@@ -49,15 +56,15 @@ def _hierarchical_class_order(val_results: ValResults) -> list[int]:
     dist_matrix = (dist_matrix + dist_matrix.T) / 2
 
     condensed = squareform(dist_matrix, checks=False)
-    Z = linkage(condensed, method='average')
+    Z = linkage(condensed, method="average")
     return list(leaves_list(Z))
 
 
 def _build_confusion_matrix(
     val_results: ValResults,
     normalize: bool,
-    ba_library: 'BenthicAttributeLibrary',
-    gf_library: 'GrowthFormLibrary',
+    ba_library: "BenthicAttributeLibrary",
+    gf_library: "GrowthFormLibrary",
     class_order: list[int],
 ) -> tuple[pd.DataFrame, plt.Figure]:
     """Build a confusion matrix DataFrame and matplotlib Figure.
@@ -68,7 +75,7 @@ def _build_confusion_matrix(
         y_true=val_results.gt,
         y_pred=val_results.est,
         labels=range(len(val_results.classes)),
-        normalize='true' if normalize else None,
+        normalize="true" if normalize else None,
     )
 
     if normalize:
@@ -79,13 +86,12 @@ def _build_confusion_matrix(
     matrix = matrix[np.ix_(class_order, class_order)]
 
     bagf_names = [
-        ba_library.bagf_id_to_name(
-            val_results.classes[class_index], gf_library)
+        ba_library.bagf_id_to_name(val_results.classes[class_index], gf_library)
         for class_index in class_order
     ]
 
     df = pd.DataFrame(data=matrix, columns=bagf_names)
-    df.insert(loc=0, column='-', value=bagf_names)
+    df.insert(loc=0, column="-", value=bagf_names)
 
     num_labels = len(bagf_names)
     fig_size = max(12, num_labels * 0.6)
@@ -93,26 +99,27 @@ def _build_confusion_matrix(
     try:
         # Matplotlib visualization of the confusion matrix.
         display = sklearn.metrics.ConfusionMatrixDisplay(
-            confusion_matrix=matrix, display_labels=bagf_names)
+            confusion_matrix=matrix, display_labels=bagf_names
+        )
         display.plot(
             ax=ax,
-            cmap='Blues',
+            cmap="Blues",
             # Prevent "100" displaying as "1e+02".
-            values_format='d',
+            values_format="d",
             # A color legend feels unnecessary here.
             colorbar=False,
         )
 
         # Move x-axis labels to the top.
-        ax.xaxis.set_label_position('top')
-        ax.xaxis.set_ticks_position('top')
+        ax.xaxis.set_label_position("top")
+        ax.xaxis.set_ticks_position("top")
         # Rotate x-axis tick labels to prevent their texts from overlapping.
         label_font_size = max(8, min(12, 150 / num_labels))
         plt.setp(
             ax.get_xticklabels(),
             rotation=45,
-            ha='left',
-            rotation_mode='anchor',
+            ha="left",
+            rotation_mode="anchor",
             fontsize=label_font_size,
         )
         # Match y-axis labels' font size with the x axis.
@@ -137,22 +144,23 @@ def compute_confusion_matrices(ctx: MetricsContext) -> MetricGroupResult:
     class_order = _hierarchical_class_order(ctx.val_results)
 
     for normalize, filestem in [
-        (False, 'confusion_matrix/frequencies'),
-        (True, 'confusion_matrix/percents'),
+        (False, "confusion_matrix/frequencies"),
+        (True, "confusion_matrix/percents"),
     ]:
         try:
             df, fig = _build_confusion_matrix(
-                ctx.val_results, normalize, ctx.ba_library, ctx.gf_library,
+                ctx.val_results,
+                normalize,
+                ctx.ba_library,
+                ctx.gf_library,
                 class_order,
             )
         except Exception:
             for fig_result in result.figures:
                 plt.close(fig_result.fig)
             raise
-        result.dataframes.append(
-            DataFrameResult(df=df, artifact_path=filestem))
-        result.figures.append(
-            FigureResult(fig=fig, artifact_path=filestem + '.png'))
+        result.dataframes.append(DataFrameResult(df=df, artifact_path=filestem))
+        result.figures.append(FigureResult(fig=fig, artifact_path=filestem + ".png"))
 
     return result
 
@@ -163,14 +171,14 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
 
     # Convert the valresults to a pandas dataframe.
 
-    actual_annotations = pd.Categorical(
-        [val_results.classes[i] for i in val_results.gt])
-    predicted_annotations = pd.Categorical(
-        [val_results.classes[i] for i in val_results.est])
-    annotations_df = pd.DataFrame({
-        'actual': actual_annotations,
-        'predicted': predicted_annotations,
-    })
+    actual_annotations = pd.Categorical([val_results.classes[i] for i in val_results.gt])
+    predicted_annotations = pd.Categorical([val_results.classes[i] for i in val_results.est])
+    annotations_df = pd.DataFrame(
+        {
+            "actual": actual_annotations,
+            "predicted": predicted_annotations,
+        }
+    )
 
     # Precision, recall, F1: per label
 
@@ -178,15 +186,14 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
     label_counts = Counter(val_results.classes[i] for i in val_results.gt)
 
     for label in val_results.classes:
-
         precision = sklearn.metrics.precision_score(
-            annotations_df['actual'],
-            annotations_df['predicted'],
+            annotations_df["actual"],
+            annotations_df["predicted"],
             # This makes it produce single-label metrics.
             labels=[label],
             # For single-label, micro and macro are the same, so it doesn't
             # matter which we pass in for `average`.
-            average='micro',
+            average="micro",
             # If any label is lacking true positives and false positives,
             # or true positives and false negatives, either precision or
             # recall may have zero in the denominator of the calculation.
@@ -194,10 +201,10 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
             zero_division=0.0,
         )
         recall = sklearn.metrics.recall_score(
-            annotations_df['actual'],
-            annotations_df['predicted'],
+            annotations_df["actual"],
+            annotations_df["predicted"],
             labels=[label],
-            average='micro',
+            average="micro",
             zero_division=0.0,
         )
 
@@ -207,18 +214,20 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
         else:
             f1_score = 2 * (precision * recall) / (precision + recall)
 
-        per_label_metrics.append(dict(
-            bagf_name=ctx.ba_library.bagf_id_to_name(label, ctx.gf_library),
-            precision=ctx.format_func(precision),
-            recall=ctx.format_func(recall),
-            f1_score=ctx.format_func(f1_score),
-            n_samples=int(label_counts.get(label, 0)),
-            bagf_id=label,
-        ))
+        per_label_metrics.append(
+            {
+                "bagf_name": ctx.ba_library.bagf_id_to_name(label, ctx.gf_library),
+                "precision": ctx.format_func(precision),
+                "recall": ctx.format_func(recall),
+                "f1_score": ctx.format_func(f1_score),
+                "n_samples": int(label_counts.get(label, 0)),
+                "bagf_id": label,
+            }
+        )
 
     # Precision, recall, F1: overall
 
-    overall_metrics = dict()
+    overall_metrics = {}
 
     # average='macro' calculates precision for each class and then averages
     # them, treating all classes equally irrespective of their frequency
@@ -230,25 +239,22 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
     precision = sklearn.metrics.precision_score(
         actual_annotations,
         predicted_annotations,
-        average='macro',
+        average="macro",
         zero_division=0.0,
     )
     recall = sklearn.metrics.recall_score(
         actual_annotations,
         predicted_annotations,
-        average='macro',
+        average="macro",
         zero_division=0.0,
     )
-    if (precision + recall) > 0:
-        f1_score = 2 * (precision * recall) / (precision + recall)
-    else:
-        f1_score = 0.0
+    f1_score = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
 
-    overall_metrics |= dict(
-        precision_macro=ctx.format_func(precision),
-        recall_macro=ctx.format_func(recall),
-        f1_macro=ctx.format_func(f1_score),
-    )
+    overall_metrics |= {
+        "precision_macro": ctx.format_func(precision),
+        "recall_macro": ctx.format_func(recall),
+        "f1_macro": ctx.format_func(f1_score),
+    }
 
     # Build result
 
@@ -260,13 +266,11 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
 
     # Per-label metrics as a DataFrame artifact.
     result.dataframes.append(
-        DataFrameResult(
-            df=pd.DataFrame(per_label_metrics),
-            artifact_path='metrics_per_label'))
+        DataFrameResult(df=pd.DataFrame(per_label_metrics), artifact_path="metrics_per_label")
+    )
 
     # Overall metrics as a dict artifact.
-    result.dicts.append(
-        DictResult(data=overall_metrics, artifact_path='metrics_overall.yaml'))
+    result.dicts.append(DictResult(data=overall_metrics, artifact_path="metrics_overall.yaml"))
 
     return result
 
@@ -281,17 +285,12 @@ def compute_balanced_accuracy_mcc(ctx: MetricsContext) -> MetricGroupResult:
     gt_labels = [ctx.val_results.classes[i] for i in ctx.val_results.gt]
     est_labels = [ctx.val_results.classes[i] for i in ctx.val_results.est]
 
-    balanced_acc = sklearn.metrics.balanced_accuracy_score(
-        gt_labels, est_labels)
+    balanced_acc = sklearn.metrics.balanced_accuracy_score(gt_labels, est_labels)
     mcc = sklearn.metrics.matthews_corrcoef(gt_labels, est_labels)
 
     return MetricGroupResult(
         scalars=[
-            ScalarMetric(
-                name='balanced_accuracy',
-                value=ctx.format_func(balanced_acc)),
-            ScalarMetric(
-                name='mcc',
-                value=ctx.format_func(mcc)),
+            ScalarMetric(name="balanced_accuracy", value=ctx.format_func(balanced_acc)),
+            ScalarMetric(name="mcc", value=ctx.format_func(mcc)),
         ],
     )

--- a/mermaid_classifier/pyspacer/metrics/classification.py
+++ b/mermaid_classifier/pyspacer/metrics/classification.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import sklearn
 import sklearn.metrics
+from matplotlib.figure import Figure
 from scipy.cluster.hierarchy import leaves_list, linkage
 from scipy.spatial.distance import squareform
 from sklearn.metrics.pairwise import cosine_distances
@@ -66,7 +67,7 @@ def _build_confusion_matrix(
     ba_library: "BenthicAttributeLibrary",
     gf_library: "GrowthFormLibrary",
     class_order: list[int],
-) -> tuple[pd.DataFrame, plt.Figure]:
+) -> tuple[pd.DataFrame, Figure]:
     """Build a confusion matrix DataFrame and matplotlib Figure.
 
     Returns (df, fig). Caller is responsible for closing the figure.
@@ -80,18 +81,20 @@ def _build_confusion_matrix(
 
     if normalize:
         # 0-to-1 values -> integer percents.
-        matrix = np.int64(np.floor(matrix * 100))
+        matrix = np.floor(matrix * 100).astype(np.int64)
 
     # Reorder rows and columns by hierarchical clustering order.
     matrix = matrix[np.ix_(class_order, class_order)]
 
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes_str: list[str] = val_results.classes  # pyright: ignore[reportAssignmentType]
     bagf_names = [
-        ba_library.bagf_id_to_name(val_results.classes[class_index], gf_library)
+        ba_library.bagf_id_to_name(classes_str[class_index], gf_library)
         for class_index in class_order
     ]
 
-    df = pd.DataFrame(data=matrix, columns=bagf_names)
-    df.insert(loc=0, column="-", value=bagf_names)
+    df = pd.DataFrame(data=matrix, columns=bagf_names)  # pyright: ignore[reportArgumentType]
+    df.insert(loc=0, column="-", value=bagf_names)  # pyright: ignore[reportArgumentType]
 
     num_labels = len(bagf_names)
     fig_size = max(12, num_labels * 0.6)
@@ -169,10 +172,13 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
     """Compute per-label and overall precision, recall, and F1."""
     val_results = ctx.val_results
 
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes_str: list[str] = val_results.classes  # pyright: ignore[reportAssignmentType]
+
     # Convert the valresults to a pandas dataframe.
 
-    actual_annotations = pd.Categorical([val_results.classes[i] for i in val_results.gt])
-    predicted_annotations = pd.Categorical([val_results.classes[i] for i in val_results.est])
+    actual_annotations = pd.Categorical([classes_str[i] for i in val_results.gt])
+    predicted_annotations = pd.Categorical([classes_str[i] for i in val_results.est])
     annotations_df = pd.DataFrame(
         {
             "actual": actual_annotations,
@@ -183,9 +189,9 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
     # Precision, recall, F1: per label
 
     per_label_metrics = []
-    label_counts = Counter(val_results.classes[i] for i in val_results.gt)
+    label_counts = Counter(classes_str[i] for i in val_results.gt)
 
-    for label in val_results.classes:
+    for label in classes_str:
         precision = sklearn.metrics.precision_score(
             annotations_df["actual"],
             annotations_df["predicted"],
@@ -198,14 +204,14 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
             # or true positives and false negatives, either precision or
             # recall may have zero in the denominator of the calculation.
             # So we define what value we use in that situation.
-            zero_division=0.0,
+            zero_division=0.0,  # pyright: ignore[reportArgumentType]  # sklearn stubs type as str only
         )
         recall = sklearn.metrics.recall_score(
             annotations_df["actual"],
             annotations_df["predicted"],
             labels=[label],
             average="micro",
-            zero_division=0.0,
+            zero_division=0.0,  # pyright: ignore[reportArgumentType]  # sklearn stubs type as str only
         )
 
         if precision + recall == 0.0:
@@ -240,13 +246,13 @@ def compute_precision_recall_f1(ctx: MetricsContext) -> MetricGroupResult:
         actual_annotations,
         predicted_annotations,
         average="macro",
-        zero_division=0.0,
+        zero_division=0.0,  # pyright: ignore[reportArgumentType]  # sklearn stubs type as str only
     )
     recall = sklearn.metrics.recall_score(
         actual_annotations,
         predicted_annotations,
         average="macro",
-        zero_division=0.0,
+        zero_division=0.0,  # pyright: ignore[reportArgumentType]  # sklearn stubs type as str only
     )
     f1_score = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
 

--- a/mermaid_classifier/pyspacer/metrics/coordinator.py
+++ b/mermaid_classifier/pyspacer/metrics/coordinator.py
@@ -29,7 +29,6 @@ from mermaid_classifier.pyspacer.metrics.probability import compute_probability
 from mermaid_classifier.pyspacer.metrics.ranking import compute_ranking
 from mermaid_classifier.pyspacer.metrics.taxonomic import compute_taxonomic
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -49,14 +48,11 @@ class MetricsCoordinator:
         try:
             self.ctx.validate()
         except MetricsContextError:
-            logger.warning(
-                "Metrics skipped: context validation failed", exc_info=True)
+            logger.warning("Metrics skipped: context validation failed", exc_info=True)
             return
 
-        self.ctx.ba_to_top = build_ba_to_top(
-            self.ctx.val_results.classes, self.ctx.ba_library)
-        self.ctx.ba_paths = build_ba_paths(
-            self.ctx.val_results.classes, self.ctx.ba_library)
+        self.ctx.ba_to_top = build_ba_to_top(self.ctx.val_results.classes, self.ctx.ba_library)
+        self.ctx.ba_paths = build_ba_paths(self.ctx.val_results.classes, self.ctx.ba_library)
 
         if self.ctx.clf is not None and self.ctx.dataset is not None:
             self._precompute_probabilities()
@@ -66,8 +62,7 @@ class MetricsCoordinator:
                 result = func(self.ctx)
                 self._log_result(result)
             except Exception:
-                logger.warning(
-                    f"Metric group '{name}' failed", exc_info=True)
+                logger.warning(f"Metric group '{name}' failed", exc_info=True)
 
     def _precompute_probabilities(self):
         """Pre-compute the full probability matrix for val set.
@@ -79,9 +74,7 @@ class MetricsCoordinator:
         try:
             all_proba = []
             all_gt = []
-            for batch_x, batch_y in (
-                self.ctx.dataset.labels.val.load_data_in_batches()
-            ):
+            for batch_x, batch_y in self.ctx.dataset.labels.val.load_data_in_batches():
                 all_proba.append(self.ctx.clf.predict_proba(batch_x))
                 all_gt.extend(batch_y)
             self.ctx.val_proba = np.vstack(all_proba)
@@ -90,7 +83,8 @@ class MetricsCoordinator:
             logger.warning(
                 "Failed to pre-compute probability matrix; "
                 "probability and ranking metrics will be skipped",
-                exc_info=True)
+                exc_info=True,
+            )
 
     def _get_metric_groups(self):
         """Return ordered list of (name, func).
@@ -99,22 +93,22 @@ class MetricsCoordinator:
         """
         # Always available (only need ValResults + libraries):
         groups = [
-            ('confusion_matrices', compute_confusion_matrices),
-            ('precision_recall_f1', compute_precision_recall_f1),
-            ('balanced_accuracy_mcc', compute_balanced_accuracy_mcc),
-            ('taxonomic', compute_taxonomic),
-            ('calibration', compute_calibration),
+            ("confusion_matrices", compute_confusion_matrices),
+            ("precision_recall_f1", compute_precision_recall_f1),
+            ("balanced_accuracy_mcc", compute_balanced_accuracy_mcc),
+            ("taxonomic", compute_taxonomic),
+            ("calibration", compute_calibration),
         ]
 
         # Need dataset:
         if self.ctx.dataset is not None:
-            groups.append(('cover', compute_cover))
-            groups.append(('per_source', compute_per_source))
+            groups.append(("cover", compute_cover))
+            groups.append(("per_source", compute_per_source))
 
         # Need pre-computed probability matrix:
         if self.ctx.val_proba is not None:
-            groups.append(('probability', compute_probability))
-            groups.append(('ranking', compute_ranking))
+            groups.append(("probability", compute_probability))
+            groups.append(("ranking", compute_ranking))
 
         return groups
 
@@ -127,8 +121,8 @@ class MetricsCoordinator:
             # the insert and crashes on the metrics UNIQUE constraint.
             if scalar.value is None or np.isnan(scalar.value):
                 logger.warning(
-                    "Skipping metric %r with non-finite value %r",
-                    scalar.name, scalar.value)
+                    "Skipping metric %r with non-finite value %r", scalar.name, scalar.value
+                )
                 continue
             mlflow.log_metric(scalar.name, scalar.value)
 

--- a/mermaid_classifier/pyspacer/metrics/coordinator.py
+++ b/mermaid_classifier/pyspacer/metrics/coordinator.py
@@ -51,8 +51,10 @@ class MetricsCoordinator:
             logger.warning("Metrics skipped: context validation failed", exc_info=True)
             return
 
-        self.ctx.ba_to_top = build_ba_to_top(self.ctx.val_results.classes, self.ctx.ba_library)
-        self.ctx.ba_paths = build_ba_paths(self.ctx.val_results.classes, self.ctx.ba_library)
+        # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+        classes_str: list[str] = self.ctx.val_results.classes  # pyright: ignore[reportAssignmentType]
+        self.ctx.ba_to_top = build_ba_to_top(classes_str, self.ctx.ba_library)
+        self.ctx.ba_paths = build_ba_paths(classes_str, self.ctx.ba_library)
 
         if self.ctx.clf is not None and self.ctx.dataset is not None:
             self._precompute_probabilities()
@@ -72,6 +74,9 @@ class MetricsCoordinator:
         val_proba being None).
         """
         try:
+            assert (
+                self.ctx.dataset is not None
+            )  # guarded by caller: only called when dataset is not None
             all_proba = []
             all_gt = []
             for batch_x, batch_y in self.ctx.dataset.labels.val.load_data_in_batches():
@@ -119,7 +124,7 @@ class MetricsCoordinator:
             # associate them with the model, and its dedup-on-conflict filter
             # can't recognize an already-logged NaN (NaN != NaN), so it retries
             # the insert and crashes on the metrics UNIQUE constraint.
-            if scalar.value is None or np.isnan(scalar.value):
+            if np.isnan(scalar.value):
                 logger.warning(
                     "Skipping metric %r with non-finite value %r", scalar.name, scalar.value
                 )

--- a/mermaid_classifier/pyspacer/metrics/cover.py
+++ b/mermaid_classifier/pyspacer/metrics/cover.py
@@ -30,8 +30,7 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
     # Build per-image cover vectors from flat gt/est arrays.
     # evaluate_classifier iterates images in dict.keys() order,
     # with each image's points contiguous.
-    all_classes = sorted(set(
-        classes[i] for i in set(val_results.gt) | set(val_results.est)))
+    all_classes = sorted({classes[i] for i in set(val_results.gt) | set(val_results.est)})
     class_to_idx = {c: i for i, c in enumerate(all_classes)}
     n_classes = len(all_classes)
 
@@ -45,8 +44,8 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
 
     for img_idx, feature_loc in enumerate(dataset.labels.val.keys()):
         n_points = len(dataset.labels.val[feature_loc])
-        img_gts = gt_labels[offset:offset + n_points]
-        img_ests = est_labels[offset:offset + n_points]
+        img_gts = gt_labels[offset : offset + n_points]
+        img_ests = est_labels[offset : offset + n_points]
         offset += n_points
 
         for label in img_gts:
@@ -59,7 +58,7 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
     # Per-class metrics.
     errors = pred_cover_matrix - true_cover_matrix
     per_class_bias = errors.mean(axis=0)
-    per_class_rmse = np.sqrt((errors ** 2).mean(axis=0))
+    per_class_rmse = np.sqrt((errors**2).mean(axis=0))
     per_class_mae = np.abs(errors).mean(axis=0)
 
     per_class_r2 = np.full(n_classes, np.nan)
@@ -68,21 +67,20 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
         if true_col.std() > 0:
             per_class_r2[i] = r2_score(true_col, pred_cover_matrix[:, i])
 
-    cover_df = pd.DataFrame({
-        'bagf_id': all_classes,
-        'bagf_name': [
-            ctx.ba_library.bagf_id_to_name(c, ctx.gf_library)
-            for c in all_classes
-        ],
-        'mean_true_cover_pct': true_cover_matrix.mean(axis=0) * 100,
-        'bias_pct': per_class_bias * 100,
-        'rmse_pct': per_class_rmse * 100,
-        'mae_pct': per_class_mae * 100,
-        'r_squared': per_class_r2,
-    }).sort_values('mean_true_cover_pct', ascending=False)
+    cover_df = pd.DataFrame(
+        {
+            "bagf_id": all_classes,
+            "bagf_name": [ctx.ba_library.bagf_id_to_name(c, ctx.gf_library) for c in all_classes],
+            "mean_true_cover_pct": true_cover_matrix.mean(axis=0) * 100,
+            "bias_pct": per_class_bias * 100,
+            "rmse_pct": per_class_rmse * 100,
+            "mae_pct": per_class_mae * 100,
+            "r_squared": per_class_r2,
+        }
+    ).sort_values("mean_true_cover_pct", ascending=False)
 
     # Aggregate over classes with >0.5% mean cover.
-    significant = cover_df[cover_df['mean_true_cover_pct'] > 0.5]
+    significant = cover_df[cover_df["mean_true_cover_pct"] > 0.5]
 
     result = MetricGroupResult()
 
@@ -90,32 +88,34 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
         # r_squared is NaN for classes whose true cover is constant across
         # images; median over all-NaN warns "Mean of empty slice" via
         # pandas → numpy. Drop NaNs first; fall back to NaN if none remain.
-        r2_values = significant['r_squared'].dropna()
-        median_r2 = float(r2_values.median()) if len(r2_values) > 0 else float('nan')
-        result.scalars.extend([
-            ScalarMetric(
-                name='cover_mean_abs_bias_pct',
-                value=float(significant['bias_pct'].abs().mean())),
-            ScalarMetric(
-                name='cover_mean_rmse_pct',
-                value=float(significant['rmse_pct'].mean())),
-            ScalarMetric(
-                name='cover_mean_mae_pct',
-                value=float(significant['mae_pct'].mean())),
-            ScalarMetric(
-                name='cover_median_r_squared',
-                value=median_r2),
-        ])
+        r2_values = significant["r_squared"].dropna()
+        median_r2 = float(r2_values.median()) if len(r2_values) > 0 else float("nan")
+        result.scalars.extend(
+            [
+                ScalarMetric(
+                    name="cover_mean_abs_bias_pct",
+                    value=float(significant["bias_pct"].abs().mean()),
+                ),
+                ScalarMetric(
+                    name="cover_mean_rmse_pct", value=float(significant["rmse_pct"].mean())
+                ),
+                ScalarMetric(name="cover_mean_mae_pct", value=float(significant["mae_pct"].mean())),
+                ScalarMetric(name="cover_median_r_squared", value=median_r2),
+            ]
+        )
     else:
-        result.scalars.extend([
-            ScalarMetric(name='cover_mean_abs_bias_pct', value=0.0),
-            ScalarMetric(name='cover_mean_rmse_pct', value=0.0),
-            ScalarMetric(name='cover_mean_mae_pct', value=0.0),
-            ScalarMetric(name='cover_median_r_squared', value=0.0),
-        ])
+        result.scalars.extend(
+            [
+                ScalarMetric(name="cover_mean_abs_bias_pct", value=0.0),
+                ScalarMetric(name="cover_mean_rmse_pct", value=0.0),
+                ScalarMetric(name="cover_mean_mae_pct", value=0.0),
+                ScalarMetric(name="cover_median_r_squared", value=0.0),
+            ]
+        )
 
-    result.dataframes.append(DataFrameResult(
-        df=cover_df, artifact_path='cover/per_class_cover_metrics'))
+    result.dataframes.append(
+        DataFrameResult(df=cover_df, artifact_path="cover/per_class_cover_metrics")
+    )
 
     # Bias bar chart for top classes by mean cover.
     top_n = min(20, len(significant))
@@ -123,22 +123,18 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
         top_classes = significant.head(top_n)
         fig, ax = plt.subplots(figsize=(10, 6))
         try:
-            colors = [
-                '#d32f2f' if b > 0 else '#1976d2'
-                for b in top_classes['bias_pct']
-            ]
-            ax.barh(range(top_n), top_classes['bias_pct'], color=colors)
+            colors = ["#d32f2f" if b > 0 else "#1976d2" for b in top_classes["bias_pct"]]
+            ax.barh(range(top_n), top_classes["bias_pct"], color=colors)
             ax.set_yticks(range(top_n))
-            ax.set_yticklabels(top_classes['bagf_name'], fontsize=9)
-            ax.set_xlabel('Cover Bias (%)')
-            ax.set_title('Per-Class Cover Bias (top classes by mean cover)')
-            ax.axvline(x=0, color='black', linewidth=0.5)
+            ax.set_yticklabels(top_classes["bagf_name"], fontsize=9)
+            ax.set_xlabel("Cover Bias (%)")
+            ax.set_title("Per-Class Cover Bias (top classes by mean cover)")
+            ax.axvline(x=0, color="black", linewidth=0.5)
             ax.invert_yaxis()
             plt.tight_layout()
         except Exception:
             plt.close(fig)
             raise
-        result.figures.append(FigureResult(
-            fig=fig, artifact_path='cover/per_class_bias.png'))
+        result.figures.append(FigureResult(fig=fig, artifact_path="cover/per_class_bias.png"))
 
     return result

--- a/mermaid_classifier/pyspacer/metrics/cover.py
+++ b/mermaid_classifier/pyspacer/metrics/cover.py
@@ -25,17 +25,21 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
     """Compute per-image cover reconstruction metrics."""
     val_results = ctx.val_results
     dataset = ctx.dataset
+    assert dataset is not None  # compute_cover is only called when dataset is not None
     classes = val_results.classes
+
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes_str: list[str] = classes  # pyright: ignore[reportAssignmentType]
 
     # Build per-image cover vectors from flat gt/est arrays.
     # evaluate_classifier iterates images in dict.keys() order,
     # with each image's points contiguous.
-    all_classes = sorted({classes[i] for i in set(val_results.gt) | set(val_results.est)})
+    all_classes = sorted({classes_str[i] for i in set(val_results.gt) | set(val_results.est)})
     class_to_idx = {c: i for i, c in enumerate(all_classes)}
     n_classes = len(all_classes)
 
-    gt_labels = [classes[i] for i in val_results.gt]
-    est_labels = [classes[i] for i in val_results.est]
+    gt_labels = [classes_str[i] for i in val_results.gt]
+    est_labels = [classes_str[i] for i in val_results.est]
 
     n_images = len(list(dataset.labels.val.keys()))
     true_cover_matrix = np.zeros((n_images, n_classes))
@@ -70,7 +74,9 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
     cover_df = pd.DataFrame(
         {
             "bagf_id": all_classes,
-            "bagf_name": [ctx.ba_library.bagf_id_to_name(c, ctx.gf_library) for c in all_classes],
+            "bagf_name": [
+                ctx.ba_library.bagf_id_to_name(c, ctx.gf_library) for c in all_classes
+            ],  # all_classes is list[str]
             "mean_true_cover_pct": true_cover_matrix.mean(axis=0) * 100,
             "bias_pct": per_class_bias * 100,
             "rmse_pct": per_class_rmse * 100,
@@ -88,13 +94,13 @@ def compute_cover(ctx: MetricsContext) -> MetricGroupResult:
         # r_squared is NaN for classes whose true cover is constant across
         # images; median over all-NaN warns "Mean of empty slice" via
         # pandas → numpy. Drop NaNs first; fall back to NaN if none remain.
-        r2_values = significant["r_squared"].dropna()
+        r2_values = significant["r_squared"].dropna()  # pyright: ignore[reportAttributeAccessIssue]  # pandas Series, not ndarray
         median_r2 = float(r2_values.median()) if len(r2_values) > 0 else float("nan")
         result.scalars.extend(
             [
                 ScalarMetric(
                     name="cover_mean_abs_bias_pct",
-                    value=float(significant["bias_pct"].abs().mean()),
+                    value=float(significant["bias_pct"].abs().mean()),  # pyright: ignore[reportAttributeAccessIssue]  # pandas Series
                 ),
                 ScalarMetric(
                     name="cover_mean_rmse_pct", value=float(significant["rmse_pct"].mean())

--- a/mermaid_classifier/pyspacer/metrics/per_source.py
+++ b/mermaid_classifier/pyspacer/metrics/per_source.py
@@ -47,7 +47,7 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
     classes = val_results.classes
     result = MetricGroupResult()
 
-    feature_loc_to_source = getattr(dataset, 'feature_loc_to_source', None)
+    feature_loc_to_source = getattr(dataset, "feature_loc_to_source", None)
     if not feature_loc_to_source:
         # Older dataset instances (e.g. from re-evaluation paths) may not
         # have the per-image source map. Skip silently — coordinator logs
@@ -59,7 +59,7 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
     # used when building val_results.
     source_per_index: list[str] = []
     images_per_source: Counter = Counter()
-    for feature_loc in dataset.labels.val.keys():
+    for feature_loc in dataset.labels.val.keys():  # noqa: SIM118 — ImageLabels.keys() is not a plain dict; __iter__ differs
         site, project_id = feature_loc_to_source[feature_loc]
         source_key = f"{site}:{project_id}"
         n_points = len(dataset.labels.val[feature_loc])
@@ -93,7 +93,7 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
         if n == 0:
             continue
 
-        site, source_id = source_key.split(':', 1)
+        site, source_id = source_key.split(":", 1)
         accuracy = float(accuracy_score(gt_s, est_s))
         accuracies.append(accuracy)
 
@@ -107,25 +107,23 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
-                    message=(
-                        "A single label was found in 'y_true' and "
-                        "'y_pred'"
-                    ),
+                    message=("A single label was found in 'y_true' and 'y_pred'"),
                     category=UserWarning,
                 )
                 balanced_acc = float(balanced_accuracy_score(gt_s, est_s))
         except ValueError:
-            balanced_acc = float('nan')
+            balanced_acc = float("nan")
 
         prec, rec, f1, _ = precision_recall_fscore_support(
-            gt_s, est_s, average='macro', zero_division=0)
+            gt_s, est_s, average="macro", zero_division=0
+        )
 
         # Per-source cross-branch error rate, using the same definition
         # as taxonomic._compute_error_attribution (LCA == None ->
         # cross-branch).
         err_total = 0
         err_cross_branch = 0
-        for gt_idx, est_idx in zip(gt_s, est_s):
+        for gt_idx, est_idx in zip(gt_s, est_s, strict=False):
             if gt_idx == est_idx:
                 continue
             err_total += 1
@@ -133,45 +131,48 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
             ba_est, _ = split_ba_gf(classes[est_idx])
             if find_lca(ba_gt, ba_est, ba_paths) is None:
                 err_cross_branch += 1
-        cross_branch_rate = (
-            err_cross_branch / err_total if err_total > 0 else 0.0
-        )
+        cross_branch_rate = err_cross_branch / err_total if err_total > 0 else 0.0
 
-        rows.append({
-            'source_key': source_key,
-            'site': site,
-            'source_id': source_id,
-            'num_val_images': int(images_per_source[source_key]),
-            'num_val_annotations': n,
-            'accuracy': round(accuracy, 4),
-            'balanced_accuracy': round(balanced_acc, 4),
-            'f1_macro': round(float(f1), 4),
-            'precision_macro': round(float(prec), 4),
-            'recall_macro': round(float(rec), 4),
-            'cross_branch_error_rate': round(cross_branch_rate, 4),
-        })
+        rows.append(
+            {
+                "source_key": source_key,
+                "site": site,
+                "source_id": source_id,
+                "num_val_images": int(images_per_source[source_key]),
+                "num_val_annotations": n,
+                "accuracy": round(accuracy, 4),
+                "balanced_accuracy": round(balanced_acc, 4),
+                "f1_macro": round(float(f1), 4),
+                "precision_macro": round(float(prec), 4),
+                "recall_macro": round(float(rec), 4),
+                "cross_branch_error_rate": round(cross_branch_rate, 4),
+            }
+        )
 
     if not rows:
         return result
 
-    df = pd.DataFrame(rows).sort_values(
-        'num_val_annotations', ascending=False).reset_index(drop=True)
+    df = (
+        pd.DataFrame(rows)
+        .sort_values("num_val_annotations", ascending=False)
+        .reset_index(drop=True)
+    )
 
-    result.dataframes.append(DataFrameResult(
-        df=df, artifact_path='per_source/metrics'))
+    result.dataframes.append(DataFrameResult(df=df, artifact_path="per_source/metrics"))
 
-    result.scalars.extend([
-        ScalarMetric(name='per_source/n_sources', value=float(len(rows))),
-        ScalarMetric(
-            name='per_source/min_accuracy', value=float(min(accuracies))),
-        ScalarMetric(
-            name='per_source/max_accuracy', value=float(max(accuracies))),
-    ])
+    result.scalars.extend(
+        [
+            ScalarMetric(name="per_source/n_sources", value=float(len(rows))),
+            ScalarMetric(name="per_source/min_accuracy", value=float(min(accuracies))),
+            ScalarMetric(name="per_source/max_accuracy", value=float(max(accuracies))),
+        ]
+    )
 
     if len(df) > 1:
         fig = _plot_accuracy_by_source(df)
-        result.figures.append(FigureResult(
-            fig=fig, artifact_path='per_source/accuracy_by_source.png'))
+        result.figures.append(
+            FigureResult(fig=fig, artifact_path="per_source/accuracy_by_source.png")
+        )
 
     return result
 
@@ -187,28 +188,32 @@ def _plot_accuracy_by_source(df: pd.DataFrame):
     try:
         y = np.arange(n)
         bar_h = 0.4
-        ax.barh(y - bar_h / 2, df['accuracy'], bar_h,
-                color='#1976d2', label='Accuracy')
-        ax.barh(y + bar_h / 2, df['balanced_accuracy'], bar_h,
-                color='#d32f2f', label='Balanced Accuracy')
+        ax.barh(y - bar_h / 2, df["accuracy"], bar_h, color="#1976d2", label="Accuracy")
+        ax.barh(
+            y + bar_h / 2,
+            df["balanced_accuracy"],
+            bar_h,
+            color="#d32f2f",
+            label="Balanced Accuracy",
+        )
 
         ax.set_yticks(list(y))
-        ax.set_yticklabels(df['source_key'], fontsize=9)
+        ax.set_yticklabels(df["source_key"], fontsize=9)
         ax.set_xlim(0, 1.0)
-        ax.set_xlabel('Score')
-        ax.set_title(
-            'Per-Source Validation Accuracy '
-            '(sources ordered by val annotation count)')
+        ax.set_xlabel("Score")
+        ax.set_title("Per-Source Validation Accuracy (sources ordered by val annotation count)")
         ax.invert_yaxis()
-        ax.axvline(x=df['accuracy'].mean(), color='#1976d2',
-                   linestyle=':', linewidth=0.8, alpha=0.6)
-        ax.legend(loc='lower right', fontsize=9)
+        ax.axvline(
+            x=df["accuracy"].mean(), color="#1976d2", linestyle=":", linewidth=0.8, alpha=0.6
+        )
+        ax.legend(loc="lower right", fontsize=9)
 
         # Annotate each row with annotation count for context.
         x_max = 1.0
-        for i, count in enumerate(df['num_val_annotations']):
-            ax.text(x_max + 0.005, i, f'n={count:,}',
-                    va='center', ha='left', fontsize=8, color='#444')
+        for i, count in enumerate(df["num_val_annotations"]):
+            ax.text(
+                x_max + 0.005, i, f"n={count:,}", va="center", ha="left", fontsize=8, color="#444"
+            )
         ax.set_xlim(0, x_max + 0.12)
 
         plt.tight_layout()

--- a/mermaid_classifier/pyspacer/metrics/per_source.py
+++ b/mermaid_classifier/pyspacer/metrics/per_source.py
@@ -58,7 +58,8 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
     # n_points entries; iteration order matches what evaluate_classifier
     # used when building val_results.
     source_per_index: list[str] = []
-    images_per_source: Counter = Counter()
+    images_per_source: Counter[str] = Counter()
+    assert dataset is not None  # compute_per_source only called when dataset is not None
     for feature_loc in dataset.labels.val.keys():  # noqa: SIM118 — ImageLabels.keys() is not a plain dict; __iter__ differs
         site, project_id = feature_loc_to_source[feature_loc]
         source_key = f"{site}:{project_id}"
@@ -80,7 +81,9 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
     gt = np.array(val_results.gt)
     est = np.array(val_results.est)
 
-    ba_paths = ctx.ba_paths or build_ba_paths(classes, ctx.ba_library)
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes_str: list[str] = classes  # pyright: ignore[reportAssignmentType]
+    ba_paths = ctx.ba_paths or build_ba_paths(classes_str, ctx.ba_library)
 
     rows = []
     accuracies: list[float] = []
@@ -115,7 +118,10 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
             balanced_acc = float("nan")
 
         prec, rec, f1, _ = precision_recall_fscore_support(
-            gt_s, est_s, average="macro", zero_division=0
+            gt_s,
+            est_s,
+            average="macro",
+            zero_division=0,  # pyright: ignore[reportArgumentType]  # sklearn stubs type as str only
         )
 
         # Per-source cross-branch error rate, using the same definition
@@ -127,8 +133,8 @@ def compute_per_source(ctx: MetricsContext) -> MetricGroupResult:
             if gt_idx == est_idx:
                 continue
             err_total += 1
-            ba_gt, _ = split_ba_gf(classes[gt_idx])
-            ba_est, _ = split_ba_gf(classes[est_idx])
+            ba_gt, _ = split_ba_gf(classes_str[gt_idx])
+            ba_est, _ = split_ba_gf(classes_str[est_idx])
             if find_lca(ba_gt, ba_est, ba_paths) is None:
                 err_cross_branch += 1
         cross_branch_rate = err_cross_branch / err_total if err_total > 0 else 0.0
@@ -204,7 +210,7 @@ def _plot_accuracy_by_source(df: pd.DataFrame):
         ax.set_title("Per-Source Validation Accuracy (sources ordered by val annotation count)")
         ax.invert_yaxis()
         ax.axvline(
-            x=df["accuracy"].mean(), color="#1976d2", linestyle=":", linewidth=0.8, alpha=0.6
+            x=float(df["accuracy"].mean()), color="#1976d2", linestyle=":", linewidth=0.8, alpha=0.6
         )
         ax.legend(loc="lower right", fontsize=9)
 

--- a/mermaid_classifier/pyspacer/metrics/probability.py
+++ b/mermaid_classifier/pyspacer/metrics/probability.py
@@ -27,6 +27,9 @@ from mermaid_classifier.pyspacer.metrics._taxonomy_helpers import (
 
 def compute_probability(ctx: MetricsContext) -> MetricGroupResult:
     """Compute probability-based metrics: log loss overall + per-category."""
+    # Both are pre-computed by coordinator; it only calls this when val_proba is not None.
+    assert ctx.val_proba is not None, "compute_probability requires val_proba"
+    assert ctx.val_gt_labels is not None, "compute_probability requires val_gt_labels"
     val_proba = ctx.val_proba
     val_gt_labels = ctx.val_gt_labels
     classes = ctx.clf.classes_
@@ -74,7 +77,7 @@ def compute_probability(ctx: MetricsContext) -> MetricGroupResult:
         DataFrameResult(
             df=pd.DataFrame(cat_rows)
             if cat_rows
-            else pd.DataFrame(columns=["category", "log_loss", "n_samples"]),
+            else pd.DataFrame(columns=["category", "log_loss", "n_samples"]),  # pyright: ignore[reportArgumentType]  # pandas stubs type columns as Axes|None
             artifact_path="probability/per_category_log_loss",
         )
     )

--- a/mermaid_classifier/pyspacer/metrics/probability.py
+++ b/mermaid_classifier/pyspacer/metrics/probability.py
@@ -35,7 +35,7 @@ def compute_probability(ctx: MetricsContext) -> MetricGroupResult:
 
     # Overall log loss.
     overall_ll = sklearn_log_loss(val_gt_labels, val_proba, labels=classes)
-    result.scalars.append(ScalarMetric(name='log_loss', value=overall_ll))
+    result.scalars.append(ScalarMetric(name="log_loss", value=overall_ll))
 
     # Per-sample log loss: -log(p_true).
     classes_list = list(classes)
@@ -49,51 +49,69 @@ def compute_probability(ctx: MetricsContext) -> MetricGroupResult:
     ba_to_top = ctx.ba_to_top or build_ba_to_top(classes_list, ctx.ba_library)
 
     groups = group_by_top_level(
-        list(range(len(val_gt_labels))), gt_col_indices, classes_list,
-        ba_to_top, ctx.ba_library, min_samples=30)
+        list(range(len(val_gt_labels))),
+        gt_col_indices,
+        classes_list,
+        ba_to_top,
+        ctx.ba_library,
+        min_samples=30,
+    )
 
     cat_rows = []
     for group in groups:
-        idx = group['indices']
+        idx = group["indices"]
         cat_losses = sample_losses[idx]
-        cat_rows.append({
-            'category': group['name'],
-            'log_loss': float(np.mean(cat_losses)),
-            'n_samples': group['n_samples'],
-        })
+        cat_rows.append(
+            {
+                "category": group["name"],
+                "log_loss": float(np.mean(cat_losses)),
+                "n_samples": group["n_samples"],
+            }
+        )
 
-    cat_rows.sort(key=lambda r: r['log_loss'], reverse=True)
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(cat_rows) if cat_rows else pd.DataFrame(
-            columns=['category', 'log_loss', 'n_samples']),
-        artifact_path='probability/per_category_log_loss',
-    ))
+    cat_rows.sort(key=lambda r: r["log_loss"], reverse=True)
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(cat_rows)
+            if cat_rows
+            else pd.DataFrame(columns=["category", "log_loss", "n_samples"]),
+            artifact_path="probability/per_category_log_loss",
+        )
+    )
 
     # Per-category log loss figure.
     if cat_rows:
-        fig, ax = plt.subplots(
-            figsize=(10, max(4, len(cat_rows) * 0.45)))
+        fig, ax = plt.subplots(figsize=(10, max(4, len(cat_rows) * 0.45)))
         try:
-            names = [r['category'] for r in cat_rows]
-            losses = [r['log_loss'] for r in cat_rows]
-            counts = [r['n_samples'] for r in cat_rows]
+            names = [r["category"] for r in cat_rows]
+            losses = [r["log_loss"] for r in cat_rows]
+            counts = [r["n_samples"] for r in cat_rows]
 
             y_pos = range(len(names))
-            bars = ax.barh(y_pos, losses, color='#d32f2f',
-                           edgecolor='white', alpha=0.85)
+            bars = ax.barh(y_pos, losses, color="#d32f2f", edgecolor="white", alpha=0.85)
             ax.set_yticks(list(y_pos))
             ax.set_yticklabels(names)
             ax.invert_yaxis()
-            ax.set_xlabel('Log Loss (nats)')
-            ax.set_title('Log Loss by Top-Level Category')
-            ax.axvline(overall_ll, color='#1976d2', linestyle='--',
-                       linewidth=1.5, label=f'Overall: {overall_ll:.3f}')
-            ax.legend(loc='lower right')
+            ax.set_xlabel("Log Loss (nats)")
+            ax.set_title("Log Loss by Top-Level Category")
+            ax.axvline(
+                overall_ll,
+                color="#1976d2",
+                linestyle="--",
+                linewidth=1.5,
+                label=f"Overall: {overall_ll:.3f}",
+            )
+            ax.legend(loc="lower right")
 
-            for bar, n in zip(bars, counts):
-                ax.text(bar.get_width() + 0.02,
-                        bar.get_y() + bar.get_height() / 2,
-                        f'n={n:,}', va='center', fontsize=9, color='#444444')
+            for bar, n in zip(bars, counts, strict=False):
+                ax.text(
+                    bar.get_width() + 0.02,
+                    bar.get_y() + bar.get_height() / 2,
+                    f"n={n:,}",
+                    va="center",
+                    fontsize=9,
+                    color="#444444",
+                )
 
             ax.set_xlim(0, max(losses) * 1.25 if losses else 1)
             plt.tight_layout()
@@ -101,7 +119,8 @@ def compute_probability(ctx: MetricsContext) -> MetricGroupResult:
             plt.close(fig)
             raise
 
-        result.figures.append(FigureResult(
-            fig=fig, artifact_path='probability/per_category_log_loss.png'))
+        result.figures.append(
+            FigureResult(fig=fig, artifact_path="probability/per_category_log_loss.png")
+        )
 
     return result

--- a/mermaid_classifier/pyspacer/metrics/ranking.py
+++ b/mermaid_classifier/pyspacer/metrics/ranking.py
@@ -47,8 +47,7 @@ def _compute_topk_mrr(proba, gt_labels, classes, ks=(1, 3, 5, 10)):
 
     topk = {k: float(np.mean(ranks <= k)) for k in ks}
     mrr = float(np.mean(1.0 / ranks))
-    return {'topk': topk, 'mrr': mrr, 'ranks': ranks,
-            'sorted_indices': sorted_indices}
+    return {"topk": topk, "mrr": mrr, "ranks": ranks, "sorted_indices": sorted_indices}
 
 
 def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
@@ -65,9 +64,8 @@ def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
 
     # Overall scalars.
     for k in ks:
-        result.scalars.append(ScalarMetric(
-            name=f'top_{k}_accuracy', value=ranking['topk'][k]))
-    result.scalars.append(ScalarMetric(name='mrr', value=ranking['mrr']))
+        result.scalars.append(ScalarMetric(name=f"top_{k}_accuracy", value=ranking["topk"][k]))
+    result.scalars.append(ScalarMetric(name="mrr", value=ranking["mrr"]))
 
     # Per-category top-K.
     ba_to_top = ctx.ba_to_top or build_ba_to_top(classes, ba_library)
@@ -76,64 +74,77 @@ def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
     gt_col_indices = [class_to_idx[g] for g in val_gt_labels]
 
     groups = group_by_top_level(
-        list(range(len(val_gt_labels))), gt_col_indices, classes,
-        ba_to_top, ba_library, min_samples=30)
+        list(range(len(val_gt_labels))),
+        gt_col_indices,
+        classes,
+        ba_to_top,
+        ba_library,
+        min_samples=30,
+    )
 
-    ranks = ranking['ranks']
+    ranks = ranking["ranks"]
     cat_results = []
     for group in groups:
-        idx = group['indices']
+        idx = group["indices"]
         ranks_arr = ranks[idx]
         row = {
-            'category': group['name'],
-            'n_samples': group['n_samples'],
-            'mrr': float(np.mean(1.0 / ranks_arr)),
+            "category": group["name"],
+            "n_samples": group["n_samples"],
+            "mrr": float(np.mean(1.0 / ranks_arr)),
         }
         for k in ks:
-            row[f'top_{k}'] = float(np.mean(ranks_arr <= k))
+            row[f"top_{k}"] = float(np.mean(ranks_arr <= k))
         cat_results.append(row)
 
-    cat_results.sort(key=lambda r: r['top_1'], reverse=True)
+    cat_results.sort(key=lambda r: r["top_1"], reverse=True)
 
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(cat_results) if cat_results else pd.DataFrame(
-            columns=['category', 'top_1', 'top_3', 'top_5', 'top_10',
-                     'mrr', 'n_samples']),
-        artifact_path='ranking/per_category_topk',
-    ))
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(cat_results)
+            if cat_results
+            else pd.DataFrame(
+                columns=["category", "top_1", "top_3", "top_5", "top_10", "mrr", "n_samples"]
+            ),
+            artifact_path="ranking/per_category_topk",
+        )
+    )
 
     # Per-category top-K figure.
     if cat_results:
-        fig, ax = plt.subplots(
-            figsize=(12, max(4, len(cat_results) * 0.5)))
+        fig, ax = plt.subplots(figsize=(12, max(4, len(cat_results) * 0.5)))
         try:
             bar_height = 0.18
             y_pos = np.arange(len(cat_results))
-            colors = {1: '#1976d2', 3: '#388e3c', 5: '#f57c00', 10: '#7b1fa2'}
+            colors = {1: "#1976d2", 3: "#388e3c", 5: "#f57c00", 10: "#7b1fa2"}
 
             for i, k in enumerate(ks):
-                values = [r[f'top_{k}'] for r in cat_results]
-                ax.barh(y_pos + i * bar_height, values, bar_height,
-                        label=f'Top-{k}', color=colors[k], alpha=0.85)
+                values = [r[f"top_{k}"] for r in cat_results]
+                ax.barh(
+                    y_pos + i * bar_height,
+                    values,
+                    bar_height,
+                    label=f"Top-{k}",
+                    color=colors[k],
+                    alpha=0.85,
+                )
 
             ax.set_yticks(y_pos + bar_height * 1.5)
-            ax.set_yticklabels([r['category'] for r in cat_results])
+            ax.set_yticklabels([r["category"] for r in cat_results])
             ax.invert_yaxis()
-            ax.set_xlabel('Accuracy')
+            ax.set_xlabel("Accuracy")
             ax.set_xlim(0, 1.05)
-            ax.set_title('Top-K Accuracy by Top-Level Category')
-            ax.legend(loc='lower right')
+            ax.set_title("Top-K Accuracy by Top-Level Category")
+            ax.legend(loc="lower right")
             plt.tight_layout()
         except Exception:
             plt.close(fig)
             raise
 
-        result.figures.append(FigureResult(
-            fig=fig, artifact_path='ranking/per_category_topk.png'))
+        result.figures.append(FigureResult(fig=fig, artifact_path="ranking/per_category_topk.png"))
 
     # Hierarchical top-K with taxonomic similarity.
     ba_paths = ctx.ba_paths or build_ba_paths(classes, ba_library)
-    sorted_indices = ranking['sorted_indices']
+    sorted_indices = ranking["sorted_indices"]
     class_ba_ids = [split_ba_gf(c)[0] for c in classes]
     gt_ba_ids = [split_ba_gf(g)[0] for g in val_gt_labels]
 
@@ -148,32 +159,34 @@ def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
         gt_ba = gt_ba_ids[i]
         top_indices = sorted_indices[i, :max_k]
         sims = [
-            taxonomic_similarity(gt_ba, class_ba_ids[j], ba_paths, ba_library)
-            for j in top_indices
+            taxonomic_similarity(gt_ba, class_ba_ids[j], ba_paths, ba_library) for j in top_indices
         ]
         for k in hier_ks:
             max_sim_at_k[k][i] = max(sims[:k])
 
-    result.scalars.append(ScalarMetric(
-        name='hierarchical_top_5_mean_similarity',
-        value=float(np.mean(max_sim_at_k[5]))))
+    result.scalars.append(
+        ScalarMetric(
+            name="hierarchical_top_5_mean_similarity", value=float(np.mean(max_sim_at_k[5]))
+        )
+    )
 
     # Hierarchical top-K DataFrame.
     hier_rows = []
     for k in hier_ks:
         row = {
-            'k': k,
-            'mean_max_similarity': float(np.mean(max_sim_at_k[k])),
+            "k": k,
+            "mean_max_similarity": float(np.mean(max_sim_at_k[k])),
         }
         for t in thresholds:
-            label = {1.0: 'hit_exact', 0.75: 'hit_sibling_0.75',
-                     0.5: 'hit_family_0.5'}[t]
+            label = {1.0: "hit_exact", 0.75: "hit_sibling_0.75", 0.5: "hit_family_0.5"}[t]
             row[label] = float(np.mean(max_sim_at_k[k] >= t))
         hier_rows.append(row)
 
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(hier_rows),
-        artifact_path='ranking/hierarchical_topk',
-    ))
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(hier_rows),
+            artifact_path="ranking/hierarchical_topk",
+        )
+    )
 
     return result

--- a/mermaid_classifier/pyspacer/metrics/ranking.py
+++ b/mermaid_classifier/pyspacer/metrics/ranking.py
@@ -9,9 +9,12 @@ Metrics:
 Requires val_proba, val_gt_labels, and clf in MetricsContext.
 """
 
+from typing import TypedDict
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 
 from mermaid_classifier.common.benthic_attributes import split_ba_gf
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
@@ -29,7 +32,19 @@ from mermaid_classifier.pyspacer.metrics._taxonomy_helpers import (
 )
 
 
-def _compute_topk_mrr(proba, gt_labels, classes, ks=(1, 3, 5, 10)):
+class _TopKMRRResult(TypedDict):
+    topk: dict[int, float]
+    mrr: float
+    ranks: NDArray[np.intp]
+    sorted_indices: NDArray[np.intp]
+
+
+def _compute_topk_mrr(
+    proba: np.ndarray,
+    gt_labels: list[str],
+    classes: list[str],
+    ks: tuple[int, ...] = (1, 3, 5, 10),
+) -> _TopKMRRResult:
     """Compute top-K accuracy and MRR from a probability matrix.
 
     Returns dict with 'topk' (dict k->accuracy), 'mrr' (float),
@@ -40,10 +55,10 @@ def _compute_topk_mrr(proba, gt_labels, classes, ks=(1, 3, 5, 10)):
     sorted_indices = np.argsort(-proba, axis=1)
 
     n = len(gt_labels)
-    ranks = np.zeros(n, dtype=int)
+    ranks: NDArray[np.intp] = np.zeros(n, dtype=np.intp)
     for i, gt_label in enumerate(gt_labels):
         gt_idx = class_to_idx[gt_label]
-        ranks[i] = np.where(sorted_indices[i] == gt_idx)[0][0] + 1
+        ranks[i] = int(np.where(sorted_indices[i] == gt_idx)[0][0]) + 1
 
     topk = {k: float(np.mean(ranks <= k)) for k in ks}
     mrr = float(np.mean(1.0 / ranks))
@@ -52,9 +67,12 @@ def _compute_topk_mrr(proba, gt_labels, classes, ks=(1, 3, 5, 10)):
 
 def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
     """Compute ranking metrics: top-K, MRR, per-category, hierarchical."""
-    val_proba = ctx.val_proba
-    val_gt_labels = ctx.val_gt_labels
-    classes = list(ctx.clf.classes_)
+    # Both are pre-computed by coordinator; it only calls this when val_proba is not None.
+    assert ctx.val_proba is not None, "compute_ranking requires val_proba"
+    assert ctx.val_gt_labels is not None, "compute_ranking requires val_gt_labels"
+    val_proba: np.ndarray = ctx.val_proba
+    val_gt_labels: list[str] = ctx.val_gt_labels  # pyright: ignore[reportAssignmentType]  # MERMAID always uses str labels
+    classes: list[str] = list(ctx.clf.classes_)  # pyright: ignore[reportAssignmentType]  # MERMAID always uses str labels
     ba_library = ctx.ba_library
 
     result = MetricGroupResult()
@@ -103,7 +121,7 @@ def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
             df=pd.DataFrame(cat_results)
             if cat_results
             else pd.DataFrame(
-                columns=["category", "top_1", "top_3", "top_5", "top_10", "mrr", "n_samples"]
+                columns=["category", "top_1", "top_3", "top_5", "top_10", "mrr", "n_samples"]  # pyright: ignore[reportArgumentType]  # pandas stubs type columns as Axes|None
             ),
             artifact_path="ranking/per_category_topk",
         )
@@ -159,7 +177,8 @@ def compute_ranking(ctx: MetricsContext) -> MetricGroupResult:
         gt_ba = gt_ba_ids[i]
         top_indices = sorted_indices[i, :max_k]
         sims = [
-            taxonomic_similarity(gt_ba, class_ba_ids[j], ba_paths, ba_library) for j in top_indices
+            taxonomic_similarity(gt_ba, class_ba_ids[int(j)], ba_paths, ba_library)
+            for j in top_indices
         ]
         for k in hier_ks:
             max_sim_at_k[k][i] = max(sims[:k])

--- a/mermaid_classifier/pyspacer/metrics/taxonomic.py
+++ b/mermaid_classifier/pyspacer/metrics/taxonomic.py
@@ -64,7 +64,7 @@ def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
     lca_error_counts: Counter = Counter()
     total_errors = 0
 
-    for gt_idx, est_idx in zip(val_results.gt, val_results.est):
+    for gt_idx, est_idx in zip(val_results.gt, val_results.est, strict=False):
         if gt_idx == est_idx:
             continue
         total_errors += 1
@@ -76,17 +76,27 @@ def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
     result = MetricGroupResult()
 
     if total_errors == 0:
-        result.scalars.extend([
-            ScalarMetric(name='cross_branch_error_rate', value=0.0),
-            ScalarMetric(name='within_branch_error_rate', value=0.0),
-        ])
-        result.dataframes.append(DataFrameResult(
-            df=pd.DataFrame(columns=[
-                'lca_node', 'lca_name', 'branch', 'error_count',
-                'pct_of_errors', 'classes_in_subtree',
-            ]),
-            artifact_path='taxonomic/error_attribution',
-        ))
+        result.scalars.extend(
+            [
+                ScalarMetric(name="cross_branch_error_rate", value=0.0),
+                ScalarMetric(name="within_branch_error_rate", value=0.0),
+            ]
+        )
+        result.dataframes.append(
+            DataFrameResult(
+                df=pd.DataFrame(
+                    columns=[
+                        "lca_node",
+                        "lca_name",
+                        "branch",
+                        "error_count",
+                        "pct_of_errors",
+                        "classes_in_subtree",
+                    ]
+                ),
+                artifact_path="taxonomic/error_attribution",
+            )
+        )
         return result
 
     # Aggregate by branch.
@@ -106,76 +116,78 @@ def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
         if lca_node is None:
             continue
         descendants = ba_library.get_descendants(lca_node)
-        desc_ids = {d['id'] for d in descendants} | {lca_node}
+        desc_ids = {d["id"] for d in descendants} | {lca_node}
         lca_class_counts[lca_node] = len(desc_ids & all_ba_ids)
 
     cross_branch_count = lca_error_counts.get(None, 0)
     within_branch_count = total_errors - cross_branch_count
 
-    result.scalars.extend([
-        ScalarMetric(
-            name='cross_branch_error_rate',
-            value=cross_branch_count / total_errors),
-        ScalarMetric(
-            name='within_branch_error_rate',
-            value=within_branch_count / total_errors),
-    ])
+    result.scalars.extend(
+        [
+            ScalarMetric(name="cross_branch_error_rate", value=cross_branch_count / total_errors),
+            ScalarMetric(name="within_branch_error_rate", value=within_branch_count / total_errors),
+        ]
+    )
 
     # Build DataFrame.
     rows = []
     for node, count in lca_error_counts.most_common():
         if node is None:
-            rows.append({
-                'lca_node': '(cross-branch)',
-                'lca_name': '(cross-branch)',
-                'branch': '',
-                'error_count': count,
-                'pct_of_errors': count / total_errors * 100,
-                'classes_in_subtree': 0,
-            })
+            rows.append(
+                {
+                    "lca_node": "(cross-branch)",
+                    "lca_name": "(cross-branch)",
+                    "branch": "",
+                    "error_count": count,
+                    "pct_of_errors": count / total_errors * 100,
+                    "classes_in_subtree": 0,
+                }
+            )
         else:
-            rows.append({
-                'lca_node': node,
-                'lca_name': ba_library.id_to_name(node),
-                'branch': ba_library.id_to_name(get_branch(node)),
-                'error_count': count,
-                'pct_of_errors': count / total_errors * 100,
-                'classes_in_subtree': lca_class_counts.get(node, 0),
-            })
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(rows),
-        artifact_path='taxonomic/error_attribution',
-    ))
+            rows.append(
+                {
+                    "lca_node": node,
+                    "lca_name": ba_library.id_to_name(node),
+                    "branch": ba_library.id_to_name(get_branch(node)),
+                    "error_count": count,
+                    "pct_of_errors": count / total_errors * 100,
+                    "classes_in_subtree": lca_class_counts.get(node, 0),
+                }
+            )
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(rows),
+            artifact_path="taxonomic/error_attribution",
+        )
+    )
 
     # Two-panel figure.
     fig = _plot_error_attribution(
-        lca_error_counts, branch_errors, total_errors,
-        cross_branch_count, ba_library, get_branch)
-    result.figures.append(FigureResult(
-        fig=fig, artifact_path='taxonomic/error_attribution.png'))
+        lca_error_counts, branch_errors, total_errors, cross_branch_count, ba_library, get_branch
+    )
+    result.figures.append(FigureResult(fig=fig, artifact_path="taxonomic/error_attribution.png"))
 
     return result
 
 
 def _plot_error_attribution(
-    lca_error_counts, branch_errors, total_errors,
-    cross_branch_count, ba_library, get_branch,
+    lca_error_counts,
+    branch_errors,
+    total_errors,
+    cross_branch_count,
+    ba_library,
+    get_branch,
 ):
     """Build the two-panel error attribution figure."""
-    cmap = matplotlib.colormaps['tab20']
+    cmap = matplotlib.colormaps["tab20"]
 
-    branch_ids_sorted = sorted(
-        branch_errors.keys(),
-        key=lambda b: branch_errors[b], reverse=True)
+    branch_ids_sorted = sorted(branch_errors.keys(), key=lambda b: branch_errors[b], reverse=True)
     branch_color = {
-        bid: cmap(i / max(len(branch_ids_sorted), 1))
-        for i, bid in enumerate(branch_ids_sorted)
+        bid: cmap(i / max(len(branch_ids_sorted), 1)) for i, bid in enumerate(branch_ids_sorted)
     }
 
-    fig, axes = plt.subplots(
-        2, 1, figsize=(12, 9),
-        gridspec_kw={'height_ratios': [1, 4]})
-    fig.suptitle('Error Attribution by Taxonomy Node', fontsize=14, y=0.98)
+    fig, axes = plt.subplots(2, 1, figsize=(12, 9), gridspec_kw={"height_ratios": [1, 4]})
+    fig.suptitle("Error Attribution by Taxonomy Node", fontsize=14, y=0.98)
 
     # Panel 1: Summary stacked horizontal bar.
     ax_bar = axes[0]
@@ -185,32 +197,48 @@ def _plot_error_attribution(
     for bid in branch_ids_sorted:
         frac = branch_errors[bid] / total_errors
         color = branch_color[bid]
-        bar = ax_bar.barh(0, frac, left=left, color=color, edgecolor='white')
+        bar = ax_bar.barh(0, frac, left=left, color=color, edgecolor="white")
         if frac > 0.04:
-            ax_bar.text(left + frac / 2, 0, f'{frac:.0%}',
-                        ha='center', va='center', fontsize=10,
-                        fontweight='bold')
+            ax_bar.text(
+                left + frac / 2,
+                0,
+                f"{frac:.0%}",
+                ha="center",
+                va="center",
+                fontsize=10,
+                fontweight="bold",
+            )
         legend_handles.append(bar[0])
-        legend_labels.append(
-            f"{ba_library.id_to_name(bid)} ({branch_errors[bid]:,})")
+        legend_labels.append(f"{ba_library.id_to_name(bid)} ({branch_errors[bid]:,})")
         left += frac
 
     cross_frac = cross_branch_count / total_errors
-    bar = ax_bar.barh(0, cross_frac, left=left, color='#999999',
-                      edgecolor='white')
+    bar = ax_bar.barh(0, cross_frac, left=left, color="#999999", edgecolor="white")
     if cross_frac > 0.04:
-        ax_bar.text(left + cross_frac / 2, 0, f'{cross_frac:.0%}',
-                    ha='center', va='center', fontsize=10, fontweight='bold')
+        ax_bar.text(
+            left + cross_frac / 2,
+            0,
+            f"{cross_frac:.0%}",
+            ha="center",
+            va="center",
+            fontsize=10,
+            fontweight="bold",
+        )
     legend_handles.append(bar[0])
     legend_labels.append(f"Cross-branch ({cross_branch_count:,})")
 
     ax_bar.set_xlim(0, 1)
     ax_bar.set_yticks([])
-    ax_bar.set_xlabel('Fraction of all errors')
+    ax_bar.set_xlabel("Fraction of all errors")
     ax_bar.legend(
-        legend_handles, legend_labels,
-        loc='lower center', bbox_to_anchor=(0.5, 1.05),
-        ncol=min(len(legend_labels), 4), fontsize=9, frameon=False)
+        legend_handles,
+        legend_labels,
+        loc="lower center",
+        bbox_to_anchor=(0.5, 1.05),
+        ncol=min(len(legend_labels), 4),
+        fontsize=9,
+        frameon=False,
+    )
 
     # Panel 2: Top 15 LCA nodes horizontal bar chart.
     ax_detail = axes[1]
@@ -240,8 +268,8 @@ def _plot_error_attribution(
     for node, count in display_entries:
         bar_counts.append(count)
         if node is None:
-            y_labels.append('Cross-branch')
-            bar_colors.append('#999999')
+            y_labels.append("Cross-branch")
+            bar_colors.append("#999999")
         else:
             name = ba_library.id_to_name(node)
             branch_id = get_branch(node)
@@ -250,22 +278,24 @@ def _plot_error_attribution(
                 y_labels.append(name)
             else:
                 y_labels.append(f"{name}  ({branch_name})")
-            bar_colors.append(branch_color.get(branch_id, '#cccccc'))
+            bar_colors.append(branch_color.get(branch_id, "#cccccc"))
 
     y_pos = range(len(display_entries))
-    bars = ax_detail.barh(y_pos, bar_counts, color=bar_colors,
-                          edgecolor='white')
+    bars = ax_detail.barh(y_pos, bar_counts, color=bar_colors, edgecolor="white")
     ax_detail.set_yticks(list(y_pos))
     ax_detail.set_yticklabels(y_labels, fontsize=9)
-    ax_detail.set_xlabel('Number of errors')
+    ax_detail.set_xlabel("Number of errors")
 
-    for bar, count in zip(bars, bar_counts):
+    for bar, count in zip(bars, bar_counts, strict=False):
         pct = count / total_errors * 100
         ax_detail.text(
             bar.get_width() + max(bar_counts) * 0.01,
             bar.get_y() + bar.get_height() / 2,
-            f'{count:,} ({pct:.1f}%)',
-            ha='left', va='center', fontsize=9)
+            f"{count:,} ({pct:.1f}%)",
+            ha="left",
+            va="center",
+            fontsize=9,
+        )
 
     ax_detail.set_xlim(0, max(bar_counts) * 1.2)
 
@@ -283,7 +313,7 @@ def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
 
     top_gt = []
     top_est = []
-    for gt_idx, est_idx in zip(val_results.gt, val_results.est):
+    for gt_idx, est_idx in zip(val_results.gt, val_results.est, strict=False):
         gt_ba, _ = split_ba_gf(classes[gt_idx])
         est_ba, _ = split_ba_gf(classes[est_idx])
         top_gt.append(ba_to_top[gt_ba])
@@ -299,7 +329,7 @@ def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
 
     n_top = len(top_ids_by_freq)
     cm = np.zeros((n_top, n_top), dtype=int)
-    for g, e in zip(top_gt, top_est):
+    for g, e in zip(top_gt, top_est, strict=False):
         cm[id_to_idx[g], id_to_idx[e]] += 1
 
     row_sums = cm.sum(axis=1, keepdims=True)
@@ -313,42 +343,48 @@ def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
     fig, ax = plt.subplots(figsize=(fig_size, fig_size))
     try:
         disp = sklearn.metrics.ConfusionMatrixDisplay(
-            confusion_matrix=cm_pct, display_labels=top_names)
-        disp.plot(ax=ax, cmap='Blues', values_format='d', colorbar=False)
-        ax.set_title('Top-Level Confusion (row-normalized %)', pad=20)
-        ax.xaxis.set_label_position('top')
-        ax.xaxis.set_ticks_position('top')
-        ax.set_xlabel('Predicted')
-        ax.set_ylabel('True')
+            confusion_matrix=cm_pct, display_labels=top_names
+        )
+        disp.plot(ax=ax, cmap="Blues", values_format="d", colorbar=False)
+        ax.set_title("Top-Level Confusion (row-normalized %)", pad=20)
+        ax.xaxis.set_label_position("top")
+        ax.xaxis.set_ticks_position("top")
+        ax.set_xlabel("Predicted")
+        ax.set_ylabel("True")
         label_fs = max(8, min(12, 150 / n_top))
-        plt.setp(ax.get_xticklabels(), rotation=45, ha='left',
-                 rotation_mode='anchor', fontsize=label_fs)
+        plt.setp(
+            ax.get_xticklabels(), rotation=45, ha="left", rotation_mode="anchor", fontsize=label_fs
+        )
         plt.setp(ax.get_yticklabels(), fontsize=label_fs)
         plt.tight_layout()
     except Exception:
         plt.close(fig)
         raise
 
-    result.figures.append(FigureResult(
-        fig=fig, artifact_path='taxonomic/top_level_confusion.png'))
+    result.figures.append(FigureResult(fig=fig, artifact_path="taxonomic/top_level_confusion.png"))
 
     # DataFrame of off-diagonal confusions.
     confusions = []
     for i in range(n_top):
         for j in range(n_top):
             if i != j and cm[i, j] > 0:
-                confusions.append({
-                    'true': top_names[i],
-                    'predicted': top_names[j],
-                    'row_normalized_pct': int(cm_pct[i, j]),
-                    'sample_count': int(cm[i, j]),
-                })
-    confusions.sort(key=lambda x: x['row_normalized_pct'], reverse=True)
-    result.dataframes.append(DataFrameResult(
-        df=pd.DataFrame(confusions) if confusions else pd.DataFrame(
-            columns=['true', 'predicted', 'row_normalized_pct', 'sample_count']),
-        artifact_path='taxonomic/top_level_confusions',
-    ))
+                confusions.append(
+                    {
+                        "true": top_names[i],
+                        "predicted": top_names[j],
+                        "row_normalized_pct": int(cm_pct[i, j]),
+                        "sample_count": int(cm[i, j]),
+                    }
+                )
+    confusions.sort(key=lambda x: x["row_normalized_pct"], reverse=True)
+    result.dataframes.append(
+        DataFrameResult(
+            df=pd.DataFrame(confusions)
+            if confusions
+            else pd.DataFrame(columns=["true", "predicted", "row_normalized_pct", "sample_count"]),
+            artifact_path="taxonomic/top_level_confusions",
+        )
+    )
 
     return result
 
@@ -363,12 +399,12 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     pred_gf_names = []
     ba_match_flags = []
 
-    for gt_idx, est_idx in zip(val_results.gt, val_results.est):
+    for gt_idx, est_idx in zip(val_results.gt, val_results.est, strict=False):
         gt_ba, gt_gf = split_ba_gf(classes[gt_idx])
         est_ba, est_gf = split_ba_gf(classes[est_idx])
 
-        gt_gf_name = gf_library.id_to_name(gt_gf) if gt_gf != '' else '(no GF)'
-        est_gf_name = gf_library.id_to_name(est_gf) if est_gf != '' else '(no GF)'
+        gt_gf_name = gf_library.id_to_name(gt_gf) if gt_gf != "" else "(no GF)"
+        est_gf_name = gf_library.id_to_name(est_gf) if est_gf != "" else "(no GF)"
 
         true_gf_names.append(gt_gf_name)
         pred_gf_names.append(est_gf_name)
@@ -378,27 +414,28 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     pred_gf_names_arr = np.array(pred_gf_names)
     ba_match_flags_arr = np.array(ba_match_flags)
 
-    true_has_gf = true_gf_names_arr != '(no GF)'
+    true_has_gf = true_gf_names_arr != "(no GF)"
     n_gf_relevant = true_has_gf.sum()
 
     result = MetricGroupResult()
 
     if n_gf_relevant == 0:
-        result.scalars.extend([
-            ScalarMetric(name='gf_accuracy_gf_relevant', value=0.0),
-            ScalarMetric(name='within_ba_gf_accuracy', value=0.0),
-        ])
-        result.dataframes.append(DataFrameResult(
-            df=pd.DataFrame(
-                columns=['growth_form', 'precision', 'recall', 'f1',
-                         'support']),
-            artifact_path='taxonomic/gf_precision_recall_f1'))
+        result.scalars.extend(
+            [
+                ScalarMetric(name="gf_accuracy_gf_relevant", value=0.0),
+                ScalarMetric(name="within_ba_gf_accuracy", value=0.0),
+            ]
+        )
+        result.dataframes.append(
+            DataFrameResult(
+                df=pd.DataFrame(columns=["growth_form", "precision", "recall", "f1", "support"]),
+                artifact_path="taxonomic/gf_precision_recall_f1",
+            )
+        )
         return result
 
     # GF accuracy among GF-relevant predictions.
-    gf_relevant_correct = (
-        true_gf_names_arr[true_has_gf] == pred_gf_names_arr[true_has_gf]
-    ).sum()
+    gf_relevant_correct = (true_gf_names_arr[true_has_gf] == pred_gf_names_arr[true_has_gf]).sum()
     gf_relevant_acc = gf_relevant_correct / n_gf_relevant
 
     # Within-BA GF accuracy.
@@ -406,39 +443,48 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     n_ba_correct_gf_relevant = ba_correct_and_has_gf.sum()
     if n_ba_correct_gf_relevant > 0:
         within_ba_gf_correct = (
-            true_gf_names_arr[ba_correct_and_has_gf]
-            == pred_gf_names_arr[ba_correct_and_has_gf]
+            true_gf_names_arr[ba_correct_and_has_gf] == pred_gf_names_arr[ba_correct_and_has_gf]
         ).sum()
         within_ba_gf_acc = within_ba_gf_correct / n_ba_correct_gf_relevant
     else:
-        within_ba_gf_acc = float('nan')
+        within_ba_gf_acc = float("nan")
 
-    result.scalars.extend([
-        ScalarMetric(name='gf_accuracy_gf_relevant', value=float(gf_relevant_acc)),
-        ScalarMetric(name='within_ba_gf_accuracy', value=float(within_ba_gf_acc)),
-    ])
+    result.scalars.extend(
+        [
+            ScalarMetric(name="gf_accuracy_gf_relevant", value=float(gf_relevant_acc)),
+            ScalarMetric(name="within_ba_gf_accuracy", value=float(within_ba_gf_acc)),
+        ]
+    )
 
     # Per-GF precision/recall/F1.
     true_gf_counts = Counter(true_gf_names_arr[true_has_gf])
     gf_row_labels = [name for name, _ in true_gf_counts.most_common()]
-    gf_col_labels = gf_row_labels + ['(no GF)']
+    gf_col_labels = gf_row_labels + ["(no GF)"]
 
     t_filtered = true_gf_names_arr[true_has_gf]
     p_filtered = pred_gf_names_arr[true_has_gf]
 
     prec, rec, f1, support = sklearn.metrics.precision_recall_fscore_support(
-        t_filtered, p_filtered, labels=gf_row_labels, zero_division=0)
+        t_filtered, p_filtered, labels=gf_row_labels, zero_division=0
+    )
 
-    prf_df = pd.DataFrame({
-        'growth_form': gf_row_labels,
-        'precision': np.round(prec, 3),
-        'recall': np.round(rec, 3),
-        'f1': np.round(f1, 3),
-        'support': support.astype(int),
-    }).sort_values('support', ascending=False).reset_index(drop=True)
+    prf_df = (
+        pd.DataFrame(
+            {
+                "growth_form": gf_row_labels,
+                "precision": np.round(prec, 3),
+                "recall": np.round(rec, 3),
+                "f1": np.round(f1, 3),
+                "support": support.astype(int),
+            }
+        )
+        .sort_values("support", ascending=False)
+        .reset_index(drop=True)
+    )
 
-    result.dataframes.append(DataFrameResult(
-        df=prf_df, artifact_path='taxonomic/gf_precision_recall_f1'))
+    result.dataframes.append(
+        DataFrameResult(df=prf_df, artifact_path="taxonomic/gf_precision_recall_f1")
+    )
 
     # GF confusion matrix figure.
     row_idx = {name: i for i, name in enumerate(gf_row_labels)}
@@ -448,9 +494,9 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     n_cols = len(gf_col_labels)
     cm_raw = np.zeros((n_rows, n_cols), dtype=int)
 
-    for t, p in zip(t_filtered, p_filtered):
+    for t, p in zip(t_filtered, p_filtered, strict=False):
         r = row_idx[t]
-        c = col_idx.get(p, None)
+        c = col_idx.get(p)
         if c is not None:
             cm_raw[r, c] += 1
 
@@ -458,38 +504,32 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     row_sums[row_sums == 0] = 1
     cm_pct = np.int64(np.floor(cm_raw / row_sums * 100))
 
-    fig, ax = plt.subplots(
-        figsize=(max(10, n_cols * 0.9), max(6, n_rows * 0.55)))
+    fig, ax = plt.subplots(figsize=(max(10, n_cols * 0.9), max(6, n_rows * 0.55)))
     try:
-        im = ax.imshow(cm_pct, cmap='Blues', aspect='auto')
+        im = ax.imshow(cm_pct, cmap="Blues", aspect="auto")  # noqa: F841 — imshow side-effect registers the colormap scale on the axes
 
         for i in range(n_rows):
             for j in range(n_cols):
                 val = cm_pct[i, j]
                 if val > 0:
-                    text_color = 'white' if val > 50 else 'black'
-                    ax.text(j, i, str(val), ha='center', va='center',
-                            fontsize=9, color=text_color)
+                    text_color = "white" if val > 50 else "black"
+                    ax.text(j, i, str(val), ha="center", va="center", fontsize=9, color=text_color)
 
         ax.set_xticks(range(n_cols))
         ax.set_xticklabels(gf_col_labels, fontsize=10)
-        ax.xaxis.set_label_position('top')
-        ax.xaxis.set_ticks_position('top')
-        plt.setp(ax.get_xticklabels(), rotation=45, ha='left',
-                 rotation_mode='anchor')
+        ax.xaxis.set_label_position("top")
+        ax.xaxis.set_ticks_position("top")
+        plt.setp(ax.get_xticklabels(), rotation=45, ha="left", rotation_mode="anchor")
         ax.set_yticks(range(n_rows))
         ax.set_yticklabels(gf_row_labels, fontsize=10)
-        ax.set_xlabel('Predicted Growth Form', fontsize=11)
-        ax.set_ylabel('True Growth Form', fontsize=11)
-        ax.set_title(
-            'GF Confusion Matrix — row-normalized % (true label has GF)',
-            pad=50)
+        ax.set_xlabel("Predicted Growth Form", fontsize=11)
+        ax.set_ylabel("True Growth Form", fontsize=11)
+        ax.set_title("GF Confusion Matrix — row-normalized % (true label has GF)", pad=50)
         plt.tight_layout()
     except Exception:
         plt.close(fig)
         raise
 
-    result.figures.append(FigureResult(
-        fig=fig, artifact_path='taxonomic/gf_confusion.png'))
+    result.figures.append(FigureResult(fig=fig, artifact_path="taxonomic/gf_confusion.png"))
 
     return result

--- a/mermaid_classifier/pyspacer/metrics/taxonomic.py
+++ b/mermaid_classifier/pyspacer/metrics/taxonomic.py
@@ -6,16 +6,22 @@ Metrics:
 - Growth form differentiation accuracy
 """
 
+import typing
 from collections import Counter
+from typing import TYPE_CHECKING
 
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import sklearn.metrics
+from matplotlib.figure import Figure
 
 from mermaid_classifier.common.benthic_attributes import split_ba_gf
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
+
+if TYPE_CHECKING:
+    from mermaid_classifier.common.benthic_attributes import BenthicAttributeLibrary
 from mermaid_classifier.pyspacer.metrics._results import (
     DataFrameResult,
     FigureResult,
@@ -49,19 +55,20 @@ def compute_taxonomic(ctx: MetricsContext) -> MetricGroupResult:
 def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
     """Attribute misclassifications to their LCA in the taxonomy tree."""
     val_results = ctx.val_results
-    classes = val_results.classes
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes: list[str] = val_results.classes  # pyright: ignore[reportAssignmentType]
     ba_library = ctx.ba_library
 
     ba_full_paths = ctx.ba_paths or build_ba_paths(classes, ba_library)
 
-    def get_branch(ba_id):
+    def get_branch(ba_id: str) -> str:
         if ba_id in ba_full_paths:
             return ba_full_paths[ba_id][0]
         ancestors = ba_library.get_ancestor_ids(ba_id)
         return ancestors[0] if ancestors else ba_id
 
     # Count errors per LCA node.
-    lca_error_counts: Counter = Counter()
+    lca_error_counts: Counter[str | None] = Counter()
     total_errors = 0
 
     for gt_idx, est_idx in zip(val_results.gt, val_results.est, strict=False):
@@ -85,7 +92,7 @@ def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
         result.dataframes.append(
             DataFrameResult(
                 df=pd.DataFrame(
-                    columns=[
+                    columns=[  # pyright: ignore[reportArgumentType]  # pandas stubs type columns as Axes|None
                         "lca_node",
                         "lca_name",
                         "branch",
@@ -100,7 +107,7 @@ def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
         return result
 
     # Aggregate by branch.
-    branch_errors: Counter = Counter()
+    branch_errors: Counter[str] = Counter()
     for lca_node, count in lca_error_counts.items():
         if lca_node is not None:
             branch_errors[get_branch(lca_node)] += count
@@ -171,13 +178,13 @@ def _compute_error_attribution(ctx: MetricsContext) -> MetricGroupResult:
 
 
 def _plot_error_attribution(
-    lca_error_counts,
-    branch_errors,
-    total_errors,
-    cross_branch_count,
-    ba_library,
-    get_branch,
-):
+    lca_error_counts: Counter[str | None],
+    branch_errors: Counter[str],
+    total_errors: int,
+    cross_branch_count: int,
+    ba_library: "BenthicAttributeLibrary",
+    get_branch: "typing.Callable[[str], str]",
+) -> Figure:
     """Build the two-panel error attribution figure."""
     cmap = matplotlib.colormaps["tab20"]
 
@@ -299,14 +306,15 @@ def _plot_error_attribution(
 
     ax_detail.set_xlim(0, max(bar_counts) * 1.2)
 
-    plt.tight_layout(rect=[0, 0, 1, 0.96])
+    plt.tight_layout(rect=(0, 0, 1, 0.96))
     return fig
 
 
 def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
     """Build row-normalized confusion matrix at the top-level BA."""
     val_results = ctx.val_results
-    classes = val_results.classes
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes: list[str] = val_results.classes  # pyright: ignore[reportAssignmentType]
     ba_library = ctx.ba_library
 
     ba_to_top = ctx.ba_to_top or build_ba_to_top(classes, ba_library)
@@ -334,7 +342,7 @@ def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
 
     row_sums = cm.sum(axis=1, keepdims=True)
     row_sums[row_sums == 0] = 1
-    cm_pct = np.int64(np.floor(cm / row_sums * 100))
+    cm_pct = np.floor(cm / row_sums * 100).astype(np.int64)
 
     result = MetricGroupResult()
 
@@ -381,7 +389,7 @@ def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
         DataFrameResult(
             df=pd.DataFrame(confusions)
             if confusions
-            else pd.DataFrame(columns=["true", "predicted", "row_normalized_pct", "sample_count"]),
+            else pd.DataFrame(columns=["true", "predicted", "row_normalized_pct", "sample_count"]),  # pyright: ignore[reportArgumentType]  # pandas stubs type columns as Axes|None
             artifact_path="taxonomic/top_level_confusions",
         )
     )
@@ -392,7 +400,8 @@ def _compute_top_level_confusion(ctx: MetricsContext) -> MetricGroupResult:
 def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     """Analyze growth form prediction accuracy."""
     val_results = ctx.val_results
-    classes = val_results.classes
+    # val_results.classes is list[LabelId] (int|str); MERMAID always uses str.
+    classes: list[str] = val_results.classes  # pyright: ignore[reportAssignmentType]
     gf_library = ctx.gf_library
 
     true_gf_names = []
@@ -428,7 +437,7 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
         )
         result.dataframes.append(
             DataFrameResult(
-                df=pd.DataFrame(columns=["growth_form", "precision", "recall", "f1", "support"]),
+                df=pd.DataFrame(columns=["growth_form", "precision", "recall", "f1", "support"]),  # pyright: ignore[reportArgumentType]  # pandas stubs type columns as Axes|None
                 artifact_path="taxonomic/gf_precision_recall_f1",
             )
         )
@@ -465,7 +474,10 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
     p_filtered = pred_gf_names_arr[true_has_gf]
 
     prec, rec, f1, support = sklearn.metrics.precision_recall_fscore_support(
-        t_filtered, p_filtered, labels=gf_row_labels, zero_division=0
+        t_filtered,
+        p_filtered,
+        labels=gf_row_labels,
+        zero_division=0,  # pyright: ignore[reportArgumentType]  # sklearn stubs type as str only
     )
 
     prf_df = (
@@ -475,7 +487,7 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
                 "precision": np.round(prec, 3),
                 "recall": np.round(rec, 3),
                 "f1": np.round(f1, 3),
-                "support": support.astype(int),
+                "support": support.astype(int),  # pyright: ignore[reportOptionalMemberAccess]  # support is ndarray when labels given
             }
         )
         .sort_values("support", ascending=False)
@@ -502,11 +514,11 @@ def _compute_gf_differentiation(ctx: MetricsContext) -> MetricGroupResult:
 
     row_sums = cm_raw.sum(axis=1, keepdims=True)
     row_sums[row_sums == 0] = 1
-    cm_pct = np.int64(np.floor(cm_raw / row_sums * 100))
+    cm_pct = np.floor(cm_raw / row_sums * 100).astype(np.int64)
 
     fig, ax = plt.subplots(figsize=(max(10, n_cols * 0.9), max(6, n_rows * 0.55)))
     try:
-        im = ax.imshow(cm_pct, cmap="Blues", aspect="auto")  # noqa: F841 — imshow side-effect registers the colormap scale on the axes
+        _im = ax.imshow(cm_pct, cmap="Blues", aspect="auto")  # noqa: F841 — imshow side-effect registers the colormap scale on the axes
 
         for i in range(n_rows):
             for j in range(n_cols):

--- a/mermaid_classifier/pyspacer/mlflow_model.py
+++ b/mermaid_classifier/pyspacer/mlflow_model.py
@@ -9,6 +9,7 @@ This module imports ``mlflow`` and therefore lives train-side, NOT in
 ``mermaid_classifier.pyspacer.inference`` (which must stay mlflow-free so the
 ``[inference]`` dependency split holds).
 """
+
 from __future__ import annotations
 
 import mlflow

--- a/mermaid_classifier/pyspacer/mlflow_model.py
+++ b/mermaid_classifier/pyspacer/mlflow_model.py
@@ -12,32 +12,44 @@ This module imports ``mlflow`` and therefore lives train-side, NOT in
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any
+
 import mlflow
+from mlflow.models.signature import ModelSignature
+from mlflow.pyfunc import (
+    PythonModel,  # pyright: ignore[reportPrivateImportUsage]  # mlflow does not re-export PythonModel at package level
+)
 
 from mermaid_classifier.pyspacer.inference import load_predictor
 
 
-class ArtifactPredictorModel(mlflow.pyfunc.PythonModel):
+class ArtifactPredictorModel(PythonModel):
     """Loads model.pt + model.json via load_predictor; ``predict`` returns the
     calibrated probability matrix for a feature batch."""
 
-    def load_context(self, context):
+    def load_context(self, context: Any) -> None:  # pyright: ignore[reportUnknownParameterType]  # mlflow PythonModelContext is untyped
         self._predictor = load_predictor(
             context.artifacts["model_pt"],
             context.artifacts["model_json"],
         )
 
-    def predict(self, context, model_input, params=None):
+    def predict(  # pyright: ignore[reportUnknownParameterType]  # mlflow PythonModel.predict signature is untyped
+        self,
+        context: Any,
+        model_input: Any,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
         return self._predictor.predict_proba(model_input)
 
 
 def log_artifact_model(
-    model_pt_path,
-    model_json_path,
+    model_pt_path: Path | str,
+    model_json_path: Path | str,
     *,
-    registered_model_name,
-    signature=None,
-):
+    registered_model_name: str,
+    signature: ModelSignature | None = None,
+) -> Any:  # pyright: ignore[reportReturnType]  # mlflow.pyfunc.log_model return type is untyped
     """Log the portable artifact as an MLflow pyfunc model and register it.
 
     Stores ``model.pt`` + ``model.json`` as the model's artifacts, preserving
@@ -58,5 +70,5 @@ def log_artifact_model(
             "model_json": str(model_json_path),
         },
         registered_model_name=registered_model_name,
-        signature=signature,
+        signature=signature,  # pyright: ignore[reportArgumentType]  # mlflow signature param typed as ModelSignature (not Optional) but None is accepted at runtime
     )

--- a/mermaid_classifier/pyspacer/settings.py
+++ b/mermaid_classifier/pyspacer/settings.py
@@ -4,7 +4,6 @@ from typing import Literal
 import psutil
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-
 # EfficientNet feature vector dimensionality (4096 floats).
 _FEATURE_DIM = 4096
 # Bytes per float64 element (numpy / sklearn default).
@@ -71,10 +70,11 @@ class Settings(BaseSettings):
     Though none of the settings are 100% strictly required, some are
     needed in common cases.
     """
+
     # ML inputs
 
-    coralnet_train_data_bucket: str = 'coral-reef-training'
-    mermaid_train_data_bucket: str = 'coral-reef-training'
+    coralnet_train_data_bucket: str = "coral-reef-training"
+    mermaid_train_data_bucket: str = "coral-reef-training"
     # Annotation file paths/patterns require settings to be overrideable
     # for unit tests, because these files are read in with DuckDB,
     # and DuckDB is not easy (if even possible) to use with Python
@@ -83,16 +83,14 @@ class Settings(BaseSettings):
         # The placeholders get filled in with a format() call during use.
         # Custom patterns don't HAVE to include the placeholders.
         # They just get used if they're present.
-        's3://{coralnet_train_data_bucket}'
-        '/s{source_id}/annotations.csv'
+        "s3://{coralnet_train_data_bucket}/s{source_id}/annotations.csv"
     )
     mermaid_annotations_parquet_pattern: str = (
-        's3://{mermaid_train_data_bucket}'
-        '/mermaid/mermaid_confirmed_annotations.parquet'
+        "s3://{mermaid_train_data_bucket}/mermaid/mermaid_confirmed_annotations.parquet"
     )
     weights_location: str | None = None
-    aws_region: str = 'us-east-1'
-    aws_anonymous: Literal['False', 'True'] = 'False'
+    aws_region: str = "us-east-1"
+    aws_anonymous: Literal["False", "True"] = "False"
     aws_key_id: str | None = None
     aws_secret: str | None = None
     aws_session_token: str | None = None
@@ -112,8 +110,7 @@ class Settings(BaseSettings):
     mlflow_http_request_max_retries: str | None = None
     mlflow_default_experiment_name: str | None = None
 
-    model_config = SettingsConfigDict(
-        env_file='.env', env_file_encoding='utf-8')
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 
 
 settings = Settings()
@@ -125,28 +122,28 @@ def set_env_vars_for_packages():
     configured with .env, rather than having to be manually set as
     env vars.
     """
-    setting_to_env_name = dict(
+    setting_to_env_name = {
         # Filesystem directory to use for caching extractor weights that
         # were downloaded from S3 or from a URL.
         # This is required if loading weights from such a source.
-        spacer_extractors_cache_dir='SPACER_EXTRACTORS_CACHE_DIR',
-        aws_region='SPACER_AWS_REGION',
+        "spacer_extractors_cache_dir": "SPACER_EXTRACTORS_CACHE_DIR",
+        "aws_region": "SPACER_AWS_REGION",
         # If True, AWS is accessed without any credentials, which can
         # simplify setup while still allowing access to public S3 files.
-        aws_anonymous='SPACER_AWS_ANONYMOUS',
+        "aws_anonymous": "SPACER_AWS_ANONYMOUS",
         # Accessing private AWS data is most easily done by using the
         # instance metadata service within AWS, but here are other
         # ways. For example, log into AWS with SSO, choose a role to view
         # a temporary key+secret+token for, and plug those 3 values in.
-        aws_key_id='SPACER_AWS_ACCESS_KEY_ID',
-        aws_secret='SPACER_AWS_SECRET_ACCESS_KEY',
-        aws_session_token='SPACER_AWS_SESSION_TOKEN',
+        "aws_key_id": "SPACER_AWS_ACCESS_KEY_ID",
+        "aws_secret": "SPACER_AWS_SECRET_ACCESS_KEY",
+        "aws_session_token": "SPACER_AWS_SESSION_TOKEN",
         # When retrieving or saving models, this is the number of
         # exponential-backoff retries that MLflow will attempt when it's
         # having trouble connecting.
         # Default 7, but that takes forever; 2 is recommended.
-        mlflow_http_request_max_retries='MLFLOW_HTTP_REQUEST_MAX_RETRIES',
-    )
+        "mlflow_http_request_max_retries": "MLFLOW_HTTP_REQUEST_MAX_RETRIES",
+    }
     for setting_name, env_var_name in setting_to_env_name.items():
         var_value = getattr(settings, setting_name)
         if var_value:
@@ -160,4 +157,4 @@ def set_env_vars_for_packages():
     # trainer.py, the ref set no longer needs to fit in memory at once,
     # so we set this to a very large value to let ref_val_ratios alone
     # determine the ref set size.
-    os.environ['SPACER_TRAINING_BATCH_LABEL_COUNT'] = str(2**31 - 1)
+    os.environ["SPACER_TRAINING_BATCH_LABEL_COUNT"] = str(2**31 - 1)

--- a/mermaid_classifier/pyspacer/swap_monitor.py
+++ b/mermaid_classifier/pyspacer/swap_monitor.py
@@ -5,10 +5,10 @@ from mlflow.system_metrics.metrics.base_metrics_monitor import BaseMetricsMonito
 class SwapMonitor(BaseMetricsMonitor):
     """Monitor swap memory usage for MLflow system metrics logging."""
 
-    def collect_metrics(self):
+    def collect_metrics(self) -> None:
         swap = psutil.swap_memory()
         self._metrics["swap_usage_megabytes"].append(swap.used / 1e6)
         self._metrics["swap_usage_percentage"].append(swap.percent)
 
-    def aggregate_metrics(self):
+    def aggregate_metrics(self) -> dict[str, float]:  # pyright: ignore[reportIncompatibleMethodOverride]  # base class has no return type annotation; our return is semantically correct
         return {k: round(sum(v) / len(v), 1) for k, v in self._metrics.items()}

--- a/mermaid_classifier/pyspacer/torch_classifier.py
+++ b/mermaid_classifier/pyspacer/torch_classifier.py
@@ -29,6 +29,7 @@ Pickling: `_module` and `_optimizer` are serialised via `state_dict()`
 and rebuilt on unpickle so loaded classifiers remain callable without
 requiring the exact same torch internal object graph.
 """
+
 from __future__ import annotations
 
 import warnings
@@ -39,7 +40,6 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 
 # Upper bound on the row-sum drift we expect from a softmax computed in
 # float32 then cast to float64. float32 eps ≈ 1.2e-7; even naive summation
@@ -61,7 +61,7 @@ class _MLPModule(nn.Module):
         super().__init__()
         layer_sizes = [n_features_in, *hidden_layer_sizes, n_outputs]
         layers: list[nn.Linear] = []
-        for in_size, out_size in zip(layer_sizes[:-1], layer_sizes[1:]):
+        for in_size, out_size in zip(layer_sizes[:-1], layer_sizes[1:], strict=False):
             layers.append(nn.Linear(in_size, out_size))
         self.linears = nn.ModuleList(layers)
 
@@ -110,14 +110,10 @@ class TorchMLPClassifier:
     ):
         if activation != "relu":
             raise ValueError(
-                f"TorchMLPClassifier only supports activation='relu', got"
-                f" {activation!r}."
+                f"TorchMLPClassifier only supports activation='relu', got {activation!r}."
             )
         if solver != "adam":
-            raise ValueError(
-                f"TorchMLPClassifier only supports solver='adam', got"
-                f" {solver!r}."
-            )
+            raise ValueError(f"TorchMLPClassifier only supports solver='adam', got {solver!r}.")
 
         self.hidden_layer_sizes = tuple(hidden_layer_sizes)
         self.activation = activation
@@ -156,9 +152,7 @@ class TorchMLPClassifier:
         # `np.random.seed(...)` makes shuffling reproducible — while still
         # advancing between calls (no fixed shuffle).
         if not hasattr(self, "_none_rng"):
-            self._none_rng = np.random.default_rng(
-                np.random.randint(0, np.iinfo(np.int32).max)
-            )
+            self._none_rng = np.random.default_rng(np.random.randint(0, np.iinfo(np.int32).max))
         return self._none_rng
 
     def _labels_to_indices(self, y: np.ndarray) -> np.ndarray:
@@ -205,8 +199,7 @@ class TorchMLPClassifier:
         weights: list[float] = []
         for cls in self.classes_:
             if cls not in self.class_weight:
-                bad = sorted(set(self.classes_.tolist())
-                             - set(self.class_weight))
+                bad = sorted(set(self.classes_.tolist()) - set(self.class_weight))
                 raise ValueError(
                     f"class_weight is missing weights for {bad!r}."
                     f" Pass weights for every class in classes_."
@@ -214,8 +207,7 @@ class TorchMLPClassifier:
             w = float(self.class_weight[cls])
             if w < 0:
                 raise ValueError(
-                    f"class_weight for {cls!r} is negative ({w!r});"
-                    f" weights must be >= 0."
+                    f"class_weight for {cls!r} is negative ({w!r}); weights must be >= 0."
                 )
             weights.append(w)
         return torch.tensor(weights, dtype=torch.float32)
@@ -226,7 +218,7 @@ class TorchMLPClassifier:
         # scales it.
         penalty = torch.zeros(1, dtype=torch.float32)
         for linear in self._module.linears:
-            penalty = penalty + (linear.weight ** 2).sum()
+            penalty = penalty + (linear.weight**2).sum()
         return penalty.squeeze()
 
     def partial_fit(
@@ -234,7 +226,7 @@ class TorchMLPClassifier:
         X: np.ndarray | list,
         y: np.ndarray | list,
         classes: Sequence | None = None,
-    ) -> "TorchMLPClassifier":
+    ) -> TorchMLPClassifier:
         X_arr = np.asarray(X, dtype=np.float32)
         if X_arr.ndim != 2:
             raise ValueError(f"X must be 2D, got shape {X_arr.shape}")
@@ -255,10 +247,7 @@ class TorchMLPClassifier:
             self._class_weight_tensor = self._build_class_weight_tensor()
         else:
             if X_arr.shape[1] != self.n_features_in_:
-                raise ValueError(
-                    f"X has {X_arr.shape[1]} features, expected"
-                    f" {self.n_features_in_}"
-                )
+                raise ValueError(f"X has {X_arr.shape[1]} features, expected {self.n_features_in_}")
 
         y_indices = self._labels_to_indices(np.asarray(y))
         n_samples = X_arr.shape[0]
@@ -290,8 +279,7 @@ class TorchMLPClassifier:
             # zero direct gradient via their own CE term, but their
             # logits still participate in the softmax denominator for
             # other classes — for full exclusion, filter the dataset.
-            data_loss = F.cross_entropy(
-                logits, yb, weight=self._class_weight_tensor)
+            data_loss = F.cross_entropy(logits, yb, weight=self._class_weight_tensor)
             # Match sklearn's MLP: L2 penalty per mini-batch is
             # (0.5 * alpha / mb_size) * sum(W^2) — scaled by the size of
             # this specific mini-batch, not the full partial_fit input.
@@ -316,12 +304,18 @@ class TorchMLPClassifier:
         self,
         X: np.ndarray | list,
         y: np.ndarray | list,
-    ) -> "TorchMLPClassifier":
+    ) -> TorchMLPClassifier:
         y_arr = np.asarray(y)
         classes = np.unique(y_arr)
         # Reset so fit() starts fresh even on a previously-trained instance.
-        for attr in ("_module", "_optimizer", "classes_", "n_features_in_",
-                     "n_iter_", "loss_curve_"):
+        for attr in (
+            "_module",
+            "_optimizer",
+            "classes_",
+            "n_features_in_",
+            "n_iter_",
+            "loss_curve_",
+        ):
             if hasattr(self, attr):
                 delattr(self, attr)
         prev_loss = np.inf
@@ -346,10 +340,7 @@ class TorchMLPClassifier:
         if X_arr.ndim != 2:
             raise ValueError(f"X must be 2D, got shape {X_arr.shape}")
         if X_arr.shape[1] != self.n_features_in_:
-            raise ValueError(
-                f"X has {X_arr.shape[1]} features, expected"
-                f" {self.n_features_in_}"
-            )
+            raise ValueError(f"X has {X_arr.shape[1]} features, expected {self.n_features_in_}")
         self._module.eval()
         with torch.no_grad():
             probs = F.softmax(self._module(torch.from_numpy(X_arr)), dim=1)
@@ -405,12 +396,10 @@ class TorchMLPClassifier:
             "class_weight": getattr(self, "class_weight", None),
         }
 
-    def set_params(self, **params: Any) -> "TorchMLPClassifier":
+    def set_params(self, **params: Any) -> TorchMLPClassifier:
         for key, value in params.items():
             if not hasattr(self, key):
-                raise ValueError(
-                    f"Invalid parameter {key!r} for TorchMLPClassifier"
-                )
+                raise ValueError(f"Invalid parameter {key!r} for TorchMLPClassifier")
             setattr(self, key, value)
         return self
 
@@ -421,9 +410,7 @@ class TorchMLPClassifier:
         module = state.pop("_module", None)
         optimizer = state.pop("_optimizer", None)
         if module is not None:
-            state["_module_state"] = {
-                k: v.detach().cpu() for k, v in module.state_dict().items()
-            }
+            state["_module_state"] = {k: v.detach().cpu() for k, v in module.state_dict().items()}
         if optimizer is not None:
             state["_optimizer_state"] = optimizer.state_dict()
         return state

--- a/mermaid_classifier/pyspacer/torch_classifier.py
+++ b/mermaid_classifier/pyspacer/torch_classifier.py
@@ -65,11 +65,12 @@ class _MLPModule(nn.Module):
             layers.append(nn.Linear(in_size, out_size))
         self.linears = nn.ModuleList(layers)
 
-        for linear in self.linears:
+        for module in self.linears:
+            assert isinstance(module, nn.Linear)
             # Glorot uniform — matches sklearn MLP's init for non-logistic
             # activations (factor=6 in sklearn's _init_coef).
-            nn.init.xavier_uniform_(linear.weight)
-            nn.init.zeros_(linear.bias)
+            nn.init.xavier_uniform_(module.weight)
+            nn.init.zeros_(module.bias)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         for i, linear in enumerate(self.linears):
@@ -106,7 +107,7 @@ class TorchMLPClassifier:
         beta_1: float = 0.9,
         beta_2: float = 0.999,
         epsilon: float = 1e-8,
-        class_weight: dict | None = None,
+        class_weight: dict[str, float] | None = None,
     ):
         if activation != "relu":
             raise ValueError(
@@ -217,15 +218,16 @@ class TorchMLPClassifier:
         # over weights (not biases). We compute sum(W^2) here; the caller
         # scales it.
         penalty = torch.zeros(1, dtype=torch.float32)
-        for linear in self._module.linears:
-            penalty = penalty + (linear.weight**2).sum()
+        for module in self._module.linears:
+            assert isinstance(module, nn.Linear)
+            penalty = penalty + (module.weight**2).sum()
         return penalty.squeeze()
 
     def partial_fit(
         self,
-        X: np.ndarray | list,
-        y: np.ndarray | list,
-        classes: Sequence | None = None,
+        X: np.ndarray | list[Any],
+        y: np.ndarray | list[Any],
+        classes: Sequence[Any] | None = None,
     ) -> TorchMLPClassifier:
         X_arr = np.asarray(X, dtype=np.float32)
         if X_arr.ndim != 2:
@@ -302,11 +304,11 @@ class TorchMLPClassifier:
 
     def fit(
         self,
-        X: np.ndarray | list,
-        y: np.ndarray | list,
+        X: np.ndarray | list[Any],
+        y: np.ndarray | list[Any],
     ) -> TorchMLPClassifier:
         y_arr = np.asarray(y)
-        classes = np.unique(y_arr)
+        classes: list[Any] = np.unique(y_arr).tolist()
         # Reset so fit() starts fresh even on a previously-trained instance.
         for attr in (
             "_module",
@@ -327,7 +329,7 @@ class TorchMLPClassifier:
             prev_loss = cur
         return self
 
-    def _forward_probs(self, X: np.ndarray | list) -> np.ndarray:
+    def _forward_probs(self, X: np.ndarray | list[Any]) -> np.ndarray:
         if not hasattr(self, "_module"):
             raise RuntimeError(
                 "TorchMLPClassifier is not fitted. Call partial_fit or fit"
@@ -367,10 +369,10 @@ class TorchMLPClassifier:
         probs_np /= row_sums[:, np.newaxis]
         return probs_np
 
-    def predict_proba(self, X: np.ndarray | list) -> np.ndarray:
+    def predict_proba(self, X: np.ndarray | list[Any]) -> np.ndarray:
         return self._forward_probs(X)
 
-    def predict(self, X: np.ndarray | list) -> np.ndarray:
+    def predict(self, X: np.ndarray | list[Any]) -> np.ndarray:
         return self.classes_[np.argmax(self._forward_probs(X), axis=1)]
 
     # --- sklearn parameter protocol (lightweight) -------------------------

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -15,6 +15,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 import duckdb
 import mlflow
@@ -81,7 +82,7 @@ class Sites(enum.Enum):
 
 
 @contextmanager
-def section_profiling(profiled_sections: list[dict], section_name: str):
+def section_profiling(profiled_sections: list[dict[str, object]], section_name: str):
     """
     Performance-profile a wrapped section of code and save the stats
     (time, memory) as part of the passed structure.
@@ -93,7 +94,7 @@ def section_profiling(profiled_sections: list[dict], section_name: str):
     yield
 
     seconds_elapsed = time.perf_counter() - start_time
-    section_profile = {
+    section_profile: dict[str, object] = {
         # Name for this section of code.
         "name": section_name,
         # Number of seconds.
@@ -143,19 +144,19 @@ def download_features_parallel(
     failed: set[tuple[str, str]] = set()
     succeeded = 0
 
-    def _download(item):
+    def _download(item: tuple[tuple[str, str], str]) -> None:
         (bucket, key), local_path = item
         if os.path.exists(local_path) and os.path.getsize(local_path) > 0:
             return
         s3 = get_s3_resource()
         part_path = local_path + ".part"
-        s3.Object(bucket, key).download_file(part_path)
+        s3.Object(bucket, key).download_file(part_path)  # pyright: ignore[reportAttributeAccessIssue]  # boto3 S3 resource is untyped
         os.rename(part_path, local_path)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = {executor.submit(_download, item): item for item in s3_keys.items()}
         for i, future in enumerate(concurrent.futures.as_completed(futures), 1):
-            (bucket, key), local_path = futures[future]
+            (bucket, key), _local_path = futures[future]
             try:
                 future.result()
                 succeeded += 1
@@ -188,11 +189,13 @@ class LabelFilter(CsvSpec):
 
         self.inclusion = inclusion
 
-    def per_row_init_action(self, row):
+    def per_row_init_action(self, row: dict[str, str | None]) -> None:
         # Ensure absent values are just '', not '' or None.
-        self.bagf_set.add((row["ba_id"], row.get("gf_id") or ""))
+        self.bagf_set.add((row["ba_id"] or "", row.get("gf_id") or ""))
 
-    def accepts_bagf(self, bagf_id: str):
+    def accepts_bagf(self, bagf_id: str | None) -> bool:
+        if bagf_id is None:
+            return not self.inclusion
         ba_id, gf_id = split_ba_gf(bagf_id)
 
         if self.inclusion:
@@ -249,18 +252,20 @@ class LabelRollupSpec(CsvSpec):
         ColumnSpec(name="to_gf_id"),
     ]
 
-    def __init__(self, *args, **kwargs):
-        self.lookup = {}
+    def __init__(self, *args: typing.Any, **kwargs: typing.Any) -> None:
+        self.lookup: dict[tuple[str, str], tuple[str, str]] = {}
 
         super().__init__(*args, **kwargs)
 
-    def per_row_init_action(self, row):
+    def per_row_init_action(self, row: dict[str, str | None]) -> None:
         # Ensure absent values are just '', not '' or None.
-        key = (row["from_ba_id"], row.get("from_gf_id") or "")
-        value = (row["to_ba_id"], row.get("to_gf_id") or "")
+        key = (row["from_ba_id"] or "", row.get("from_gf_id") or "")
+        value = (row["to_ba_id"] or "", row.get("to_gf_id") or "")
         self.lookup[key] = value
 
-    def roll_up(self, bagf_id: str) -> str:
+    def roll_up(self, bagf_id: str | None) -> str | None:
+        if bagf_id is None:
+            return None
         ba_id, gf_id = split_ba_gf(bagf_id)
 
         if (ba_id, gf_id) in self.lookup:
@@ -348,10 +353,10 @@ class CNSourceFilter(CsvSpec):
 
         super().__init__(csv_file=csv_file)
 
-    def per_row_init_action(self, row):
-        self.source_id_list.append(row["id"])
+    def per_row_init_action(self, row: dict[str, str | None]) -> None:
+        self.source_id_list.append(row["id"] or "")
 
-    def is_empty(self):
+    def is_empty(self) -> bool:
         return len(self.source_id_list) == 0
 
 
@@ -366,8 +371,8 @@ class Artifacts:
     coralnet_label_mapping: pd.DataFrame
     coralnet_project_stats: pd.DataFrame
     mermaid_project_stats: pd.DataFrame
-    profiled_sections: list[dict]
-    train_summary_stats: dict
+    profiled_sections: list[dict[str, object]]
+    train_summary_stats: dict[str, object]
     unmapped_labels: pd.DataFrame
 
 
@@ -460,11 +465,11 @@ class DatasetOptions:
     """
 
     include_mermaid: bool = True
-    coralnet_sources_csv: str = None
+    coralnet_sources_csv: str | None = None
     drop_growthforms: bool = False
-    label_rollup_spec_csv: str = None
-    included_labels_csv: str = None
-    excluded_labels_csv: str = None
+    label_rollup_spec_csv: str | None = None
+    included_labels_csv: str | None = None
+    excluded_labels_csv: str | None = None
     ref_val_ratios: tuple[float, float] = (0.1, 0.1)
     # Optional per-class subsampling. None means use all annotations.
     # See mermaid_classifier.training.subsample for available strategies
@@ -599,7 +604,7 @@ class TrainingDataset:
 
         # https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem
         self.s3 = S3FileSystem(
-            anon=settings.aws_anonymous,
+            anon=settings.aws_anonymous == "True",
             key=settings.aws_key_id,
             secret=settings.aws_secret,
             token=settings.aws_session_token,
@@ -629,7 +634,7 @@ class TrainingDataset:
 
         def _annotations_stats() -> tuple[int, int]:
             # (annotation rows, distinct feature_vector i.e. unique images)
-            return self.duck_conn.execute(
+            return self.duck_conn.execute(  # pyright: ignore[reportReturnType]  # duckdb fetchone returns tuple[Any, ...] | None but we know it's always (int, int)
                 "SELECT COUNT(*), COUNT(DISTINCT feature_vector) FROM annotations"
             ).fetchone()
 
@@ -879,7 +884,7 @@ class TrainingDataset:
         # mapping, but the string 'None' from the MERMAID annotations
         # parquet.
         # Normalize the latter to ''.
-        def transform_func(gf_id):
+        def transform_func(gf_id: str | None) -> str | None:
             if gf_id == "None":
                 return ""
             return gf_id
@@ -1030,8 +1035,8 @@ class TrainingDataset:
 
         # Add BAs and GFs to the DuckDB table, using
         # our mapping from CoralNet label IDs to MERMAID BAs/GFs.
-        def label_to_ba(label):
-            if label not in label_mapping:
+        def label_to_ba(label: str | None) -> str | None:
+            if label is None or label not in label_mapping:
                 return None
             entry = label_mapping[label]
             return entry.benthic_attribute_id
@@ -1044,8 +1049,8 @@ class TrainingDataset:
             base_to_new_func=label_to_ba,
         )
 
-        def label_to_gf(label):
-            if label not in label_mapping:
+        def label_to_gf(label: str | None) -> str | None:
+            if label is None or label not in label_mapping:
                 return None
             entry = label_mapping[label]
             return entry.growth_form_id
@@ -1087,7 +1092,7 @@ class TrainingDataset:
         # Result should be [] if doesn't exist, which 'bools' to False.
         return bool(table_query_result)
 
-    def handle_missing_feature_vectors(self, mermaid_full_paths_in_s3: set):
+    def handle_missing_feature_vectors(self, mermaid_full_paths_in_s3: set[str]) -> None:
 
         # Build the annotation data's full feature paths, in DuckDB.
         self.duck_conn.execute(
@@ -1110,7 +1115,7 @@ class TrainingDataset:
             )
 
             # Get the S3 feature paths into another table.
-            s3_paths_df = pd.DataFrame({"feature_full": list(mermaid_full_paths_in_s3)})  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            s3_paths_df = pd.DataFrame({"feature_full": list(mermaid_full_paths_in_s3)})  # noqa: F841  # pyright: ignore[reportUnusedVariable]  # referenced by name in DuckDB SQL via Python-scope scanning
             self.duck_conn.execute(
                 f"CREATE TEMP TABLE {s3_features_table_name} AS SELECT * FROM s3_paths_df"
             )
@@ -1198,16 +1203,18 @@ class TrainingDataset:
                 # Here, in one loop iteration, we're given all the
                 # annotation rows for a single image.
                 first_row = rows[0]
-                bucket = first_row["bucket"]
-                feature_bucket_path = first_row["feature_vector"]
-                site = first_row["site"]
-                project_id = first_row["project_id"]
+                bucket = str(first_row["bucket"])
+                feature_bucket_path = str(first_row["feature_vector"])
+                site = str(first_row["site"])
+                project_id = str(first_row["project_id"])
 
                 image_annotations = []
 
                 # One annotation per row.
                 for row in rows:
-                    bagf = combine_ba_gf(row["benthic_attribute_id"], row["growth_form_id"])
+                    bagf = combine_ba_gf(
+                        str(row["benthic_attribute_id"]), str(row["growth_form_id"])
+                    )
 
                     annotation = (
                         int(row["row"]),
@@ -1315,7 +1322,9 @@ class TrainingDataset:
 
         return self._duck_conn
 
-    def compute_project_stats(self, site=None, has_training_sets=False):
+    def compute_project_stats(
+        self, site: str | None = None, has_training_sets: bool = False
+    ) -> pd.DataFrame:
         where_clause = "" if site is None else f"WHERE site = '{site}'"
 
         counts_sql = " count(DISTINCT image_id) AS num_images, count(*) AS num_annotations"
@@ -1367,7 +1376,7 @@ class TrainingDataset:
             )
 
             for set_name, training_set in training_sets:
-                values_batch: list[tuple] = []
+                values_batch: list[tuple[str, str, int, int, str]] = []
 
                 for feature_loc, row, col in self.generate_training_set_annotations(training_set):
                     # feature_loc is a filesystem DataLocation whose key is a
@@ -1405,8 +1414,10 @@ class TrainingDataset:
                 f"  USING (bucket, feature_vector, row, col)"
             )
 
-    def _add_tuples_to_table(self, table_name, tuples: list[tuple]):
-        df = pd.DataFrame.from_records(tuples)  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+    def _add_tuples_to_table(
+        self, table_name: str, tuples: list[tuple[str, str, int, int, str]]
+    ) -> None:
+        df = pd.DataFrame.from_records(tuples)  # noqa: F841  # pyright: ignore[reportUnusedVariable]  # referenced by name in DuckDB SQL via Python-scope scanning
         self.duck_conn.execute(f"INSERT INTO {table_name} SELECT * FROM df")
 
     @staticmethod
@@ -1431,13 +1442,22 @@ class TrainingDataset:
             " countif(training_set IS NULL) AS dropped"
             " FROM annotations GROUP BY benthic_attribute_id"
         )
+        ba_library = get_benthic_attribute_library()
+        gf_library_inst = get_growth_form_library()
+
+        def _ba_id_to_name(ba_id: str | None) -> str | None:
+            return ba_library.id_to_name(ba_id) if ba_id is not None else None
+
+        def _gf_id_to_name(gf_id: str | None) -> str | None:
+            return gf_library_inst.id_to_name(gf_id) if gf_id is not None else None
+
         # Add BA names alongside the IDs for readability.
         duckdb_add_column(
             duck_conn=self.duck_conn,
             duck_table_name="ba_counts",
             base_column_name="benthic_attribute_id",
             new_column_name="benthic_attribute_name",
-            base_to_new_func=get_benthic_attribute_library().id_to_name,
+            base_to_new_func=_ba_id_to_name,
         )
         # Sort by total annotation count, and reorder columns
         # while we're at it.
@@ -1476,7 +1496,7 @@ class TrainingDataset:
             duck_table_name="bagf_counts",
             base_column_name="benthic_attribute_id",
             new_column_name="benthic_attribute_name",
-            base_to_new_func=get_benthic_attribute_library().id_to_name,
+            base_to_new_func=_ba_id_to_name,
         )
         # Add GF names for readability.
         duckdb_add_column(
@@ -1484,7 +1504,7 @@ class TrainingDataset:
             duck_table_name="bagf_counts",
             base_column_name="growth_form_id",
             new_column_name="growth_form_name",
-            base_to_new_func=get_growth_form_library().id_to_name,
+            base_to_new_func=_gf_id_to_name,
         )
         # Sort by annotation count, and reorder columns
         # while we're at it.
@@ -1595,13 +1615,13 @@ class TrainingRunner:
     MLflow.
     """
 
-    dataset: TrainingDataset = None
-    profiled_sections: list[dict]
+    dataset: TrainingDataset | None = None
+    profiled_sections: list[dict[str, object]]
 
     def __init__(
         self,
-        dataset_options: DatasetOptions = None,
-        training_options: TrainingOptions = None,
+        dataset_options: DatasetOptions | None = None,
+        training_options: TrainingOptions | None = None,
     ):
         # Normalize Settings -> SPACER_*/MLFLOW_* env vars before any PySpacer
         # or MLflow work. This used to run as an import side effect of
@@ -1682,14 +1702,14 @@ class TrainingRunner:
             if cleanup_dataset and self.dataset is not None:
                 self.dataset.cleanup()
 
-    def _on_epoch_end(self, metrics: dict):
+    def _on_epoch_end(self, metrics: dict[str, object]) -> None:
         """Called after each training epoch. Override for logging."""
         pass
 
     def _compute_class_weights(
         self,
-        labels,
-    ) -> tuple[dict | None, dict]:
+        labels: typing.Any,
+    ) -> tuple[dict[str, float] | None, dict[str, object]]:
         """Compute per-class loss weights from training-set class counts,
         using the configured ``DatasetOptions.weighting`` strategy.
 
@@ -1782,7 +1802,9 @@ class TrainingRunner:
 
 
 class MLflowTrainingRunner(TrainingRunner):
-    def __init__(self, *args, mlflow_options: MLflowOptions = None, **kwargs):
+    def __init__(
+        self, *args: typing.Any, mlflow_options: MLflowOptions | None = None, **kwargs: typing.Any
+    ) -> None:
         # Normalize Settings -> SPACER_*/MLFLOW_* env vars *before* the first
         # mlflow_connect() below, which needs MLFLOW_HTTP_REQUEST_MAX_RETRIES to
         # be set (otherwise a failed initial connection retries far more times
@@ -1798,7 +1820,7 @@ class MLflowTrainingRunner(TrainingRunner):
         super().__init__(*args, **kwargs)
         self.mlflow_options = mlflow_options or MLflowOptions()
 
-    def run(self, run_name=None):
+    def run(self, run_name: str | None = None, cleanup_dataset: bool = True) -> typing.Any:  # type: ignore[override]  # pyright: ignore[reportIncompatibleMethodOverride]  # intentionally narrows cleanup_dataset; MLflow runner always manages cleanup itself
 
         model_name = self._get_model_name()
         if run_name is None:
@@ -1808,9 +1830,12 @@ class MLflowTrainingRunner(TrainingRunner):
         mlflow.enable_system_metrics_logging()
         mlflow.set_experiment(self.mlflow_options.experiment_name)
 
+        return_msg: typing.Any = None
+        model_info: typing.Any = None
+
         with mlflow.start_run(run_name=run_name):
             # Add swap monitoring to MLflow's system metrics polling loop.
-            run_id = mlflow.active_run().info.run_id
+            run_id = mlflow.active_run().info.run_id  # pyright: ignore[reportOptionalMemberAccess]  # active_run() is non-None inside start_run() context
             if run_id in run_id_to_system_metrics_monitor:
                 run_id_to_system_metrics_monitor[run_id].monitors.append(SwapMonitor())
 
@@ -1870,6 +1895,7 @@ class MLflowTrainingRunner(TrainingRunner):
                 return_msg, clf_calibrated, val_results = super().run(
                     run_name=run_name, cleanup_dataset=False
                 )
+                assert self.dataset is not None  # set by base TrainingRunner.run()
 
                 # Weighting artifacts/metrics are stashed by the base run()
                 # via _compute_class_weights. Log them now.
@@ -1932,12 +1958,12 @@ class MLflowTrainingRunner(TrainingRunner):
                         epoch: self.format_metric(acc)
                         for epoch, acc in enumerate(return_msg.ref_accs, 1)
                     }
-                    mlflow.log_dict(ref_accs_dict, "epoch_ref_accuracies.yaml")
+                    mlflow.log_dict(ref_accs_dict, "epoch_ref_accuracies.yaml")  # pyright: ignore[reportArgumentType]  # mlflow log_dict expects dict[str, Any] but int keys are valid in YAML
 
                     # Store the deployable artifact (model.pt + model.json) as
                     # the registered model via the pyfunc shim — one loader
                     # everywhere.
-                    signature = mlflow.models.infer_signature(params=training_options_to_log)
+                    signature = mlflow.models.infer_signature(params=training_options_to_log)  # pyright: ignore[reportPrivateImportUsage]  # mlflow.models is a submodule, not formally re-exported
                     model_info = log_artifact_model(
                         model_pt,
                         model_json,
@@ -1946,13 +1972,13 @@ class MLflowTrainingRunner(TrainingRunner):
                     )
             finally:
                 if getattr(self, "dataset", None) is not None:
-                    self.dataset.cleanup()
+                    self.dataset.cleanup()  # pyright: ignore[reportOptionalMemberAccess]  # getattr guard above ensures non-None
 
         logger.info(f"Model ID: {model_info.model_id}")
 
         return return_msg, model_info
 
-    def _on_epoch_end(self, metrics: dict):
+    def _on_epoch_end(self, metrics: dict[str, Any]) -> None:
         """Log per-epoch metrics to MLflow.
 
         Logs step-based metrics that appear as live charts in the MLflow UI
@@ -1967,31 +1993,37 @@ class MLflowTrainingRunner(TrainingRunner):
         `best_val_loss`); we log them as flat scalar metrics so they're
         easy to query post-hoc.
         """
-        step = metrics["epoch"]
-        mlflow.log_metric("epoch/ref_accuracy", metrics["ref_accuracy"], step=step)
+        step = int(metrics["epoch"])  # type: ignore[arg-type]
+        mlflow.log_metric("epoch/ref_accuracy", float(metrics["ref_accuracy"]), step=step)  # type: ignore[arg-type]
         if metrics.get("val_accuracy") is not None:
-            mlflow.log_metric("epoch/val_accuracy", metrics["val_accuracy"], step=step)
+            mlflow.log_metric("epoch/val_accuracy", float(metrics["val_accuracy"]), step=step)  # type: ignore[arg-type]
         if metrics.get("val_loss") is not None:
-            mlflow.log_metric("epoch/val_loss", metrics["val_loss"], step=step)
+            mlflow.log_metric("epoch/val_loss", float(metrics["val_loss"]), step=step)  # type: ignore[arg-type]
         if metrics["training_loss"] is not None:
-            mlflow.log_metric("epoch/training_loss", metrics["training_loss"], step=step)
-        mlflow.log_metric("epoch/cumulative_seconds", metrics["cumulative_seconds"], step=step)
+            mlflow.log_metric("epoch/training_loss", float(metrics["training_loss"]), step=step)  # type: ignore[arg-type]
+        mlflow.log_metric(
+            "epoch/cumulative_seconds", float(metrics["cumulative_seconds"]), step=step
+        )  # type: ignore[arg-type]
 
         # One-shot early-stopping summary (only present on the final
         # epoch). Logged as scalar metrics with no step so they appear
         # alongside the other run-level numbers.
         if metrics.get("final_epoch") is not None:
-            mlflow.log_metric("early_stop/final_epoch", float(metrics["final_epoch"]), step=0)
+            mlflow.log_metric("early_stop/final_epoch", float(metrics["final_epoch"]), step=0)  # type: ignore[arg-type]
             mlflow.log_metric(
                 "early_stop/triggered", float(bool(metrics.get("early_stopped"))), step=0
             )
             if metrics.get("best_val_epoch") is not None:
                 mlflow.log_metric(
-                    "early_stop/best_val_epoch", float(metrics["best_val_epoch"]), step=0
+                    "early_stop/best_val_epoch",
+                    float(metrics["best_val_epoch"]),
+                    step=0,  # type: ignore[arg-type]
                 )
             if metrics.get("best_val_loss") is not None:
                 mlflow.log_metric(
-                    "early_stop/best_val_loss", float(metrics["best_val_loss"]), step=0
+                    "early_stop/best_val_loss",
+                    float(metrics["best_val_loss"]),
+                    step=0,  # type: ignore[arg-type]
                 )
 
     def _get_model_name(self):
@@ -2060,9 +2092,9 @@ class MLflowTrainingRunner(TrainingRunner):
         ba_library = get_benthic_attribute_library()
         gf_library = get_growth_form_library()
 
-        def _decorate(row):
+        def _decorate(row: pd.Series) -> pd.Series:  # type: ignore[type-arg]
             try:
-                ba_id, gf_id = split_ba_gf(row["bagf_id"])
+                ba_id, gf_id = split_ba_gf(str(row["bagf_id"]))
                 ba_name = ba_library.id_to_name(ba_id) if ba_id else ""
                 gf_name = gf_library.id_to_name(gf_id) if gf_id else ""
             except Exception:
@@ -2078,7 +2110,7 @@ class MLflowTrainingRunner(TrainingRunner):
 
         decorated = df.apply(_decorate, axis=1)
         df = pd.concat([df, decorated], axis=1)
-        df = df[
+        df = df[  # type: ignore[index]
             [
                 "bagf_id",
                 "ba_id",
@@ -2088,7 +2120,7 @@ class MLflowTrainingRunner(TrainingRunner):
                 "count",
                 "weight",
             ]
-        ].sort_values("weight", ascending=False)
+        ].sort_values("weight", ascending=False)  # pyright: ignore[reportCallIssue]  # pandas DataFrame.sort_values overload issue with column-subscript result
 
         self.log_dataframe(df, "weighting/per_class_weights")
 
@@ -2115,16 +2147,12 @@ class MLflowTrainingRunner(TrainingRunner):
         ba_library = get_benthic_attribute_library()
         gf_library = get_growth_form_library()
 
-        def _decorate(row):
+        def _decorate(row: pd.Series) -> pd.Series:  # type: ignore[type-arg]
             try:
-                ba_name = (
-                    ba_library.id_to_name(row["benthic_attribute_id"])
-                    if row["benthic_attribute_id"]
-                    else ""
-                )
-                gf_name = (
-                    gf_library.id_to_name(row["growth_form_id"]) if row["growth_form_id"] else ""
-                )
+                _ba_id = str(row["benthic_attribute_id"])
+                _gf_id = str(row["growth_form_id"])
+                ba_name = ba_library.id_to_name(_ba_id) if _ba_id else ""
+                gf_name = gf_library.id_to_name(_gf_id) if _gf_id else ""
             except Exception:
                 ba_name, gf_name = "", ""
             return pd.Series({"ba_name": ba_name, "gf_name": gf_name})
@@ -2132,7 +2160,7 @@ class MLflowTrainingRunner(TrainingRunner):
         if not df.empty:
             decorated = df.apply(_decorate, axis=1)
             out = pd.concat([df, decorated], axis=1)
-            out = out[
+            out = out[  # type: ignore[index]
                 [
                     "benthic_attribute_id",
                     "ba_name",
@@ -2142,7 +2170,7 @@ class MLflowTrainingRunner(TrainingRunner):
                     "target_n",
                     "realized_n",
                 ]
-            ].sort_values("realized_n", ascending=False)
+            ].sort_values("realized_n", ascending=False)  # pyright: ignore[reportCallIssue]  # pandas DataFrame.sort_values overload issue with column-subscript result
             self.log_dataframe(out, "subsample/per_class_counts")
 
         realized = getattr(self.dataset, "_subsample_realized_total", None)
@@ -2232,11 +2260,12 @@ class MLflowTrainingRunner(TrainingRunner):
         ).fetch_df()
         self.log_dataframe(val_annotations_df, "annotations_val")
 
-    def log_dataframe(self, df, filestem):
+    def log_dataframe(self, df: pd.DataFrame, filestem: str) -> None:
         """
         MLflow's log_table() saves a .json instead of .csv, which means
         the resulting artifact file cannot be inspected readily with an
         external program such as Excel / LibreOffice Calc.
         To save a .csv, we use log_text() instead, with this helper function.
         """
+        assert self.dataset is not None
         _log_dataframe(self.dataset.duck_conn, df, filestem)

--- a/mermaid_classifier/pyspacer/train.py
+++ b/mermaid_classifier/pyspacer/train.py
@@ -2,36 +2,34 @@
 Train a classifier using feature vectors and annotations
 provided on S3.
 """
+
 import concurrent.futures
-from contextlib import contextmanager
 import dataclasses
-from datetime import datetime, timedelta
 import enum
-from io import StringIO
 import os
-from pathlib import Path
 import re
 import tempfile
 import time
 import typing
+from contextlib import contextmanager
+from datetime import datetime, timedelta
+from io import StringIO
+from pathlib import Path
 
 import duckdb
 import mlflow
-from mlflow.tracking.fluent import run_id_to_system_metrics_monitor
 import pandas as pd
 import psutil
+from mlflow.tracking.fluent import run_id_to_system_metrics_monitor
 from s3fs.core import S3FileSystem
-from mermaid_classifier.pyspacer.swap_monitor import SwapMonitor
 from spacer.aws import get_s3_resource
 from spacer.data_classes import DataLocation, ImageLabels
-from spacer.task_utils import preprocess_labels, SplitMode
+from spacer.task_utils import SplitMode, preprocess_labels
 
-from mermaid_classifier.pyspacer.settings import training_batch_size
-from mermaid_classifier.pyspacer.trainer import MermaidTrainer
 from mermaid_classifier.common.benthic_attributes import (
     BAGF_SEP,
-    combine_ba_gf,
     CoralNetMermaidMapping,
+    combine_ba_gf,
     get_benthic_attribute_library,
     get_growth_form_library,
     split_ba_gf,
@@ -45,19 +43,26 @@ from mermaid_classifier.common.duckdb_utils import (
     duckdb_temp_table_name,
     duckdb_transform_column,
 )
-from mermaid_classifier.pyspacer.metrics import (
-    MetricsContext, MetricsCoordinator,
-)
 from mermaid_classifier.pyspacer.inference import (
-    export_artifact, load_predictor,
+    export_artifact,
+    load_predictor,
 )
-from mermaid_classifier.pyspacer.mlflow_model import log_artifact_model
+from mermaid_classifier.pyspacer.metrics import (
+    MetricsContext,
+    MetricsCoordinator,
+)
 from mermaid_classifier.pyspacer.metrics._logging import (
     log_dataframe as _log_dataframe,
 )
-from mermaid_classifier.pyspacer.settings import settings, set_env_vars_for_packages
-from mermaid_classifier.pyspacer.utils import (
-    logging_config_for_script, mlflow_connect)
+from mermaid_classifier.pyspacer.mlflow_model import log_artifact_model
+from mermaid_classifier.pyspacer.settings import (
+    set_env_vars_for_packages,
+    settings,
+    training_batch_size,
+)
+from mermaid_classifier.pyspacer.swap_monitor import SwapMonitor
+from mermaid_classifier.pyspacer.trainer import MermaidTrainer
+from mermaid_classifier.pyspacer.utils import logging_config_for_script, mlflow_connect
 from mermaid_classifier.training.sample_weighting import (
     SampleWeightingOptions,
     compute_class_weights,
@@ -67,13 +72,12 @@ from mermaid_classifier.training.subsample import (
     compute_per_class_targets,
 )
 
-
-logger = logging_config_for_script('train')
+logger = logging_config_for_script("train")
 
 
 class Sites(enum.Enum):
-    CORALNET = 'coralnet'
-    MERMAID = 'mermaid'
+    CORALNET = "coralnet"
+    MERMAID = "mermaid"
 
 
 @contextmanager
@@ -89,18 +93,18 @@ def section_profiling(profiled_sections: list[dict], section_name: str):
     yield
 
     seconds_elapsed = time.perf_counter() - start_time
-    section_profile = dict(
+    section_profile = {
         # Name for this section of code.
-        name=section_name,
+        "name": section_name,
         # Number of seconds.
-        seconds=format(seconds_elapsed, '.1f'),
+        "seconds": format(seconds_elapsed, ".1f"),
         # Hours, minutes, seconds, ns.
-        hms=str(timedelta(seconds=seconds_elapsed)),
+        "hms": str(timedelta(seconds=seconds_elapsed)),
         # Date and time, to see if the sections we've chosen skip any
         # substantial time blocks that we should also be monitoring.
-        approx_start=approx_start_date.strftime('%b %d %H:%M:%S'),
-        memory_usage_at_end=f'{psutil.virtual_memory().percent}%',
-    )
+        "approx_start": approx_start_date.strftime("%b %d %H:%M:%S"),
+        "memory_usage_at_end": f"{psutil.virtual_memory().percent}%",
+    }
     profiled_sections.append(section_profile)
 
     logger.debug(
@@ -129,13 +133,10 @@ def download_features_parallel(
     if total == 0:
         return set()
 
-    logger.info(
-        f"Downloading {total} feature vectors"
-        f" with {max_workers} workers...")
+    logger.info(f"Downloading {total} feature vectors with {max_workers} workers...")
 
     # Pre-create all unique parent directories.
-    unique_dirs = {os.path.dirname(local_path)
-                   for local_path in s3_keys.values()}
+    unique_dirs = {os.path.dirname(local_path) for local_path in s3_keys.values()}
     for d in unique_dirs:
         os.makedirs(d, exist_ok=True)
 
@@ -147,32 +148,24 @@ def download_features_parallel(
         if os.path.exists(local_path) and os.path.getsize(local_path) > 0:
             return
         s3 = get_s3_resource()
-        part_path = local_path + '.part'
+        part_path = local_path + ".part"
         s3.Object(bucket, key).download_file(part_path)
         os.rename(part_path, local_path)
 
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=max_workers
-    ) as executor:
-        futures = {
-            executor.submit(_download, item): item
-            for item in s3_keys.items()
-        }
-        for i, future in enumerate(
-            concurrent.futures.as_completed(futures), 1
-        ):
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(_download, item): item for item in s3_keys.items()}
+        for i, future in enumerate(concurrent.futures.as_completed(futures), 1):
             (bucket, key), local_path = futures[future]
             try:
                 future.result()
                 succeeded += 1
             except Exception as e:
                 failed.add((bucket, key))
-                logger.warning(
-                    f"Failed to download s3://{bucket}/{key}: {e}")
+                logger.warning(f"Failed to download s3://{bucket}/{key}: {e}")
             if i % 1000 == 0 or i == total:
                 logger.info(
-                    f"Download progress: {i}/{total}"
-                    f" ({succeeded} ok, {len(failed)} failed)")
+                    f"Download progress: {i}/{total} ({succeeded} ok, {len(failed)} failed)"
+                )
 
     return failed
 
@@ -182,9 +175,10 @@ class LabelFilter(CsvSpec):
     A CSV-defined spec which says what benthic attribute + growth form
     combos to include in, or exclude from, training data.
     """
+
     column_specs = [
-        ColumnSpec(name='ba_id', allow_blank=False),
-        ColumnSpec(name='gf_id'),
+        ColumnSpec(name="ba_id", allow_blank=False),
+        ColumnSpec(name="gf_id"),
     ]
 
     def __init__(self, csv_file: typing.TextIO, inclusion: bool = True):
@@ -196,22 +190,21 @@ class LabelFilter(CsvSpec):
 
     def per_row_init_action(self, row):
         # Ensure absent values are just '', not '' or None.
-        self.bagf_set.add((row['ba_id'], row.get('gf_id') or ''))
+        self.bagf_set.add((row["ba_id"], row.get("gf_id") or ""))
 
     def accepts_bagf(self, bagf_id: str):
         ba_id, gf_id = split_ba_gf(bagf_id)
 
         if self.inclusion:
             return (ba_id, gf_id) in self.bagf_set
-        else:
-            return (ba_id, gf_id) not in self.bagf_set
+        return (ba_id, gf_id) not in self.bagf_set
 
     def filter_in_duckdb(
         self,
         duck_conn: duckdb.DuckDBPyConnection,
         duck_table_name: str,
-        ba_id_column_name: str = 'benthic_attribute_id',
-        gf_id_column_name: str = 'growth_form_id',
+        ba_id_column_name: str = "benthic_attribute_id",
+        gf_id_column_name: str = "growth_form_id",
     ):
         """
         Filter down the rows in the given DuckDB table, based on the
@@ -235,14 +228,12 @@ class LabelFilter(CsvSpec):
         duckdb_filter_on_column(
             duck_conn=duck_conn,
             duck_table_name=duck_table_name,
-            column_name='bagf_id',
+            column_name="bagf_id",
             inclusion_func=self.accepts_bagf,
         )
 
         # Don't need the combined BAGF column anymore.
-        duck_conn.execute(
-            f"ALTER TABLE {duck_table_name} DROP bagf_id"
-        )
+        duck_conn.execute(f"ALTER TABLE {duck_table_name} DROP bagf_id")
 
 
 class LabelRollupSpec(CsvSpec):
@@ -250,22 +241,23 @@ class LabelRollupSpec(CsvSpec):
     A CSV-defined spec which says what BA+GF combos to roll up to
     what other BA+GF combos.
     """
+
     column_specs = [
-        ColumnSpec(name='from_ba_id', allow_blank=False),
-        ColumnSpec(name='from_gf_id'),
-        ColumnSpec(name='to_ba_id', allow_blank=False),
-        ColumnSpec(name='to_gf_id'),
+        ColumnSpec(name="from_ba_id", allow_blank=False),
+        ColumnSpec(name="from_gf_id"),
+        ColumnSpec(name="to_ba_id", allow_blank=False),
+        ColumnSpec(name="to_gf_id"),
     ]
 
     def __init__(self, *args, **kwargs):
-        self.lookup = dict()
+        self.lookup = {}
 
         super().__init__(*args, **kwargs)
 
     def per_row_init_action(self, row):
         # Ensure absent values are just '', not '' or None.
-        key = (row['from_ba_id'], row.get('from_gf_id') or '')
-        value = (row['to_ba_id'], row.get('to_gf_id') or '')
+        key = (row["from_ba_id"], row.get("from_gf_id") or "")
+        value = (row["to_ba_id"], row.get("to_gf_id") or "")
         self.lookup[key] = value
 
     def roll_up(self, bagf_id: str) -> str:
@@ -282,8 +274,8 @@ class LabelRollupSpec(CsvSpec):
         self,
         duck_conn: duckdb.DuckDBPyConnection,
         duck_table_name: str,
-        ba_id_column_name: str = 'benthic_attribute_id',
-        gf_id_column_name: str = 'growth_form_id',
+        ba_id_column_name: str = "benthic_attribute_id",
+        gf_id_column_name: str = "growth_form_id",
     ):
         """
         Roll up the BA IDs and GF IDs in the given DuckDB table,
@@ -307,7 +299,7 @@ class LabelRollupSpec(CsvSpec):
         duckdb_transform_column(
             duck_conn=duck_conn,
             duck_table_name=duck_table_name,
-            column_name='bagf_id',
+            column_name="bagf_id",
             transform_func=self.roll_up,
         )
 
@@ -337,15 +329,12 @@ class LabelRollupSpec(CsvSpec):
         )
 
         # Don't need the combined BAGF column anymore.
-        duck_conn.execute(
-            f"ALTER TABLE {duck_table_name} DROP bagf_id"
-        )
+        duck_conn.execute(f"ALTER TABLE {duck_table_name} DROP bagf_id")
 
 
 class CNSourceFilter(CsvSpec):
-
     column_specs = [
-        ColumnSpec(name='id', allow_blank=False),
+        ColumnSpec(name="id", allow_blank=False),
     ]
 
     source_id_list: list[str]
@@ -360,7 +349,7 @@ class CNSourceFilter(CsvSpec):
         super().__init__(csv_file=csv_file)
 
     def per_row_init_action(self, row):
-        self.source_id_list.append(row['id'])
+        self.source_id_list.append(row["id"])
 
     def is_empty(self):
         return len(self.source_id_list) == 0
@@ -371,6 +360,7 @@ class Artifacts:
     Namespace to make it easier to track artifacts that we're
     logging later.
     """
+
     ba_counts: pd.DataFrame
     bagf_counts: pd.DataFrame
     coralnet_label_mapping: pd.DataFrame
@@ -468,6 +458,7 @@ class DatasetOptions:
     See ``mermaid_classifier.training.subsample`` for the full list and
     instructions on adding new strategies.
     """
+
     include_mermaid: bool = True
     coralnet_sources_csv: str = None
     drop_growthforms: bool = False
@@ -512,6 +503,7 @@ class TrainingOptions:
     natural epoch-to-epoch noise in val_loss; higher (>5) wastes wall
     time on epochs that are unlikely to recover.
     """
+
     epochs: int = 10
     early_stopping_patience: int | None = None
 
@@ -546,13 +538,13 @@ class MLflowOptions:
     'i456': log annotations from CoralNet image of ID 456
     <not specified>: log nothing extra
     """
+
     experiment_name: str | None = settings.mlflow_default_experiment_name
     model_name: str | None = None
     extra_annotations_to_log: str | None = None
 
 
 class TrainingDataset:
-
     def __init__(self, options: DatasetOptions):
 
         self.options = options
@@ -568,8 +560,7 @@ class TrainingDataset:
             self._feature_dir = settings.feature_cache_dir
             self._feature_temp_dir = None
         else:
-            self._feature_temp_dir = tempfile.TemporaryDirectory(
-                prefix='mermaid_features_')
+            self._feature_temp_dir = tempfile.TemporaryDirectory(prefix="mermaid_features_")
             self._feature_dir = self._feature_temp_dir.name
         # Maps a downloaded feature vector's local path (used as the key of
         # the filesystem DataLocations in self.labels) back to its original
@@ -577,41 +568,34 @@ class TrainingDataset:
         # this to match the labels to the annotations table.
         self._feature_path_to_s3_location: dict[str, tuple[str, str]] = {}
 
-
-
         if options.coralnet_sources_csv:
             with open(options.coralnet_sources_csv) as csv_f:
                 self.cn_source_filter = CNSourceFilter(csv_f)
         else:
             # Empty set of CoralNet sources.
-            self.cn_source_filter = CNSourceFilter(StringIO(''))
+            self.cn_source_filter = CNSourceFilter(StringIO(""))
 
         if options.label_rollup_spec_csv:
             with open(options.label_rollup_spec_csv) as csv_f:
                 self.rollup_spec = LabelRollupSpec(csv_f)
         else:
             # Empty rollup-targets set, meaning nothing gets rolled up.
-            self.rollup_spec = LabelRollupSpec(StringIO(''))
+            self.rollup_spec = LabelRollupSpec(StringIO(""))
 
         if options.included_labels_csv and options.excluded_labels_csv:
-            raise ValueError(
-                "Specify one of included labels or"
-                " excluded labels, but not both.")
+            raise ValueError("Specify one of included labels or excluded labels, but not both.")
 
         if options.included_labels_csv:
             with open(options.included_labels_csv) as csv_f:
-                self.label_filter = LabelFilter(
-                    csv_f, inclusion=True)
+                self.label_filter = LabelFilter(csv_f, inclusion=True)
         elif options.excluded_labels_csv:
             with open(options.excluded_labels_csv) as csv_f:
-                self.label_filter = LabelFilter(
-                    csv_f, inclusion=False)
+                self.label_filter = LabelFilter(csv_f, inclusion=False)
         else:
             # No inclusion or exclusion set specified means we accept
             # all labels.
             # In other words, an empty exclusion set.
-            self.label_filter = LabelFilter(
-                StringIO(''), inclusion=False)
+            self.label_filter = LabelFilter(StringIO(""), inclusion=False)
 
         # https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem
         self.s3 = S3FileSystem(
@@ -622,9 +606,7 @@ class TrainingDataset:
         )
         self._duck_conn = None
 
-        self.feature_loc_to_source: dict[
-            DataLocation, tuple[str, str]
-        ] = {}
+        self.feature_loc_to_source: dict[DataLocation, tuple[str, str]] = {}
 
         if not self.cn_source_filter.is_empty():
             with self.section_profiling("Reading CoralNet annotations"):
@@ -642,37 +624,36 @@ class TrainingDataset:
         # Now this should have annotations populated.
         if not self.duckdb_annotations_table_exists():
             raise ValueError(
-                "No annotations from CoralNet or MERMAID, even before"
-                " label filtering.")
+                "No annotations from CoralNet or MERMAID, even before label filtering."
+            )
 
         def _annotations_stats() -> tuple[int, int]:
             # (annotation rows, distinct feature_vector i.e. unique images)
             return self.duck_conn.execute(
-                "SELECT COUNT(*), COUNT(DISTINCT feature_vector)"
-                " FROM annotations"
+                "SELECT COUNT(*), COUNT(DISTINCT feature_vector) FROM annotations"
             ).fetchone()
 
         with self.section_profiling("Rollups and filtering"):
-
             ann_before, img_before = _annotations_stats()
             logger.info(
                 "Before rollups/filtering: %s annotations, %s unique images",
-                f"{ann_before:,}", f"{img_before:,}",
+                f"{ann_before:,}",
+                f"{img_before:,}",
             )
 
             if options.drop_growthforms:
                 # Clear all annotations' growth forms.
                 duckdb_transform_column(
                     duck_conn=self.duck_conn,
-                    duck_table_name='annotations',
-                    column_name='growth_form_id',
-                    transform_func=lambda x: '',
+                    duck_table_name="annotations",
+                    column_name="growth_form_id",
+                    transform_func=lambda x: "",
                 )
 
             # Roll up BAGFs.
             self.rollup_spec.roll_up_in_duckdb(
                 duck_conn=self.duck_conn,
-                duck_table_name='annotations',
+                duck_table_name="annotations",
             )
             ann_after_rollup, img_after_rollup = _annotations_stats()
             logger.info(
@@ -686,20 +667,18 @@ class TrainingDataset:
             # Filter out BAGFs we don't want.
             self.label_filter.filter_in_duckdb(
                 duck_conn=self.duck_conn,
-                duck_table_name='annotations',
+                duck_table_name="annotations",
             )
             ann_after_filter, img_after_filter = _annotations_stats()
             logger.info(
-                "After included-labels filter: %s annotations (-%s),"
-                " %s unique images (-%s)",
+                "After included-labels filter: %s annotations (-%s), %s unique images (-%s)",
                 f"{ann_after_filter:,}",
                 f"{ann_after_rollup - ann_after_filter:,}",
                 f"{img_after_filter:,}",
                 f"{img_after_rollup - img_after_filter:,}",
             )
             logger.info(
-                "Rollups+filter retained %.1f%% of annotations,"
-                " %.1f%% of unique images",
+                "Rollups+filter retained %.1f%% of annotations, %.1f%% of unique images",
                 100.0 * ann_after_filter / max(ann_before, 1),
                 100.0 * img_after_filter / max(img_before, 1),
             )
@@ -716,11 +695,7 @@ class TrainingDataset:
             with self.section_profiling("Detecting missing feature vectors"):
                 # First, get the paths present in S3 (this can take a while).
                 mermaid_bucket = settings.mermaid_train_data_bucket
-                mermaid_full_paths_in_s3 = set(
-                    self.s3.find(
-                        path=f's3://{mermaid_bucket}/mermaid/'
-                    )
-                )
+                mermaid_full_paths_in_s3 = set(self.s3.find(path=f"s3://{mermaid_bucket}/mermaid/"))
                 # Check against annotation data.
                 self.handle_missing_feature_vectors(mermaid_full_paths_in_s3)
 
@@ -730,8 +705,6 @@ class TrainingDataset:
             self.add_training_set_names()
 
         self.set_train_summary_stats()
-
-
 
     def _apply_subsample(self, opts: SubsampleOptions) -> None:
         """Deterministic per-class subsampling of the annotations table.
@@ -775,13 +748,10 @@ class TrainingDataset:
             " GROUP BY benthic_attribute_id, growth_form_id"
             " ORDER BY benthic_attribute_id, growth_form_id"
         ).fetchall()
-        class_counts: dict[tuple[str, str], int] = {
-            (ba, gf): n for ba, gf, n in rows
-        }
+        class_counts: dict[tuple[str, str], int] = {(ba, gf): n for ba, gf, n in rows}
 
         if not class_counts:
-            logger.warning(
-                "Subsampling skipped: annotations table is empty.")
+            logger.warning("Subsampling skipped: annotations table is empty.")
             return
 
         # Step 2: dispatch to the strategy registry.
@@ -793,14 +763,14 @@ class TrainingDataset:
         targets_df = pd.DataFrame(
             [
                 {
-                    'benthic_attribute_id': ba,
-                    'growth_form_id': gf,
-                    'target_n': int(n),
+                    "benthic_attribute_id": ba,
+                    "growth_form_id": gf,
+                    "target_n": int(n),
                 }
                 for (ba, gf), n in targets.items()
             ]
         )
-        self.duck_conn.register('_subsample_targets', targets_df)
+        self.duck_conn.register("_subsample_targets", targets_df)
         try:
             # The (site, project_id, image_id, row, col) tuple is
             # unique per annotation in this schema (CoralNet and
@@ -826,7 +796,7 @@ class TrainingDataset:
                 " WHERE n._rn <= t.target_n"
             )
         finally:
-            self.duck_conn.unregister('_subsample_targets')
+            self.duck_conn.unregister("_subsample_targets")
 
         # Step 4: log realized per-class counts. This is the after-the-
         # fact audit trail: lets us confirm in MLflow that two parallel
@@ -839,20 +809,22 @@ class TrainingDataset:
         ).fetchall()
         realized_by_cls = {(ba, gf): n for ba, gf, n in realized_rows}
 
-        per_class_audit = pd.DataFrame([
-            {
-                'benthic_attribute_id': ba,
-                'growth_form_id': gf,
-                'pre_count': class_counts[(ba, gf)],
-                'target_n': targets.get((ba, gf), 0),
-                'realized_n': realized_by_cls.get((ba, gf), 0),
-            }
-            for (ba, gf) in sorted(class_counts)
-        ])
+        per_class_audit = pd.DataFrame(
+            [
+                {
+                    "benthic_attribute_id": ba,
+                    "growth_form_id": gf,
+                    "pre_count": class_counts[(ba, gf)],
+                    "target_n": targets.get((ba, gf), 0),
+                    "realized_n": realized_by_cls.get((ba, gf), 0),
+                }
+                for (ba, gf) in sorted(class_counts)
+            ]
+        )
         # Stash on self; logged to MLflow by the runner alongside the
         # other dataset artifacts.
         self._subsample_audit_df = per_class_audit
-        realized_total = int(per_class_audit['realized_n'].sum())
+        realized_total = int(per_class_audit["realized_n"].sum())
         self._subsample_realized_total = realized_total
         logger.info(
             f"Subsample applied: strategy={opts.strategy!r},"
@@ -881,14 +853,13 @@ class TrainingDataset:
             # INSERT INTO ... BY NAME ... means that we don't have to match
             # the column order of the existing table.
             # https://duckdb.org/docs/stable/sql/statements/insert#insert-into--by-name
-            query_start = f"INSERT INTO annotations BY NAME"
+            query_start = "INSERT INTO annotations BY NAME"
         else:
             # Didn't read any CoralNet data, so we have to create
             # the annotations table.
-            query_start = f"CREATE TABLE annotations AS"
+            query_start = "CREATE TABLE annotations AS"
         self.duck_conn.execute(
-            query_start +
-            f" SELECT"
+            query_start + f" SELECT"
             f"  image_id, row, col,"
             f"  benthic_attribute_id, growth_form_id,"
             f" '{Sites.MERMAID.value}' AS site,"
@@ -901,20 +872,22 @@ class TrainingDataset:
 
         # Get project-level stats before applying any further filters.
         self.artifacts.mermaid_project_stats = self.compute_project_stats(
-            site=Sites.MERMAID.value, has_training_sets=False)
+            site=Sites.MERMAID.value, has_training_sets=False
+        )
 
         # For growth forms, we get '' from the CoralNet-MERMAID
         # mapping, but the string 'None' from the MERMAID annotations
         # parquet.
         # Normalize the latter to ''.
         def transform_func(gf_id):
-            if gf_id == 'None':
-                return ''
+            if gf_id == "None":
+                return ""
             return gf_id
+
         duckdb_transform_column(
             duck_conn=self.duck_conn,
-            duck_table_name='annotations',
-            column_name='growth_form_id',
+            duck_table_name="annotations",
+            column_name="growth_form_id",
             transform_func=transform_func,
         )
 
@@ -924,7 +897,6 @@ class TrainingDataset:
 
         s3 = S3FileSystem(anon=False)
         for source_id in self.cn_source_filter.source_id_list:
-
             # One row per point annotation,
             # with columns including Image ID, Row, Column, Label ID
             annotations_uri = settings.coralnet_annotations_csv_pattern.format(
@@ -942,7 +914,8 @@ class TrainingDataset:
         if missing_source_ids:
             logger.warning(
                 "Skipping %d source(s) with no annotations.csv in S3: %s",
-                len(missing_source_ids), missing_source_ids,
+                len(missing_source_ids),
+                missing_source_ids,
             )
         if not annotations_uri_list:
             raise RuntimeError(
@@ -961,8 +934,8 @@ class TrainingDataset:
             # format, reading in CN, and transforming back to open data
             # format.
             raise RuntimeError(
-                "Due to format technicalities, CoralNet data must be read"
-                " in before MERMAID data.")
+                "Due to format technicalities, CoralNet data must be read in before MERMAID data."
+            )
 
         # Read each selected source's annotations-CSV into a single
         # DuckDB table.
@@ -1044,12 +1017,13 @@ class TrainingDataset:
             # all_varchar, files missing this column (or individual rows
             # without a value) come through as NULL, which propagates
             # into feature_vector and crashes os.path.join downstream.
-            f" WHERE \"Image ID\" IS NOT NULL AND \"Image ID\" <> ''"
+            f' WHERE "Image ID" IS NOT NULL AND "Image ID" <> \'\''
         )
 
         # Get project-level stats before applying any further filters.
         self.artifacts.coralnet_project_stats = self.compute_project_stats(
-            site=Sites.CORALNET.value, has_training_sets=False)
+            site=Sites.CORALNET.value, has_training_sets=False
+        )
 
         label_mapping = CoralNetMermaidMapping()
         self.artifacts.coralnet_label_mapping = label_mapping.get_dataframe()
@@ -1061,23 +1035,26 @@ class TrainingDataset:
                 return None
             entry = label_mapping[label]
             return entry.benthic_attribute_id
+
         duckdb_add_column(
             duck_conn=self.duck_conn,
-            duck_table_name='annotations',
-            base_column_name='label_id',
-            new_column_name='benthic_attribute_id',
+            duck_table_name="annotations",
+            base_column_name="label_id",
+            new_column_name="benthic_attribute_id",
             base_to_new_func=label_to_ba,
         )
+
         def label_to_gf(label):
             if label not in label_mapping:
                 return None
             entry = label_mapping[label]
             return entry.growth_form_id
+
         duckdb_add_column(
             duck_conn=self.duck_conn,
-            duck_table_name='annotations',
-            base_column_name='label_id',
-            new_column_name='growth_form_id',
+            duck_table_name="annotations",
+            base_column_name="label_id",
+            new_column_name="growth_form_id",
             base_to_new_func=label_to_gf,
         )
 
@@ -1099,15 +1076,12 @@ class TrainingDataset:
         ).fetch_df()
 
         # Then filter out those rows before moving on.
-        self.duck_conn.execute(
-            "DELETE FROM annotations WHERE benthic_attribute_id IS NULL"
-        )
+        self.duck_conn.execute("DELETE FROM annotations WHERE benthic_attribute_id IS NULL")
 
     def duckdb_annotations_table_exists(self) -> bool:
         # https://duckdb.org/docs/stable/sql/meta/information_schema
         table_query_result = self.duck_conn.execute(
-            f"SELECT * FROM information_schema.tables"
-            f" WHERE table_name = 'annotations'"
+            "SELECT * FROM information_schema.tables WHERE table_name = 'annotations'"
         ).fetchall()
 
         # Result should be [] if doesn't exist, which 'bools' to False.
@@ -1117,21 +1091,17 @@ class TrainingDataset:
 
         # Build the annotation data's full feature paths, in DuckDB.
         self.duck_conn.execute(
-            f"CREATE OR REPLACE TABLE annotations AS"
-            f" SELECT *,"
-            f"  bucket || '/' || feature_vector AS feature_full"
-            f" FROM annotations"
+            "CREATE OR REPLACE TABLE annotations AS"
+            " SELECT *,"
+            "  bucket || '/' || feature_vector AS feature_full"
+            " FROM annotations"
         )
 
         with (
-            duckdb_temp_table_name(self.duck_conn)
-            as anno_features_table_name,
-            duckdb_temp_table_name(self.duck_conn)
-            as s3_features_table_name,
-            duckdb_temp_table_name(self.duck_conn)
-            as missing_features_table_name,
+            duckdb_temp_table_name(self.duck_conn) as anno_features_table_name,
+            duckdb_temp_table_name(self.duck_conn) as s3_features_table_name,
+            duckdb_temp_table_name(self.duck_conn) as missing_features_table_name,
         ):
-
             # Get the annotation data's unique feature paths into a table.
             self.duck_conn.execute(
                 f"CREATE TABLE {anno_features_table_name} AS"
@@ -1140,11 +1110,9 @@ class TrainingDataset:
             )
 
             # Get the S3 feature paths into another table.
-            s3_paths_df = pd.DataFrame(
-                {'feature_full': list(mermaid_full_paths_in_s3)})
+            s3_paths_df = pd.DataFrame({"feature_full": list(mermaid_full_paths_in_s3)})  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
             self.duck_conn.execute(
-                f"CREATE TEMP TABLE {s3_features_table_name}"
-                f" AS SELECT * FROM s3_paths_df"
+                f"CREATE TEMP TABLE {s3_features_table_name} AS SELECT * FROM s3_paths_df"
             )
 
             in_annotations_count = self.duck_conn.execute(
@@ -1168,8 +1136,7 @@ class TrainingDataset:
             ).fetchall()[0][0]
 
             result_tuples = self.duck_conn.execute(
-                f"SELECT feature_full FROM {missing_features_table_name}"
-                f" LIMIT 3"
+                f"SELECT feature_full FROM {missing_features_table_name} LIMIT 3"
             ).fetchall()
             missing_examples = [tup[0] for tup in result_tuples]
 
@@ -1186,15 +1153,12 @@ class TrainingDataset:
             )
 
         # Don't need the feature_full column anymore.
-        self.duck_conn.execute(
-            f"ALTER TABLE annotations DROP feature_full"
-        )
+        self.duck_conn.execute("ALTER TABLE annotations DROP feature_full")
 
         # Abort if too many are missing.
         examples_str = "\n".join(missing_examples)
         missing_threshold = (
-            in_annotations_count
-            * settings.training_inputs_percent_missing_allowed / 100
+            in_annotations_count * settings.training_inputs_percent_missing_allowed / 100
         )
         if missing_count > missing_threshold:
             raise RuntimeError(
@@ -1212,16 +1176,16 @@ class TrainingDataset:
                 f"Skipping {missing_count} feature vector(s) because"
                 f" the files aren't in S3."
                 f" Example(s):"
-                f"\n{examples_str}")
+                f"\n{examples_str}"
+            )
 
     def prep_annotations_for_pyspacer(self):
 
         with self.section_profiling("Collecting feature paths"):
-
             annotations_by_image = duckdb_grouped_rows(
                 duck_conn=self.duck_conn,
-                duck_table_name='annotations',
-                grouping_column_names=['bucket', 'feature_vector'],
+                duck_table_name="annotations",
+                grouping_column_names=["bucket", "feature_vector"],
             )
 
             # First pass: collect annotations and unique S3 keys.
@@ -1231,59 +1195,53 @@ class TrainingDataset:
             image_data = []
 
             for rows in annotations_by_image:
-
                 # Here, in one loop iteration, we're given all the
                 # annotation rows for a single image.
                 first_row = rows[0]
-                bucket = first_row['bucket']
-                feature_bucket_path = first_row['feature_vector']
-                site = first_row['site']
-                project_id = first_row['project_id']
+                bucket = first_row["bucket"]
+                feature_bucket_path = first_row["feature_vector"]
+                site = first_row["site"]
+                project_id = first_row["project_id"]
 
                 image_annotations = []
 
                 # One annotation per row.
                 for row in rows:
-
-                    bagf = combine_ba_gf(
-                        row['benthic_attribute_id'], row['growth_form_id'])
+                    bagf = combine_ba_gf(row["benthic_attribute_id"], row["growth_form_id"])
 
                     annotation = (
-                        int(row['row']),
-                        int(row['col']),
+                        int(row["row"]),
+                        int(row["col"]),
                         bagf,
                     )
                     image_annotations.append(annotation)
 
                 s3_key = (bucket, feature_bucket_path)
                 if s3_key not in s3_keys:
-                    local_path = os.path.join(
-                        tmp_root, bucket, feature_bucket_path)
+                    local_path = os.path.join(tmp_root, bucket, feature_bucket_path)
                     s3_keys[s3_key] = local_path
                     # Remember how to get back from the local download path
                     # to the original S3 location, for add_training_set_names.
                     self._feature_path_to_s3_location[local_path] = s3_key
 
                 image_data.append(
-                    (bucket, feature_bucket_path, site, project_id,
-                     image_annotations))
+                    (bucket, feature_bucket_path, site, project_id, image_annotations)
+                )
 
         # Parallel download of all feature vectors from S3.
         with self.section_profiling("Downloading feature vectors"):
             failed_keys = download_features_parallel(
-                s3_keys, max_workers=settings.download_max_workers)
+                s3_keys, max_workers=settings.download_max_workers
+            )
 
         if failed_keys:
-            logger.warning(
-                f"{len(failed_keys)} feature vector download(s) failed.")
+            logger.warning(f"{len(failed_keys)} feature vector download(s) failed.")
 
         with self.section_profiling("Building PySpacer labels"):
-
             # Build ImageLabels with filesystem DataLocations.
             labels_data = ImageLabels()
 
-            for (bucket, feature_bucket_path, site, project_id,
-                 image_annotations) in image_data:
+            for bucket, feature_bucket_path, site, project_id, image_annotations in image_data:
                 # Skip images whose feature file failed to download.
                 if (bucket, feature_bucket_path) in failed_keys:
                     continue
@@ -1291,7 +1249,7 @@ class TrainingDataset:
                 local_path = s3_keys[(bucket, feature_bucket_path)]
 
                 feature_loc = DataLocation(
-                    storage_type='filesystem',
+                    storage_type="filesystem",
                     key=local_path,
                 )
                 labels_data.add_image(feature_loc, image_annotations)
@@ -1322,11 +1280,11 @@ class TrainingDataset:
             # from S3.
             # https://duckdb.org/docs/stable/core_extensions/httpfs/overview
             try:
-                self._duck_conn.load_extension('httpfs')
+                self._duck_conn.load_extension("httpfs")
             except duckdb.IOException:
                 # Extension not installed yet.
-                self._duck_conn.install_extension('httpfs')
-                self._duck_conn.load_extension('httpfs')
+                self._duck_conn.install_extension("httpfs")
+                self._duck_conn.load_extension("httpfs")
 
             # Configure region and auth, if present.
             # https://duckdb.org/docs/stable/core_extensions/httpfs/s3api
@@ -1335,7 +1293,7 @@ class TrainingDataset:
             # `SET s3_region = 'us-east-1'`:
             # https://duckdb.org/docs/stable/core_extensions/httpfs/s3api_legacy_authentication
 
-            if settings.aws_anonymous == 'False':
+            if settings.aws_anonymous == "False":
                 if settings.aws_key_id:
                     # Manual provision of a key.
                     query = (
@@ -1346,17 +1304,11 @@ class TrainingDataset:
                         f" SECRET '{settings.aws_secret}',"
                     )
                     if settings.aws_session_token:
-                        query += (
-                            f" SESSION_TOKEN '{settings.aws_session_token}',"
-                        )
+                        query += f" SESSION_TOKEN '{settings.aws_session_token}',"
                 else:
                     # The credential_chain provider allows automatically
                     # fetching AWS credentials, like through the IMDS.
-                    query = (
-                        f"CREATE OR REPLACE SECRET secret ("
-                        f" TYPE s3,"
-                        f" PROVIDER credential_chain,"
-                    )
+                    query = "CREATE OR REPLACE SECRET secret ( TYPE s3, PROVIDER credential_chain,"
                 query += f" REGION '{settings.aws_region}')"
 
                 self._duck_conn.execute(query)
@@ -1364,15 +1316,9 @@ class TrainingDataset:
         return self._duck_conn
 
     def compute_project_stats(self, site=None, has_training_sets=False):
-        if site is None:
-            where_clause = ""
-        else:
-            where_clause = f"WHERE site = '{site}'"
+        where_clause = "" if site is None else f"WHERE site = '{site}'"
 
-        counts_sql = (
-            " count(DISTINCT image_id) AS num_images,"
-            " count(*) AS num_annotations"
-        )
+        counts_sql = " count(DISTINCT image_id) AS num_images, count(*) AS num_annotations"
         if has_training_sets:
             counts_sql += (
                 ","
@@ -1400,16 +1346,15 @@ class TrainingDataset:
         This will add a training_set column to the annotations table.
         """
         training_sets = [
-            ('train', self.labels.train),
-            ('ref', self.labels.ref),
-            ('val', self.labels.val),
+            ("train", self.labels.train),
+            ("ref", self.labels.ref),
+            ("val", self.labels.val),
         ]
         # Higher means fewer DuckDB operations; lower might reduce
         # memory usage.
         batch_size = 50000
 
         with duckdb_temp_table_name(self.duck_conn) as temp_table_name:
-
             # The columns here besides training_set are the ones that should
             # uniquely identify a particular annotation.
             self.duck_conn.execute(
@@ -1424,15 +1369,12 @@ class TrainingDataset:
             for set_name, training_set in training_sets:
                 values_batch: list[tuple] = []
 
-                for feature_loc, row, col in (
-                    self.generate_training_set_annotations(training_set)
-                ):
+                for feature_loc, row, col in self.generate_training_set_annotations(training_set):
                     # feature_loc is a filesystem DataLocation whose key is a
                     # local download path; map it back to the original S3
                     # (bucket, feature_vector) so it matches the annotations
                     # table's join columns.
-                    bucket, feature_vector = (
-                        self._feature_path_to_s3_location[feature_loc.key])
+                    bucket, feature_vector = self._feature_path_to_s3_location[feature_loc.key]
                     tup = (
                         bucket,
                         feature_vector,
@@ -1443,14 +1385,12 @@ class TrainingDataset:
                     values_batch.append(tup)
 
                     if len(values_batch) > batch_size:
-                        self._add_tuples_to_table(
-                            temp_table_name, values_batch)
+                        self._add_tuples_to_table(temp_table_name, values_batch)
                         values_batch = []
 
                 if len(values_batch) > 0:
                     # Last batch
-                    self._add_tuples_to_table(
-                        temp_table_name, values_batch)
+                    self._add_tuples_to_table(temp_table_name, values_batch)
 
             # Join annotations with the temp table to add the training_set info.
             #
@@ -1466,14 +1406,12 @@ class TrainingDataset:
             )
 
     def _add_tuples_to_table(self, table_name, tuples: list[tuple]):
-        df = pd.DataFrame.from_records(tuples)
-        self.duck_conn.execute(
-            f"INSERT INTO {table_name} SELECT * FROM df"
-        )
+        df = pd.DataFrame.from_records(tuples)  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+        self.duck_conn.execute(f"INSERT INTO {table_name} SELECT * FROM df")
 
     @staticmethod
     def generate_training_set_annotations(training_set: ImageLabels):
-        for feature_loc in training_set.keys():
+        for feature_loc in training_set.keys():  # noqa: SIM118 — ImageLabels.keys() is not a plain dict; __iter__ differs
             image_annotations = training_set[feature_loc]
             for row, col, _ in image_annotations:
                 yield feature_loc, row, col
@@ -1496,9 +1434,9 @@ class TrainingDataset:
         # Add BA names alongside the IDs for readability.
         duckdb_add_column(
             duck_conn=self.duck_conn,
-            duck_table_name='ba_counts',
-            base_column_name='benthic_attribute_id',
-            new_column_name='benthic_attribute_name',
+            duck_table_name="ba_counts",
+            base_column_name="benthic_attribute_id",
+            new_column_name="benthic_attribute_name",
             base_to_new_func=get_benthic_attribute_library().id_to_name,
         )
         # Sort by total annotation count, and reorder columns
@@ -1535,17 +1473,17 @@ class TrainingDataset:
         # Add BA names for readability.
         duckdb_add_column(
             duck_conn=self.duck_conn,
-            duck_table_name='bagf_counts',
-            base_column_name='benthic_attribute_id',
-            new_column_name='benthic_attribute_name',
+            duck_table_name="bagf_counts",
+            base_column_name="benthic_attribute_id",
+            new_column_name="benthic_attribute_name",
             base_to_new_func=get_benthic_attribute_library().id_to_name,
         )
         # Add GF names for readability.
         duckdb_add_column(
             duck_conn=self.duck_conn,
-            duck_table_name='bagf_counts',
-            base_column_name='growth_form_id',
-            new_column_name='growth_form_name',
+            duck_table_name="bagf_counts",
+            base_column_name="growth_form_id",
+            new_column_name="growth_form_name",
             base_to_new_func=get_growth_form_library().id_to_name,
         )
         # Sort by annotation count, and reorder columns
@@ -1568,10 +1506,7 @@ class TrainingDataset:
 
         # Overall counts.
         counts = self.duck_conn.execute(
-            "SELECT"
-            " count(*),"
-            " count(DISTINCT image_id)"
-            " FROM annotations"
+            "SELECT count(*), count(DISTINCT image_id) FROM annotations"
         ).fetchall()[0]
         total_annotations = counts[0]
         num_of_images = counts[1]
@@ -1596,18 +1531,18 @@ class TrainingDataset:
         bas_dropped = num_of_bas - non_dropped_bas
         bagfs_dropped = num_of_bagfs - non_dropped_bagfs
 
-        self.artifacts.train_summary_stats = dict(
-            annotations=total_annotations,
-            annotations_train=self.labels.train.label_count,
-            annotations_ref=self.labels.ref.label_count,
-            annotations_val=self.labels.val.label_count,
-            annotations_dropped=annotations_dropped,
-            images=num_of_images,
-            bas=num_of_bas,
-            bas_dropped=bas_dropped,
-            bagfs=num_of_bagfs,
-            bagfs_dropped=bagfs_dropped,
-        )
+        self.artifacts.train_summary_stats = {
+            "annotations": total_annotations,
+            "annotations_train": self.labels.train.label_count,
+            "annotations_ref": self.labels.ref.label_count,
+            "annotations_val": self.labels.val.label_count,
+            "annotations_dropped": annotations_dropped,
+            "images": num_of_images,
+            "bas": num_of_bas,
+            "bas_dropped": bas_dropped,
+            "bagfs": num_of_bagfs,
+            "bagfs_dropped": bagfs_dropped,
+        }
 
     def describe_train_summary_stats(self):
         return (
@@ -1620,21 +1555,22 @@ class TrainingDataset:
             " Representation: {bas} BAs and"
             " {bagfs} BA-GF combos"
             " (dropped: {bas_dropped} BAs, {bagfs_dropped} BA-GFs).".format(
-                **self.artifacts.train_summary_stats)
+                **self.artifacts.train_summary_stats
+            )
         )
 
     def get_annotations(self, log_spec: str):
 
-        if log_spec == 'all':
+        if log_spec == "all":
             query = "SELECT * FROM annotations"
-        elif match := re.fullmatch(r's(\d+)', log_spec):
+        elif match := re.fullmatch(r"s(\d+)", log_spec):
             cn_source_id = match.groups()[0]
             query = (
                 f"SELECT * FROM annotations"
                 f" WHERE site = '{Sites.CORALNET.value}'"
                 f" AND project_id = '{cn_source_id}'"
             )
-        elif match := re.fullmatch(r'i(\d+)', log_spec):
+        elif match := re.fullmatch(r"i(\d+)", log_spec):
             cn_image_id = match.groups()[0]
             query = (
                 f"SELECT * FROM annotations"
@@ -1642,8 +1578,7 @@ class TrainingDataset:
                 f" AND image_id = '{cn_image_id}'"
             )
         else:
-            raise ValueError(
-                f"Unsupported annotations log spec: {log_spec}")
+            raise ValueError(f"Unsupported annotations log spec: {log_spec}")
 
         return self.duck_conn.execute(query).fetch_df()
 
@@ -1659,6 +1594,7 @@ class TrainingRunner:
     It could also be extended to support tracking software other than
     MLflow.
     """
+
     dataset: TrainingDataset = None
     profiled_sections: list[dict]
 
@@ -1699,15 +1635,14 @@ class TrainingRunner:
 
             if settings.spacer_batch_size is not None:
                 batch_size = settings.spacer_batch_size
-                logger.info(
-                    f"Batch size: {batch_size} (from SPACER_BATCH_SIZE)")
+                logger.info(f"Batch size: {batch_size} (from SPACER_BATCH_SIZE)")
             else:
-                batch_size, available_gb = training_batch_size(
-                    num_classes=num_classes)
+                batch_size, available_gb = training_batch_size(num_classes=num_classes)
                 logger.info(
                     f"Batch size: {batch_size}"
                     f" (auto, based on {available_gb:.1f} GB"
-                    f" available memory, {num_classes} classes)")
+                    f" available memory, {num_classes} classes)"
+                )
 
             class_weight, weighting_log = self._compute_class_weights(
                 self.dataset.labels,
@@ -1718,8 +1653,7 @@ class TrainingRunner:
                 batch_size=batch_size,
                 on_epoch_end=self._on_epoch_end,
                 class_weight=class_weight,
-                early_stopping_patience=(
-                    self.training_options.early_stopping_patience),
+                early_stopping_patience=(self.training_options.early_stopping_patience),
             )
 
             # Train directly via the trainer — no pickle round-trip. pyspacer's
@@ -1729,22 +1663,15 @@ class TrainingRunner:
             labels = preprocess_labels(self.dataset.labels)
             with self.section_profiling("PySpacer training call"):
                 clf_calibrated, val_results, return_msg = trainer(
-                    labels, self.training_options.epochs, [])
+                    labels, self.training_options.epochs, []
+                )
 
-            logger.info(
-                f"Train time (from return msg):"
-                f" {return_msg.runtime:.1f} s")
+            logger.info(f"Train time (from return msg): {return_msg.runtime:.1f} s")
 
-            logger.info(
-                f"New model's accuracy:"
-                f" {self.format_metric(return_msg.acc)}")
+            logger.info(f"New model's accuracy: {self.format_metric(return_msg.acc)}")
 
-            ref_accs_str = ", ".join(
-                [str(self.format_metric(acc))
-                 for acc in return_msg.ref_accs])
-            logger.debug(
-                f"Accuracy progression during training epochs:"
-                f" {ref_accs_str}")
+            ref_accs_str = ", ".join([str(self.format_metric(acc)) for acc in return_msg.ref_accs])
+            logger.debug(f"Accuracy progression during training epochs: {ref_accs_str}")
 
             return return_msg, clf_calibrated, val_results
         finally:
@@ -1791,41 +1718,44 @@ class TrainingRunner:
         # spread for the kept (post-transform) class set.
         rows = []
         for cls, count in class_counts.items():
-            rows.append(dict(
-                bagf_id=cls,
-                count=int(count),
-                weight=float(weights.get(cls, 0.0)),
-            ))
+            rows.append(
+                {
+                    "bagf_id": cls,
+                    "count": int(count),
+                    "weight": float(weights.get(cls, 0.0)),
+                }
+            )
         per_class_df = pd.DataFrame(rows)
 
         # Summary stats over the weights produced for the kept class set.
         weight_series = per_class_df["weight"]
         if len(weight_series) > 0 and weight_series.max() > 0:
-            summary = dict(
-                weight_mean=float(weight_series.mean()),
-                weight_median=float(weight_series.median()),
-                weight_p5=float(weight_series.quantile(0.05)),
-                weight_p95=float(weight_series.quantile(0.95)),
-                weight_max_min_ratio=float(
-                    weight_series.max() / max(weight_series.min(), 1e-12)),
-                n_classes=int(len(per_class_df)),
-            )
+            summary = {
+                "weight_mean": float(weight_series.mean()),
+                "weight_median": float(weight_series.median()),
+                "weight_p5": float(weight_series.quantile(0.05)),
+                "weight_p95": float(weight_series.quantile(0.95)),
+                "weight_max_min_ratio": float(
+                    weight_series.max() / max(weight_series.min(), 1e-12)
+                ),
+                "n_classes": int(len(per_class_df)),
+            }
         else:
-            summary = dict(
-                weight_mean=0.0,
-                weight_median=0.0,
-                weight_p5=0.0,
-                weight_p95=0.0,
-                weight_max_min_ratio=0.0,
-                n_classes=int(len(per_class_df)),
-            )
+            summary = {
+                "weight_mean": 0.0,
+                "weight_median": 0.0,
+                "weight_p5": 0.0,
+                "weight_p95": 0.0,
+                "weight_max_min_ratio": 0.0,
+                "n_classes": int(len(per_class_df)),
+            }
 
-        return weights, dict(
-            enabled=True,
-            options=opts,
-            per_class_df=per_class_df,
-            summary=summary,
-        )
+        return weights, {
+            "enabled": True,
+            "options": opts,
+            "per_class_df": per_class_df,
+            "summary": summary,
+        }
 
     def log_dataset_artifacts(self):
         """
@@ -1842,7 +1772,7 @@ class TrainingRunner:
     @staticmethod
     def current_time_str():
         current_time = datetime.now()
-        return current_time.strftime('%Y%m%dT%H%M%S')
+        return current_time.strftime("%Y%m%dT%H%M%S")
 
     @staticmethod
     def format_metric(metric: float):
@@ -1852,13 +1782,7 @@ class TrainingRunner:
 
 
 class MLflowTrainingRunner(TrainingRunner):
-
-    def __init__(
-        self,
-        *args,
-        mlflow_options: MLflowOptions = None,
-        **kwargs
-    ):
+    def __init__(self, *args, mlflow_options: MLflowOptions = None, **kwargs):
         # Normalize Settings -> SPACER_*/MLFLOW_* env vars *before* the first
         # mlflow_connect() below, which needs MLFLOW_HTTP_REQUEST_MAX_RETRIES to
         # be set (otherwise a failed initial connection retries far more times
@@ -1878,43 +1802,46 @@ class MLflowTrainingRunner(TrainingRunner):
 
         model_name = self._get_model_name()
         if run_name is None:
-            run_name = f'{model_name}-{self.current_time_str()}'
+            run_name = f"{model_name}-{self.current_time_str()}"
 
         logger.info(f"Experiment: {self.mlflow_options.experiment_name}")
         mlflow.enable_system_metrics_logging()
         mlflow.set_experiment(self.mlflow_options.experiment_name)
 
         with mlflow.start_run(run_name=run_name):
-
             # Add swap monitoring to MLflow's system metrics polling loop.
             run_id = mlflow.active_run().info.run_id
             if run_id in run_id_to_system_metrics_monitor:
                 run_id_to_system_metrics_monitor[run_id].monitors.append(SwapMonitor())
 
-            training_options_to_log = dict(
-                epochs=self.training_options.epochs,
-                early_stopping_patience=(
+            training_options_to_log = {
+                "epochs": self.training_options.epochs,
+                "early_stopping_patience": (
                     self.training_options.early_stopping_patience
-                    if self.training_options.early_stopping_patience
-                    is not None else ''
+                    if self.training_options.early_stopping_patience is not None
+                    else ""
                 ),
-            )
+            }
 
             mlflow.log_params(training_options_to_log)
 
-            dataset_options_to_log = dict(
-                include_mermaid=self.dataset_options.include_mermaid,
-                coralnet_sources_csv=os.path.basename(
-                    self.dataset_options.coralnet_sources_csv or ''),
-                drop_growthforms=self.dataset_options.drop_growthforms,
-                label_rollup_spec_csv=os.path.basename(
-                    self.dataset_options.label_rollup_spec_csv or ''),
-                excluded_labels_csv=os.path.basename(
-                    self.dataset_options.excluded_labels_csv or ''),
-                included_labels_csv=os.path.basename(
-                    self.dataset_options.included_labels_csv or ''),
-                ref_val_ratios=str(self.dataset_options.ref_val_ratios),
-            )
+            dataset_options_to_log = {
+                "include_mermaid": self.dataset_options.include_mermaid,
+                "coralnet_sources_csv": os.path.basename(
+                    self.dataset_options.coralnet_sources_csv or ""
+                ),
+                "drop_growthforms": self.dataset_options.drop_growthforms,
+                "label_rollup_spec_csv": os.path.basename(
+                    self.dataset_options.label_rollup_spec_csv or ""
+                ),
+                "excluded_labels_csv": os.path.basename(
+                    self.dataset_options.excluded_labels_csv or ""
+                ),
+                "included_labels_csv": os.path.basename(
+                    self.dataset_options.included_labels_csv or ""
+                ),
+                "ref_val_ratios": str(self.dataset_options.ref_val_ratios),
+            }
             mlflow.log_params(dataset_options_to_log)
 
             # Subsample params: logged before training so they show up
@@ -1922,9 +1849,7 @@ class MLflowTrainingRunner(TrainingRunner):
             # run later fails. Per-class realized counts are logged as
             # an artifact after dataset prep (see _log_subsample_audit).
             if self.dataset_options.subsample is not None:
-                mlflow.log_params(
-                    self.dataset_options.subsample.to_log_dict()
-                )
+                mlflow.log_params(self.dataset_options.subsample.to_log_dict())
             else:
                 mlflow.log_params({"subsample/enabled": False})
 
@@ -1932,9 +1857,7 @@ class MLflowTrainingRunner(TrainingRunner):
             # show up alongside dataset/training params even if the
             # training run later fails.
             if self.dataset_options.weighting is not None:
-                mlflow.log_params(
-                    self.dataset_options.weighting.to_log_dict()
-                )
+                mlflow.log_params(self.dataset_options.weighting.to_log_dict())
             else:
                 mlflow.log_params({"weighting/enabled": False})
 
@@ -1945,7 +1868,8 @@ class MLflowTrainingRunner(TrainingRunner):
             # exported artifact against them below; the finally cleans up.
             try:
                 return_msg, clf_calibrated, val_results = super().run(
-                    run_name=run_name, cleanup_dataset=False)
+                    run_name=run_name, cleanup_dataset=False
+                )
 
                 # Weighting artifacts/metrics are stashed by the base run()
                 # via _compute_class_weights. Log them now.
@@ -1953,21 +1877,21 @@ class MLflowTrainingRunner(TrainingRunner):
                 self._log_subsample_audit()
 
                 profiles_df = pd.DataFrame(self.profiled_sections)
-                self.log_dataframe(profiles_df, 'profiled_sections')
+                self.log_dataframe(profiles_df, "profiled_sections")
 
                 # val_results now comes from the trainer in memory (no reload).
-                mlflow.log_dict(val_results.serialize(), 'valresult.json')
+                mlflow.log_dict(val_results.serialize(), "valresult.json")
 
                 # Eval-the-artifact: export the deployable TorchScript artifact
                 # and evaluate THAT, so the logged metrics reflect what actually
                 # ships. The parity reference batch is the first val batch (real
                 # features, loaded the same way the coordinator loads val data).
-                ref_batch = next(
-                    iter(self.dataset.labels.val.load_data_in_batches()), None)
+                ref_batch = next(iter(self.dataset.labels.val.load_data_in_batches()), None)
                 if ref_batch is None:
                     raise RuntimeError(
                         "Val split yielded no feature batch; refusing to export"
-                        " an unverified artifact.")
+                        " an unverified artifact."
+                    )
                 # load_data_in_batches yields zip(*pairs); unpacking gives a
                 # (features, labels) pair of tuples, same as the metrics
                 # coordinator consumes. We only need the feature vectors.
@@ -1980,10 +1904,12 @@ class MLflowTrainingRunner(TrainingRunner):
                     artifact_dir = Path(artifact_dir)
                     # Parity-gated export (ParityError if max|Δ| > 1e-6).
                     model_pt, _manifest, _max_diff = export_artifact(
-                        clf_calibrated, artifact_dir,
+                        clf_calibrated,
+                        artifact_dir,
                         reference_features=ref_features,
-                        config={'patch_size': 224})
-                    model_json = artifact_dir / 'model.json'
+                        config={"patch_size": 224},
+                    )
+                    model_json = artifact_dir / "model.json"
                     # ManifestError on schema/class-count/input_dim mismatch.
                     predictor = load_predictor(model_pt, model_json)
 
@@ -1996,28 +1922,25 @@ class MLflowTrainingRunner(TrainingRunner):
                         clf=predictor,
                     )
 
-                    coordinator = MetricsCoordinator(
-                        ctx, duck_conn=self.dataset.duck_conn)
+                    coordinator = MetricsCoordinator(ctx, duck_conn=self.dataset.duck_conn)
                     coordinator.compute_and_log_all()
 
                     # Accuracy and ref_accs come from pyspacer's return_msg, not
                     # our metrics module (training-progress, not artifact-based).
-                    mlflow.log_metric(
-                        'accuracy', self.format_metric(return_msg.acc))
+                    mlflow.log_metric("accuracy", self.format_metric(return_msg.acc))
                     ref_accs_dict = {
                         epoch: self.format_metric(acc)
                         for epoch, acc in enumerate(return_msg.ref_accs, 1)
                     }
-                    mlflow.log_dict(
-                        ref_accs_dict, 'epoch_ref_accuracies.yaml')
+                    mlflow.log_dict(ref_accs_dict, "epoch_ref_accuracies.yaml")
 
                     # Store the deployable artifact (model.pt + model.json) as
                     # the registered model via the pyfunc shim — one loader
                     # everywhere.
-                    signature = mlflow.models.infer_signature(
-                        params=training_options_to_log)
+                    signature = mlflow.models.infer_signature(params=training_options_to_log)
                     model_info = log_artifact_model(
-                        model_pt, model_json,
+                        model_pt,
+                        model_json,
                         registered_model_name=model_name,
                         signature=signature,
                     )
@@ -2045,39 +1968,31 @@ class MLflowTrainingRunner(TrainingRunner):
         easy to query post-hoc.
         """
         step = metrics["epoch"]
-        mlflow.log_metric(
-            "epoch/ref_accuracy", metrics["ref_accuracy"], step=step)
+        mlflow.log_metric("epoch/ref_accuracy", metrics["ref_accuracy"], step=step)
         if metrics.get("val_accuracy") is not None:
-            mlflow.log_metric(
-                "epoch/val_accuracy", metrics["val_accuracy"], step=step)
+            mlflow.log_metric("epoch/val_accuracy", metrics["val_accuracy"], step=step)
         if metrics.get("val_loss") is not None:
-            mlflow.log_metric(
-                "epoch/val_loss", metrics["val_loss"], step=step)
+            mlflow.log_metric("epoch/val_loss", metrics["val_loss"], step=step)
         if metrics["training_loss"] is not None:
-            mlflow.log_metric(
-                "epoch/training_loss", metrics["training_loss"], step=step)
-        mlflow.log_metric(
-            "epoch/cumulative_seconds",
-            metrics["cumulative_seconds"], step=step)
+            mlflow.log_metric("epoch/training_loss", metrics["training_loss"], step=step)
+        mlflow.log_metric("epoch/cumulative_seconds", metrics["cumulative_seconds"], step=step)
 
         # One-shot early-stopping summary (only present on the final
         # epoch). Logged as scalar metrics with no step so they appear
         # alongside the other run-level numbers.
         if metrics.get("final_epoch") is not None:
+            mlflow.log_metric("early_stop/final_epoch", float(metrics["final_epoch"]), step=0)
             mlflow.log_metric(
-                "early_stop/final_epoch",
-                float(metrics["final_epoch"]), step=0)
-            mlflow.log_metric(
-                "early_stop/triggered",
-                float(bool(metrics.get("early_stopped"))), step=0)
+                "early_stop/triggered", float(bool(metrics.get("early_stopped"))), step=0
+            )
             if metrics.get("best_val_epoch") is not None:
                 mlflow.log_metric(
-                    "early_stop/best_val_epoch",
-                    float(metrics["best_val_epoch"]), step=0)
+                    "early_stop/best_val_epoch", float(metrics["best_val_epoch"]), step=0
+                )
             if metrics.get("best_val_loss") is not None:
                 mlflow.log_metric(
-                    "early_stop/best_val_loss",
-                    float(metrics["best_val_loss"]), step=0)
+                    "early_stop/best_val_loss", float(metrics["best_val_loss"]), step=0
+                )
 
     def _get_model_name(self):
         """
@@ -2088,34 +2003,29 @@ class MLflowTrainingRunner(TrainingRunner):
         the 'inner' one.
         """
         if self.mlflow_options.model_name is not None:
-
             model_name = self.mlflow_options.model_name
 
         else:
-
             if self.dataset_options.included_labels_csv:
                 as_path = Path(self.dataset_options.included_labels_csv)
-                model_name = f'Include{self.alphanumeric_only_str(as_path.stem)}'
+                model_name = f"Include{self.alphanumeric_only_str(as_path.stem)}"
             elif self.dataset_options.excluded_labels_csv:
                 as_path = Path(self.dataset_options.excluded_labels_csv)
-                model_name = f'Exclude{self.alphanumeric_only_str(as_path.stem)}'
+                model_name = f"Exclude{self.alphanumeric_only_str(as_path.stem)}"
             else:
-                model_name = 'AllLabels'
+                model_name = "AllLabels"
 
             if self.dataset_options.label_rollup_spec_csv:
                 as_path = Path(self.dataset_options.label_rollup_spec_csv)
-                model_name += f'-Rollup{self.alphanumeric_only_str(as_path.stem)}'
+                model_name += f"-Rollup{self.alphanumeric_only_str(as_path.stem)}"
 
             if self.dataset_options.coralnet_sources_csv:
                 as_path = Path(self.dataset_options.coralnet_sources_csv)
-                model_name += f'-{self.alphanumeric_only_str(as_path.stem)}'
+                model_name += f"-{self.alphanumeric_only_str(as_path.stem)}"
 
             if (subsample := self.dataset_options.subsample) is not None:
                 # e.g. -SubStratified400000 or -SubBalanced1770000
-                model_name += (
-                    f'-Sub{subsample.strategy.capitalize()}'
-                    f'{subsample.total_annotations}'
-                )
+                model_name += f"-Sub{subsample.strategy.capitalize()}{subsample.total_annotations}"
 
         # There's a 62 character limit for the 'model package group name'
         # which is built from the model name. For example, it could be the
@@ -2129,7 +2039,7 @@ class MLflowTrainingRunner(TrainingRunner):
         """
         Return a version of s which has the non-alphanumeric chars removed.
         """
-        return ''.join([char for char in s if char.isalnum()])
+        return "".join([char for char in s if char.isalnum()])
 
     def _log_weighting_artifacts(self) -> None:
         """Log per-class weight artifacts and summary metrics gathered by
@@ -2139,11 +2049,11 @@ class MLflowTrainingRunner(TrainingRunner):
         DataFrame with human-readable BA and GF names from the same
         libraries the rest of the runner uses for taxonomy resolution.
         """
-        weighting_log = getattr(self, '_weighting_log', None)
-        if not weighting_log or not weighting_log.get('enabled'):
+        weighting_log = getattr(self, "_weighting_log", None)
+        if not weighting_log or not weighting_log.get("enabled"):
             return
 
-        df = weighting_log['per_class_df'].copy()
+        df = weighting_log["per_class_df"].copy()
 
         # Decorate with BA/GF names. Defensive: if any label fails to
         # parse, leave the name columns blank rather than failing the run.
@@ -2152,28 +2062,39 @@ class MLflowTrainingRunner(TrainingRunner):
 
         def _decorate(row):
             try:
-                ba_id, gf_id = split_ba_gf(row['bagf_id'])
-                ba_name = ba_library.id_to_name(ba_id) if ba_id else ''
-                gf_name = gf_library.id_to_name(gf_id) if gf_id else ''
+                ba_id, gf_id = split_ba_gf(row["bagf_id"])
+                ba_name = ba_library.id_to_name(ba_id) if ba_id else ""
+                gf_name = gf_library.id_to_name(gf_id) if gf_id else ""
             except Exception:
-                ba_id, gf_id, ba_name, gf_name = '', '', '', ''
-            return pd.Series(dict(
-                ba_id=ba_id, gf_id=gf_id,
-                ba_name=ba_name, gf_name=gf_name,
-            ))
+                ba_id, gf_id, ba_name, gf_name = "", "", "", ""
+            return pd.Series(
+                {
+                    "ba_id": ba_id,
+                    "gf_id": gf_id,
+                    "ba_name": ba_name,
+                    "gf_name": gf_name,
+                }
+            )
 
         decorated = df.apply(_decorate, axis=1)
         df = pd.concat([df, decorated], axis=1)
-        df = df[[
-            'bagf_id', 'ba_id', 'ba_name', 'gf_id', 'gf_name',
-            'count', 'weight',
-        ]].sort_values('weight', ascending=False)
+        df = df[
+            [
+                "bagf_id",
+                "ba_id",
+                "ba_name",
+                "gf_id",
+                "gf_name",
+                "count",
+                "weight",
+            ]
+        ].sort_values("weight", ascending=False)
 
-        self.log_dataframe(df, 'weighting/per_class_weights')
+        self.log_dataframe(df, "weighting/per_class_weights")
 
-        summary = weighting_log['summary']
+        summary = weighting_log["summary"]
         for k, v in summary.items():
-            mlflow.log_metric(f'weighting/{k}', float(v), step=0)
+            mlflow.log_metric(f"weighting/{k}", float(v), step=0)
 
     def _log_subsample_audit(self) -> None:
         """Log the per-class audit CSV and a single realized-total metric
@@ -2187,7 +2108,7 @@ class MLflowTrainingRunner(TrainingRunner):
         ``stratification_level``, the same audit covers it without
         changes here.
         """
-        df = getattr(self.dataset, '_subsample_audit_df', None)
+        df = getattr(self.dataset, "_subsample_audit_df", None)
         if df is None:
             return
         # Decorate with human-readable names so the CSV is self-contained.
@@ -2196,28 +2117,37 @@ class MLflowTrainingRunner(TrainingRunner):
 
         def _decorate(row):
             try:
-                ba_name = ba_library.id_to_name(row['benthic_attribute_id']) \
-                    if row['benthic_attribute_id'] else ''
-                gf_name = gf_library.id_to_name(row['growth_form_id']) \
-                    if row['growth_form_id'] else ''
+                ba_name = (
+                    ba_library.id_to_name(row["benthic_attribute_id"])
+                    if row["benthic_attribute_id"]
+                    else ""
+                )
+                gf_name = (
+                    gf_library.id_to_name(row["growth_form_id"]) if row["growth_form_id"] else ""
+                )
             except Exception:
-                ba_name, gf_name = '', ''
-            return pd.Series({'ba_name': ba_name, 'gf_name': gf_name})
+                ba_name, gf_name = "", ""
+            return pd.Series({"ba_name": ba_name, "gf_name": gf_name})
 
         if not df.empty:
             decorated = df.apply(_decorate, axis=1)
             out = pd.concat([df, decorated], axis=1)
-            out = out[[
-                'benthic_attribute_id', 'ba_name',
-                'growth_form_id', 'gf_name',
-                'pre_count', 'target_n', 'realized_n',
-            ]].sort_values('realized_n', ascending=False)
-            self.log_dataframe(out, 'subsample/per_class_counts')
+            out = out[
+                [
+                    "benthic_attribute_id",
+                    "ba_name",
+                    "growth_form_id",
+                    "gf_name",
+                    "pre_count",
+                    "target_n",
+                    "realized_n",
+                ]
+            ].sort_values("realized_n", ascending=False)
+            self.log_dataframe(out, "subsample/per_class_counts")
 
-        realized = getattr(self.dataset, '_subsample_realized_total', None)
+        realized = getattr(self.dataset, "_subsample_realized_total", None)
         if realized is not None:
-            mlflow.log_metric('subsample/realized_total', float(realized),
-                              step=0)
+            mlflow.log_metric("subsample/realized_total", float(realized), step=0)
 
     @staticmethod
     def _existing_ancestor(path: str) -> str:
@@ -2226,20 +2156,20 @@ class MLflowTrainingRunner(TrainingRunner):
         while not os.path.exists(p):
             parent = os.path.dirname(p)
             if parent == p:
-                return '/'
+                return "/"
             p = parent
         return p
 
     def log_system_specs(self):
         mlflow.log_dict(
-            dict(
-                total_ram_gb=psutil.virtual_memory().total / 10**9,
-                free_storage_gb=psutil.disk_usage(
-                    self._existing_ancestor(
-                        settings.feature_cache_dir or '/')
-                ).free / 10**9,
-            ),
-            'system_specs.yaml',
+            {
+                "total_ram_gb": psutil.virtual_memory().total / 10**9,
+                "free_storage_gb": psutil.disk_usage(
+                    self._existing_ancestor(settings.feature_cache_dir or "/")
+                ).free
+                / 10**9,
+            },
+            "system_specs.yaml",
         )
 
     def log_dataset_artifacts(self):
@@ -2250,63 +2180,57 @@ class MLflowTrainingRunner(TrainingRunner):
 
         artifacts = self.dataset.artifacts
 
-        mlflow.log_text(
-            self.dataset.cn_source_filter.csv_text,
-            'coralnet_sources_included.csv')
+        mlflow.log_text(self.dataset.cn_source_filter.csv_text, "coralnet_sources_included.csv")
 
         if self.dataset.label_filter.inclusion:
-            csv_filename = 'labels_included.csv'
+            csv_filename = "labels_included.csv"
         else:
-            csv_filename = 'labels_excluded.csv'
-        mlflow.log_text(
-            self.dataset.label_filter.csv_text, csv_filename)
+            csv_filename = "labels_excluded.csv"
+        mlflow.log_text(self.dataset.label_filter.csv_text, csv_filename)
 
-        mlflow.log_text(
-            self.dataset.rollup_spec.csv_text, 'rollup_spec.csv')
+        mlflow.log_text(self.dataset.rollup_spec.csv_text, "rollup_spec.csv")
 
         # Number of images and annotations from each CN source and from
         # MERMAID.
         # First, before filtering (this is what's present in S3).
         # https://pandas.pydata.org/docs/reference/api/pandas.concat.html
         self.log_dataframe(
-            pd.concat([
-                artifacts.mermaid_project_stats,
-                artifacts.coralnet_project_stats,
-            ]),
-            'project_stats_raw')
+            pd.concat(
+                [
+                    artifacts.mermaid_project_stats,
+                    artifacts.coralnet_project_stats,
+                ]
+            ),
+            "project_stats_raw",
+        )
         # And here, after filtering (this is what training actually gets).
         self.log_dataframe(
-            self.dataset.compute_project_stats(has_training_sets=True),
-            'project_stats_train_data')
+            self.dataset.compute_project_stats(has_training_sets=True), "project_stats_train_data"
+        )
 
-        mlflow.log_dict(
-            artifacts.train_summary_stats, 'train_summary.yaml')
+        mlflow.log_dict(artifacts.train_summary_stats, "train_summary.yaml")
 
-        self.log_dataframe(artifacts.ba_counts, 'ba_counts')
-        self.log_dataframe(artifacts.bagf_counts, 'bagf_counts')
+        self.log_dataframe(artifacts.ba_counts, "ba_counts")
+        self.log_dataframe(artifacts.bagf_counts, "bagf_counts")
 
         if not self.dataset.cn_source_filter.is_empty():
             # These only apply if CoralNet data is included.
-            self.log_dataframe(
-                artifacts.coralnet_label_mapping,
-                'coralnet_label_mapping')
-            self.log_dataframe(
-                artifacts.unmapped_labels,
-                'unmapped_labels')
+            self.log_dataframe(artifacts.coralnet_label_mapping, "coralnet_label_mapping")
+            self.log_dataframe(artifacts.unmapped_labels, "unmapped_labels")
 
         # Log extra annotations, if specified.
         if self.mlflow_options.extra_annotations_to_log is not None:
             log_spec = self.mlflow_options.extra_annotations_to_log.lower()
             df = self.dataset.get_annotations(log_spec)
 
-            self.log_dataframe(df, f'annotations_{log_spec}')
+            self.log_dataframe(df, f"annotations_{log_spec}")
 
         # Always log the validation split annotations so others can
         # independently re-evaluate the model.
         val_annotations_df = self.dataset.duck_conn.execute(
             "SELECT * FROM annotations WHERE training_set = 'val'"
         ).fetch_df()
-        self.log_dataframe(val_annotations_df, 'annotations_val')
+        self.log_dataframe(val_annotations_df, "annotations_val")
 
     def log_dataframe(self, df, filestem):
         """

--- a/mermaid_classifier/pyspacer/trainer.py
+++ b/mermaid_classifier/pyspacer/trainer.py
@@ -11,8 +11,8 @@ from logging import getLogger
 
 import numpy as np
 from sklearn.calibration import CalibratedClassifierCV, _fit_calibrator
-from sklearn.metrics import accuracy_score, log_loss as sklearn_log_loss
-
+from sklearn.metrics import accuracy_score
+from sklearn.metrics import log_loss as sklearn_log_loss
 from spacer.data_classes import ImageLabels, ValResults
 from spacer.messages import TrainClassifierReturnMsg
 from spacer.train_classifier import ClassifierTrainer
@@ -29,12 +29,11 @@ def _log_entry_and_exit(name: str):
     'Entering: <name>' on enter, 'Exiting: <name> after <s> seconds.'
     on exit, timing the body."""
     start_time = time.time()
-    logger.debug('Entering: %s', name)
+    logger.debug("Entering: %s", name)
     try:
         yield
     finally:
-        logger.debug(
-            'Exiting: %s after %f seconds.', name, time.time() - start_time)
+        logger.debug("Exiting: %s after %f seconds.", name, time.time() - start_time)
 
 
 class MermaidTrainer(ClassifierTrainer):
@@ -56,11 +55,9 @@ class MermaidTrainer(ClassifierTrainer):
         class_weight: dict | None = None,
         early_stopping_patience: int | None = None,
     ):
-        if (early_stopping_patience is not None
-                and early_stopping_patience < 1):
+        if early_stopping_patience is not None and early_stopping_patience < 1:
             raise ValueError(
-                f"early_stopping_patience must be >= 1 or None,"
-                f" got {early_stopping_patience!r}"
+                f"early_stopping_patience must be >= 1 or None, got {early_stopping_patience!r}"
             )
         self.batch_size = batch_size
         self.on_epoch_end = on_epoch_end
@@ -83,21 +80,23 @@ class MermaidTrainer(ClassifierTrainer):
         logger.debug(
             f"Unique classes:"
             f" Train + Ref = {len(labels.ref.classes_set)},"
-            f" Val = {len(labels.val.classes_set)}")
+            f" Val = {len(labels.val.classes_set)}"
+        )
         logger.debug(
             f"Label count:"
             f" Train = {labels.train.label_count},"
             f" Ref = {labels.ref.label_count},"
             f" Val = {labels.val.label_count},"
-            f" Total = {labels.label_count}")
+            f" Total = {labels.label_count}"
+        )
         logger.debug(
             f"Data sets:"
             f" Train = {len(labels.train)} images,"
             f" {labels.train.label_count} labels;"
             f" Ref = {len(labels.ref)} images,"
-            f" {labels.ref.label_count} labels")
-        logger.debug(
-            f"Batch size: {self.batch_size} labels")
+            f" {labels.ref.label_count} labels"
+        )
+        logger.debug(f"Batch size: {self.batch_size} labels")
 
         classes_list = list(labels.ref.classes_set)
 
@@ -119,11 +118,11 @@ class MermaidTrainer(ClassifierTrainer):
             # Early-stopping bookkeeping. All three remain None when
             # early_stopping_patience is None, so the no-ES path adds
             # zero overhead.
-            best_val_loss: float = float('inf')
+            best_val_loss: float = float("inf")
             best_clf_snapshot = None
             best_epoch_idx: int | None = None
             epochs_since_best: int = 0
-            stop_reason: str = 'budget_exhausted'
+            stop_reason: str = "budget_exhausted"
 
             for epoch in range(nbr_epochs):
                 # Training: load batches from disk, partial_fit, then
@@ -137,8 +136,7 @@ class MermaidTrainer(ClassifierTrainer):
                 # Ref accuracy: stream ref features from disk in batches.
                 # Only predictions (tiny) accumulate, not feature arrays.
                 # Training batch data is no longer in memory at this point.
-                ref_accs.append(
-                    self._calc_acc_batched(clf, labels.ref))
+                ref_accs.append(self._calc_acc_batched(clf, labels.ref))
                 logger.debug(f"Epoch {epoch}, acc: {ref_accs[-1]}")
 
                 # Validation accuracy + log_loss: streamed in batches,
@@ -154,9 +152,9 @@ class MermaidTrainer(ClassifierTrainer):
                 # trend analysis -- we are watching the *change* across
                 # epochs, not the absolute value.
                 val_acc, val_loss = self._calc_acc_and_log_loss_batched(
-                    clf, labels.val, classes_list)
-                logger.debug(
-                    f"Epoch {epoch}, val_acc: {val_acc}, val_loss: {val_loss}")
+                    clf, labels.val, classes_list
+                )
+                logger.debug(f"Epoch {epoch}, val_acc: {val_acc}, val_loss: {val_loss}")
 
                 # Early-stopping bookkeeping (no-op if patience is None).
                 if self.early_stopping_patience is not None:
@@ -174,22 +172,19 @@ class MermaidTrainer(ClassifierTrainer):
 
                 # Determine if this is the final epoch we will run.
                 # Used to decorate the callback with stop-summary fields.
-                will_stop_after_this = (
-                    epoch == nbr_epochs - 1
-                    or (self.early_stopping_patience is not None
-                        and epochs_since_best
-                        >= self.early_stopping_patience)
+                will_stop_after_this = epoch == nbr_epochs - 1 or (
+                    self.early_stopping_patience is not None
+                    and epochs_since_best >= self.early_stopping_patience
                 )
 
                 if self.on_epoch_end is not None:
-                    loss_curve = getattr(clf, 'loss_curve_', [None])
+                    loss_curve = getattr(clf, "loss_curve_", [None])
                     cb_metrics: dict = {
                         "epoch": epoch,
                         "ref_accuracy": ref_accs[-1],
                         "val_accuracy": val_acc,
                         "val_loss": val_loss,
-                        "training_loss":
-                            loss_curve[-1] if loss_curve else None,
+                        "training_loss": loss_curve[-1] if loss_curve else None,
                         "cumulative_seconds": time.time() - t0,
                     }
                     if will_stop_after_this:
@@ -199,21 +194,20 @@ class MermaidTrainer(ClassifierTrainer):
                         # non-final epochs is intentional.
                         early_stopped = (
                             self.early_stopping_patience is not None
-                            and epochs_since_best
-                            >= self.early_stopping_patience
+                            and epochs_since_best >= self.early_stopping_patience
                         )
                         cb_metrics["final_epoch"] = epoch + 1
                         cb_metrics["early_stopped"] = early_stopped
                         if best_epoch_idx is not None:
-                            cb_metrics["best_val_epoch"] = (
-                                best_epoch_idx + 1)
+                            cb_metrics["best_val_epoch"] = best_epoch_idx + 1
                             cb_metrics["best_val_loss"] = best_val_loss
                     self.on_epoch_end(cb_metrics)
 
-                if (self.early_stopping_patience is not None
-                        and epochs_since_best
-                        >= self.early_stopping_patience):
-                    stop_reason = 'early_stopping'
+                if (
+                    self.early_stopping_patience is not None
+                    and epochs_since_best >= self.early_stopping_patience
+                ):
+                    stop_reason = "early_stopping"
                     logger.info(
                         f"Early stopping at epoch {epoch + 1}:"
                         f" val_loss has not improved for"
@@ -230,9 +224,11 @@ class MermaidTrainer(ClassifierTrainer):
             # still uses the best-val_loss snapshot rather than the
             # last-epoch one. When patience is None we never took a
             # snapshot, and clf is whatever the last epoch produced.
-            if (self.early_stopping_patience is not None
-                    and best_clf_snapshot is not None
-                    and best_epoch_idx != epoch):
+            if (
+                self.early_stopping_patience is not None
+                and best_clf_snapshot is not None
+                and best_epoch_idx != epoch
+            ):
                 logger.info(
                     f"Restoring classifier from epoch"
                     f" {(best_epoch_idx or 0) + 1}"
@@ -243,16 +239,12 @@ class MermaidTrainer(ClassifierTrainer):
             # Stash a small summary on self for runner-side logging
             # (read by MLflowTrainingRunner._log_early_stop_info).
             self._early_stop_info = {
-                'enabled': self.early_stopping_patience is not None,
-                'patience': self.early_stopping_patience,
-                'stop_reason': stop_reason,
-                'final_epoch': epoch + 1,
-                'best_val_epoch': (
-                    best_epoch_idx + 1
-                    if best_epoch_idx is not None else None),
-                'best_val_loss': (
-                    best_val_loss
-                    if best_val_loss != float('inf') else None),
+                "enabled": self.early_stopping_patience is not None,
+                "patience": self.early_stopping_patience,
+                "stop_reason": stop_reason,
+                "final_epoch": epoch + 1,
+                "best_val_epoch": (best_epoch_idx + 1 if best_epoch_idx is not None else None),
+                "best_val_loss": (best_val_loss if best_val_loss != float("inf") else None),
             }
 
         # Calibration: stream ref data in batches — avoids loading full feature
@@ -264,8 +256,7 @@ class MermaidTrainer(ClassifierTrainer):
         classes = clf_calibrated.classes_.tolist()
 
         # Evaluate new classifier on validation set
-        val_gts, val_ests, val_scores = evaluate_classifier(
-            clf_calibrated, labels.val)
+        val_gts, val_ests, val_scores = evaluate_classifier(clf_calibrated, labels.val)
 
         # Evaluate previous classifiers on validation set
         pc_accs = []
@@ -355,8 +346,7 @@ class MermaidTrainer(ClassifierTrainer):
         """
         all_preds, all_y = [], []
 
-        for x_batch, y_batch in ref_labels.load_data_in_batches(
-                batch_size=self.batch_size):
+        for x_batch, y_batch in ref_labels.load_data_in_batches(batch_size=self.batch_size):
             x_arr = np.array(x_batch)
             y_arr = np.array(y_batch)
 
@@ -372,16 +362,14 @@ class MermaidTrainer(ClassifierTrainer):
             all_y.append(y_arr)
 
         predictions = np.vstack(all_preds)  # (N, K) multiclass; (N, 1) binary
-        y = np.concatenate(all_y)           # (N,)
+        y = np.concatenate(all_y)  # (N,)
 
         # _fit_calibrator is a private sklearn API used here for memory
         # efficiency — it calibrates from pre-computed predictions instead of
         # re-running predict_proba on the full dataset at once. If an sklearn
         # upgrade breaks this, it will fail at training time (not inference).
         # The serialized model format is identical to the public .fit() API.
-        calibrated_inner = _fit_calibrator(
-            clf, predictions, y, clf.classes_, method="sigmoid"
-        )
+        calibrated_inner = _fit_calibrator(clf, predictions, y, clf.classes_, method="sigmoid")
 
         # Construct CalibratedClassifierCV without calling .fit().
         # Sets all attributes that spacer/storage.py validates:
@@ -397,6 +385,6 @@ class MermaidTrainer(ClassifierTrainer):
 
     def serialize(self) -> dict:
         data = super().serialize()
-        data['batch_size'] = self.batch_size
+        data["batch_size"] = self.batch_size
         # on_epoch_end is not JSON-serializable; excluded
         return data

--- a/mermaid_classifier/pyspacer/trainer.py
+++ b/mermaid_classifier/pyspacer/trainer.py
@@ -8,13 +8,17 @@ import time
 from collections.abc import Callable
 from contextlib import contextmanager
 from logging import getLogger
+from typing import Any
 
 import numpy as np
-from sklearn.calibration import CalibratedClassifierCV, _fit_calibrator
+from sklearn.calibration import (
+    CalibratedClassifierCV,
+    _fit_calibrator,  # pyright: ignore[reportPrivateUsage]  # private sklearn API used for memory-efficient batched calibration
+)
 from sklearn.metrics import accuracy_score
 from sklearn.metrics import log_loss as sklearn_log_loss
 from spacer.data_classes import ImageLabels, ValResults
-from spacer.messages import TrainClassifierReturnMsg
+from spacer.messages import TrainClassifierReturnMsg, TrainingTaskLabels
 from spacer.train_classifier import ClassifierTrainer
 from spacer.train_utils import evaluate_classifier
 
@@ -51,8 +55,8 @@ class MermaidTrainer(ClassifierTrainer):
     def __init__(
         self,
         batch_size: int,
-        on_epoch_end: Callable[[dict], None] | None = None,
-        class_weight: dict | None = None,
+        on_epoch_end: Callable[[dict[str, Any]], None] | None = None,
+        class_weight: dict[str, float] | None = None,
         early_stopping_patience: int | None = None,
     ):
         if early_stopping_patience is not None and early_stopping_patience < 1:
@@ -74,9 +78,15 @@ class MermaidTrainer(ClassifierTrainer):
         # Populated by __call__; readable by the runner for MLflow
         # logging. Pre-initialized so the runner never hits an
         # AttributeError when patience is None.
-        self._early_stop_info: dict | None = None
+        self._early_stop_info: dict[str, Any] | None = None
 
-    def __call__(self, labels, nbr_epochs, pc_models):
+    def __call__(  # pyright: ignore[reportIncompatibleMethodOverride]  # absorbs extra pyspacer params (e.g. the positional trainer arg) via **_kwargs
+        self,
+        labels: TrainingTaskLabels,
+        nbr_epochs: int,
+        pc_models: list[CalibratedClassifierCV],
+        **_kwargs: Any,
+    ) -> tuple[CalibratedClassifierCV, ValResults, TrainClassifierReturnMsg]:
         logger.debug(
             f"Unique classes:"
             f" Train + Ref = {len(labels.ref.classes_set)},"
@@ -123,6 +133,7 @@ class MermaidTrainer(ClassifierTrainer):
             best_epoch_idx: int | None = None
             epochs_since_best: int = 0
             stop_reason: str = "budget_exhausted"
+            epoch: int = 0
 
             for epoch in range(nbr_epochs):
                 # Training: load batches from disk, partial_fit, then
@@ -179,7 +190,7 @@ class MermaidTrainer(ClassifierTrainer):
 
                 if self.on_epoch_end is not None:
                     loss_curve = getattr(clf, "loss_curve_", [None])
-                    cb_metrics: dict = {
+                    cb_metrics: dict[str, Any] = {
                         "epoch": epoch,
                         "ref_accuracy": ref_accs[-1],
                         "val_accuracy": val_acc,
@@ -253,7 +264,8 @@ class MermaidTrainer(ClassifierTrainer):
         with _log_entry_and_exit("calibration"):
             clf_calibrated = self._calibrate_in_batches(clf, labels.ref)
 
-        classes = clf_calibrated.classes_.tolist()
+        assert clf_calibrated.classes_ is not None  # set by _calibrate_in_batches before returning
+        classes = clf_calibrated.classes_.tolist()  # pyright: ignore[reportUnknownMemberType,reportAttributeAccessIssue]  # sklearn stubs type classes_ as a union that lacks .tolist()
 
         # Evaluate new classifier on validation set
         val_gts, val_ests, val_scores = evaluate_classifier(clf_calibrated, labels.val)
@@ -280,7 +292,7 @@ class MermaidTrainer(ClassifierTrainer):
 
         return clf_calibrated, val_results, return_message
 
-    def _calc_acc_batched(self, clf, labels: ImageLabels) -> float:
+    def _calc_acc_batched(self, clf: TorchMLPClassifier, labels: ImageLabels) -> float:
         """Compute accuracy by streaming features from disk in batches,
         avoiding loading the full dataset into memory.
 
@@ -296,9 +308,9 @@ class MermaidTrainer(ClassifierTrainer):
 
     def _calc_acc_and_log_loss_batched(
         self,
-        clf,
+        clf: TorchMLPClassifier,
         labels: ImageLabels,
-        classes_list: list,
+        classes_list: list[Any],
     ) -> tuple[float, float]:
         """Compute accuracy AND log_loss in a single streaming pass.
 
@@ -313,8 +325,8 @@ class MermaidTrainer(ClassifierTrainer):
         eval set still register as zero-probability columns; matches
         the convention used by sklearn.metrics.log_loss(labels=...).
         """
-        gt: list = []
-        all_proba: list = []
+        gt: list[Any] = []
+        all_proba: list[Any] = []
         for x, y in labels.load_data_in_batches(batch_size=self.batch_size):
             all_proba.append(clf.predict_proba(x))
             gt.extend(y)
@@ -331,7 +343,7 @@ class MermaidTrainer(ClassifierTrainer):
 
     def _calibrate_in_batches(
         self,
-        clf,
+        clf: TorchMLPClassifier,
         ref_labels: ImageLabels,
     ) -> CalibratedClassifierCV:
         """
@@ -383,7 +395,7 @@ class MermaidTrainer(ClassifierTrainer):
 
         return wrapper
 
-    def serialize(self) -> dict:
+    def serialize(self) -> dict[str, Any]:
         data = super().serialize()
         data["batch_size"] = self.batch_size
         # on_epoch_end is not JSON-serializable; excluded

--- a/mermaid_classifier/pyspacer/utils.py
+++ b/mermaid_classifier/pyspacer/utils.py
@@ -1,5 +1,5 @@
-from datetime import datetime, timedelta
 import logging
+from datetime import datetime, timedelta
 
 import mlflow
 
@@ -11,34 +11,36 @@ def logging_config_for_script(name):
     Call this to set up a logging config that prints info messages,
     and file-logs info and debug messages.
     """
-    logging.config.dictConfig({
-        'version': 1,
-        'formatters': {
-            'default': {
-                'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            }
-        },
-        'handlers': {
-            'console': {
-                'level': 'INFO',
-                'class': 'logging.StreamHandler',
-                'stream': 'ext://sys.stdout',
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "default": {
+                    "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                }
             },
-            'file': {
-                'level': 'DEBUG',
-                'class': 'logging.FileHandler',
-                'filename': f'{name}.log',
-                # Clear logs of the previous run
-                'mode': 'w',
+            "handlers": {
+                "console": {
+                    "level": "INFO",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                },
+                "file": {
+                    "level": "DEBUG",
+                    "class": "logging.FileHandler",
+                    "filename": f"{name}.log",
+                    # Clear logs of the previous run
+                    "mode": "w",
+                },
             },
-        },
-        'loggers': {
-            name: {
-                'handlers': ['console', 'file'],
-                'level': 'DEBUG',
-            }
-        },
-    })
+            "loggers": {
+                name: {
+                    "handlers": ["console", "file"],
+                    "level": "DEBUG",
+                }
+            },
+        }
+    )
     return logging.getLogger(name)
 
 
@@ -58,10 +60,10 @@ def mlflow_connect(tracking_uri: str | None = None) -> timedelta:
             raise RuntimeError(
                 "Could not connect to the MLflow tracking server."
                 " Is the tracking server up and running?"
-            )
+            ) from e
         # If it's some other kind of MlflowException, just re-raise
         # for debugging purposes.
-        raise e
+        raise
 
     time_after_connect = datetime.now()
     # Return the time taken to connect.

--- a/mermaid_classifier/pyspacer/utils.py
+++ b/mermaid_classifier/pyspacer/utils.py
@@ -1,12 +1,14 @@
 import logging
+import logging.config
 from datetime import datetime, timedelta
 
 import mlflow
+from mlflow.exceptions import MlflowException
 
 from mermaid_classifier.pyspacer.settings import settings
 
 
-def logging_config_for_script(name):
+def logging_config_for_script(name: str) -> logging.Logger:
     """
     Call this to set up a logging config that prints info messages,
     and file-logs info and debug messages.
@@ -46,13 +48,14 @@ def logging_config_for_script(name):
 
 def mlflow_connect(tracking_uri: str | None = None) -> timedelta:
     uri = tracking_uri or settings.mlflow_tracking_server
-    mlflow.set_tracking_uri(uri=uri)
+    if uri is not None:
+        mlflow.set_tracking_uri(uri=uri)
 
     try:
         # Do something to test the server connection.
         time_before_connect = datetime.now()
         mlflow.search_experiments(max_results=1)
-    except mlflow.exceptions.MlflowException as e:
+    except MlflowException as e:
         # Note that this may take a long time to reach
         # unless you set MLFLOW_HTTP_REQUEST_MAX_RETRIES to
         # a low number.

--- a/mermaid_classifier/sagemaker/config.py
+++ b/mermaid_classifier/sagemaker/config.py
@@ -42,14 +42,14 @@ class SubsampleConfig(BaseModel):
 
     @field_validator("total_annotations")
     @classmethod
-    def _positive_total(cls, v):
+    def _positive_total(cls, v: int | None) -> int | None:
         if v is not None and v <= 0:
             raise ValueError("total_annotations must be > 0 or None")
         return v
 
     @field_validator("min_per_class")
     @classmethod
-    def _non_negative_floor(cls, v):
+    def _non_negative_floor(cls, v: int) -> int:
         if v < 0:
             raise ValueError("min_per_class must be >= 0")
         return v
@@ -63,7 +63,7 @@ class WeightingConfig(BaseModel):
 
     @field_validator("weight_ratio_cap")
     @classmethod
-    def _cap_at_least_one(cls, v):
+    def _cap_at_least_one(cls, v: float | None) -> float | None:
         if v is not None and v < 1.0:
             raise ValueError("weight_ratio_cap must be None or >= 1.0")
         return v
@@ -202,17 +202,17 @@ class TrainingRunConfig(BaseModel):
                 weight_ratio_cap=d.weighting.weight_ratio_cap,
             )
 
-        def _resolve(p):
+        def _resolve(p: Path | None) -> str | None:
             return None if p is None else str(p)
 
         dataset_options = DatasetOptions(
             include_mermaid=d.include_mermaid,
-            coralnet_sources_csv=_resolve(d.coralnet_sources_csv_path(config_dir)),
+            coralnet_sources_csv=_resolve(d.coralnet_sources_csv_path(config_dir)),  # pyright: ignore[reportArgumentType]  # DatasetOptions accepts str|None
             drop_growthforms=d.drop_growthforms,
-            label_rollup_spec_csv=_resolve(d.label_rollup_spec_csv_path(config_dir)),
-            included_labels_csv=_resolve(d.included_labels_csv_path(config_dir)),
-            excluded_labels_csv=_resolve(d.excluded_labels_csv_path(config_dir)),
-            ref_val_ratios=tuple(d.ref_val_ratios),
+            label_rollup_spec_csv=_resolve(d.label_rollup_spec_csv_path(config_dir)),  # pyright: ignore[reportArgumentType]  # DatasetOptions accepts str|None
+            included_labels_csv=_resolve(d.included_labels_csv_path(config_dir)),  # pyright: ignore[reportArgumentType]  # DatasetOptions accepts str|None
+            excluded_labels_csv=_resolve(d.excluded_labels_csv_path(config_dir)),  # pyright: ignore[reportArgumentType]  # DatasetOptions accepts str|None
+            ref_val_ratios=tuple(d.ref_val_ratios),  # pyright: ignore[reportArgumentType]  # runtime tuple[float,float] matches DatasetOptions
             subsample=subsample,
             weighting=weighting,
         )

--- a/mermaid_classifier/sagemaker/config.py
+++ b/mermaid_classifier/sagemaker/config.py
@@ -11,6 +11,7 @@ and ONLY THEN import pyspacer.
 `build_options()` performs the heavy imports lazily inside the method
 so callers can sequence env-var application correctly.
 """
+
 from __future__ import annotations
 
 import re
@@ -19,7 +20,6 @@ from typing import Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator
-
 
 # Mirrors the MLflow registered-model name regex enforced by the
 # SageMaker MLflow registry. Validating at config load fails the job
@@ -87,20 +87,16 @@ class DatasetConfig(BaseModel):
     weighting: WeightingConfig | None = None
 
     def coralnet_sources_csv_path(self, base: Path) -> Path | None:
-        return None if self.coralnet_sources_csv is None \
-            else base / self.coralnet_sources_csv
+        return None if self.coralnet_sources_csv is None else base / self.coralnet_sources_csv
 
     def label_rollup_spec_csv_path(self, base: Path) -> Path | None:
-        return None if self.label_rollup_spec_csv is None \
-            else base / self.label_rollup_spec_csv
+        return None if self.label_rollup_spec_csv is None else base / self.label_rollup_spec_csv
 
     def included_labels_csv_path(self, base: Path) -> Path | None:
-        return None if self.included_labels_csv is None \
-            else base / self.included_labels_csv
+        return None if self.included_labels_csv is None else base / self.included_labels_csv
 
     def excluded_labels_csv_path(self, base: Path) -> Path | None:
-        return None if self.excluded_labels_csv is None \
-            else base / self.excluded_labels_csv
+        return None if self.excluded_labels_csv is None else base / self.excluded_labels_csv
 
 
 class TrainingConfig(BaseModel):
@@ -128,9 +124,7 @@ class MLflowConfig(BaseModel):
             return v
         if not _MLFLOW_MODEL_NAME_RE.fullmatch(v):
             bad = sorted({c for c in v if not (c.isalnum() or c == "-")})
-            disallowed = (
-                f" Disallowed characters in value: {bad!r}." if bad else ""
-            )
+            disallowed = f" Disallowed characters in value: {bad!r}." if bad else ""
             raise ValueError(
                 f"model_name {v!r} is not a legal MLflow registered-model "
                 f"name. Required pattern: "
@@ -145,6 +139,7 @@ class MLflowConfig(BaseModel):
 
 class TrainingRunConfig(BaseModel):
     """Top-level schema for `training_config.yaml`."""
+
     model_config = ConfigDict(extra="forbid")
 
     dataset: DatasetConfig
@@ -155,7 +150,7 @@ class TrainingRunConfig(BaseModel):
     env: dict[str, str] = Field(default_factory=dict)
 
     @classmethod
-    def from_yaml_path(cls, path: str | Path) -> "TrainingRunConfig":
+    def from_yaml_path(cls, path: str | Path) -> TrainingRunConfig:
         text = Path(path).read_text()
         raw = yaml.safe_load(text) or {}
         return cls.model_validate(raw)
@@ -166,6 +161,7 @@ class TrainingRunConfig(BaseModel):
         Call this BEFORE importing mermaid_classifier.pyspacer.*.
         """
         import os
+
         for key, value in self.env.items():
             os.environ[key] = str(value)
 
@@ -180,12 +176,14 @@ class TrainingRunConfig(BaseModel):
         (DatasetOptions, TrainingOptions, MLflowOptions)
         """
         from mermaid_classifier.pyspacer.train import (
-            DatasetOptions, MLflowOptions, TrainingOptions,
+            DatasetOptions,
+            MLflowOptions,
+            TrainingOptions,
         )
-        from mermaid_classifier.training.subsample import SubsampleOptions
         from mermaid_classifier.training.sample_weighting import (
             SampleWeightingOptions,
         )
+        from mermaid_classifier.training.subsample import SubsampleOptions
 
         d = self.dataset
 
@@ -209,15 +207,11 @@ class TrainingRunConfig(BaseModel):
 
         dataset_options = DatasetOptions(
             include_mermaid=d.include_mermaid,
-            coralnet_sources_csv=_resolve(
-                d.coralnet_sources_csv_path(config_dir)),
+            coralnet_sources_csv=_resolve(d.coralnet_sources_csv_path(config_dir)),
             drop_growthforms=d.drop_growthforms,
-            label_rollup_spec_csv=_resolve(
-                d.label_rollup_spec_csv_path(config_dir)),
-            included_labels_csv=_resolve(
-                d.included_labels_csv_path(config_dir)),
-            excluded_labels_csv=_resolve(
-                d.excluded_labels_csv_path(config_dir)),
+            label_rollup_spec_csv=_resolve(d.label_rollup_spec_csv_path(config_dir)),
+            included_labels_csv=_resolve(d.included_labels_csv_path(config_dir)),
+            excluded_labels_csv=_resolve(d.excluded_labels_csv_path(config_dir)),
             ref_val_ratios=tuple(d.ref_val_ratios),
             subsample=subsample,
             weighting=weighting,

--- a/mermaid_classifier/sagemaker/launcher_config.py
+++ b/mermaid_classifier/sagemaker/launcher_config.py
@@ -10,6 +10,7 @@ config.py). Both schemas read the same YAML file independently with
 See `mermaid-api/iac/sagemaker-launcher-convention.md` for the schema
 authority.
 """
+
 from __future__ import annotations
 
 from typing import Literal
@@ -106,7 +107,9 @@ def parse_run_config(
     data = yaml.safe_load(yaml_text)
     if not isinstance(data, dict):
         from pydantic import ValidationError
+
         raise ValidationError.from_exception_data(
-            "RunConfig", [{"type": "model_type", "loc": (), "input": data}])
+            "RunConfig", [{"type": "model_type", "loc": (), "input": data}]
+        )
     model = RunConfig if strict else _LooseRunConfig
     return model.model_validate(data)

--- a/mermaid_classifier/training/sample_weighting/effective_number.py
+++ b/mermaid_classifier/training/sample_weighting/effective_number.py
@@ -23,12 +23,12 @@ the natural extension if needed — bump this constant or thread it through
 This strategy ignores the BA hierarchy and the GF axis; the BA+GF combo
 string is treated as an opaque class label.
 """
+
 from __future__ import annotations
 
 from mermaid_classifier.training.sample_weighting.options import (
     SampleWeightingOptions,
 )
-
 
 # Default per Cui et al. 2019 — works well for moderate-to-high imbalance.
 # Bump toward 0.99999 for stronger weighting on rare classes.
@@ -55,17 +55,14 @@ def compute_class_weights(
     weights: dict[str, float] = {}
     for label, count in class_counts.items():
         n = max(int(count), 1)
-        effective_n = (1.0 - BETA ** n) / (1.0 - BETA)
+        effective_n = (1.0 - BETA**n) / (1.0 - BETA)
         weights[label] = 1.0 / max(effective_n, 1e-12)
 
     # The formula above is always positive; assert the contract the
     # consumer (CrossEntropyLoss weight tensor) relies on.
     for label, weight in weights.items():
         if weight <= 0:
-            raise RuntimeError(
-                f"Non-positive weight {weight!r} computed for class"
-                f" {label!r}."
-            )
+            raise RuntimeError(f"Non-positive weight {weight!r} computed for class {label!r}.")
 
     # Apply the optional max:min ratio cap.
     cap = options.weight_ratio_cap

--- a/mermaid_classifier/training/sample_weighting/options.py
+++ b/mermaid_classifier/training/sample_weighting/options.py
@@ -1,4 +1,5 @@
 """SampleWeightingOptions dataclass with eager validation."""
+
 from __future__ import annotations
 
 import dataclasses
@@ -28,8 +29,7 @@ class SampleWeightingOptions:
     def __post_init__(self) -> None:
         if self.weight_ratio_cap is not None and self.weight_ratio_cap < 1.0:
             raise ValueError(
-                f"weight_ratio_cap must be None or >= 1.0,"
-                f" got {self.weight_ratio_cap!r}"
+                f"weight_ratio_cap must be None or >= 1.0, got {self.weight_ratio_cap!r}"
             )
 
     def to_log_dict(self) -> dict[str, object]:

--- a/mermaid_classifier/training/subsample/__init__.py
+++ b/mermaid_classifier/training/subsample/__init__.py
@@ -27,6 +27,7 @@ Extension points (see options.py and registry.py for details):
   add an ``oversample`` field to ``SubsampleOptions`` and a second
   SQL pass when that becomes a requirement.
 """
+
 from mermaid_classifier.training.subsample.options import SubsampleOptions
 from mermaid_classifier.training.subsample.registry import (
     SUBSAMPLE_STRATEGIES,

--- a/mermaid_classifier/training/subsample/options.py
+++ b/mermaid_classifier/training/subsample/options.py
@@ -25,10 +25,10 @@ Adding a new strategy is a two-step process:
 
 The pipeline (``TrainingDataset._apply_subsample``) doesn't change.
 """
+
 from __future__ import annotations
 
 import dataclasses
-
 
 # Authoritative list of strategy names. Kept in this module so it can
 # be imported without touching the registry (avoids circular imports
@@ -73,32 +73,21 @@ class SubsampleOptions:
     def __post_init__(self) -> None:
         if self.strategy not in SUBSAMPLE_STRATEGIES:
             raise ValueError(
-                f"strategy must be one of {SUBSAMPLE_STRATEGIES},"
-                f" got {self.strategy!r}"
+                f"strategy must be one of {SUBSAMPLE_STRATEGIES}, got {self.strategy!r}"
             )
-        if (self.total_annotations is not None
-                and self.total_annotations <= 0):
+        if self.total_annotations is not None and self.total_annotations <= 0:
             raise ValueError(
-                f"total_annotations must be > 0 or None,"
-                f" got {self.total_annotations!r}"
+                f"total_annotations must be > 0 or None, got {self.total_annotations!r}"
             )
         if self.min_per_class < 0:
-            raise ValueError(
-                f"min_per_class must be >= 0,"
-                f" got {self.min_per_class!r}"
-            )
+            raise ValueError(f"min_per_class must be >= 0, got {self.min_per_class!r}")
 
-        if self.strategy == "stratified":
-            if self.total_annotations is None:
-                raise ValueError(
-                    "strategy='stratified' requires total_annotations"
-                )
-        elif self.strategy == "balanced":
-            if self.total_annotations is None:
-                raise ValueError(
-                    "strategy='balanced' requires total_annotations"
-                    " (split equally across classes)"
-                )
+        if self.strategy == "stratified" and self.total_annotations is None:
+            raise ValueError("strategy='stratified' requires total_annotations")
+        if self.strategy == "balanced" and self.total_annotations is None:
+            raise ValueError(
+                "strategy='balanced' requires total_annotations (split equally across classes)"
+            )
 
     def to_log_dict(self) -> dict[str, object]:
         """Flat dict suitable for ``mlflow.log_params``.

--- a/mermaid_classifier/training/subsample/registry.py
+++ b/mermaid_classifier/training/subsample/registry.py
@@ -28,15 +28,15 @@ The pipeline call site (``TrainingDataset._apply_subsample``) does not
 need to change when a strategy is added; it routes through
 ``compute_per_class_targets``.
 """
+
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 from mermaid_classifier.training.subsample.options import (
     SUBSAMPLE_STRATEGIES,
     SubsampleOptions,
 )
-
 
 # Class identifier used by allocators and the SQL apply step.
 # A (benthic_attribute_id, growth_form_id) tuple matches the columns
@@ -96,7 +96,7 @@ def _stratified(
 
     grand_total = sum(class_counts.values())
     if grand_total == 0:
-        return {cls: 0 for cls in class_counts}
+        return dict.fromkeys(class_counts, 0)
 
     targets: ClassTargets = {}
     for cls, n in class_counts.items():
@@ -104,8 +104,7 @@ def _stratified(
         target = max(options.min_per_class, min(n, proportional))
         targets[cls] = target
 
-    return _trim_overshoot(
-        targets, target_total, class_counts, options.min_per_class)
+    return _trim_overshoot(targets, target_total, class_counts, options.min_per_class)
 
 
 def _balanced(
@@ -128,10 +127,7 @@ def _balanced(
     n_classes = len(class_counts)
     per = target_total // n_classes if n_classes else 0
 
-    return {
-        cls: max(options.min_per_class, min(n, per))
-        for cls, n in class_counts.items()
-    }
+    return {cls: max(options.min_per_class, min(n, per)) for cls, n in class_counts.items()}
 
 
 def _trim_overshoot(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,5 +85,39 @@ explicit = true
 torch = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
 torchvision = [{ index = "pytorch-cpu", marker = "sys_platform == 'linux'" }]
 
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+extend-exclude = ["v1"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "C4", "RET", "SIM", "PD"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["mermaid_classifier"]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.basedpyright]
+typeCheckingMode = "strict"
+pythonVersion = "3.12"
+include = ["mermaid_classifier", "scripts"]
+exclude = ["v1", "tests", "**/.venv", "**/__pycache__"]
+reportMissingTypeStubs = false
+# Disable the basedpyright-only aggressive tier layered on top of upstream
+# pyright "strict" — too noisy for a torch/numpy/duckdb/mlflow codebase.
+# (See design doc; signed off as out of scope.)
+reportAny = false
+reportExplicitAny = false
+reportUnusedCallResult = false
+reportImplicitStringConcatenation = false
+reportUnusedParameter = false
+
 [dependency-groups]
 sagemaker = []
+lint = [
+    "ruff",
+    "basedpyright",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,13 @@ extend-exclude = ["v1"]
 select = ["E", "F", "I", "UP", "B", "C4", "RET", "SIM", "PD"]
 ignore = ["E501"]
 
+[tool.ruff.lint.per-file-ignores]
+# AWS-bootstrap code must run before mermaid_classifier imports (settings read env at import time)
+"scripts/build_feature_bucket.py" = ["E402"]
+"scripts/classifier_train.py" = ["E402"]
+# sys.path manipulation to import from scripts/ must precede the import itself
+"tests/sagemaker_launcher/test_launch_processing.py" = ["E402"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["mermaid_classifier"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,14 @@ reportExplicitAny = false
 reportUnusedCallResult = false
 reportImplicitStringConcatenation = false
 reportUnusedParameter = false
+# Untyped-dependency leakage: torch/pyspacer/duckdb/mlflow/sklearn ship no
+# stubs, so their return values propagate as Unknown. Enforcing these would be
+# ~1,400 noise-only ignores. Real-bug checks and own-signature annotation
+# requirements stay ON. (Pragmatic-strict decision — see plan Global Constraints.)
+reportUnknownMemberType = false
+reportUnknownVariableType = false
+reportUnknownArgumentType = false
+reportUnknownLambdaType = false
 
 [dependency-groups]
 sagemaker = []

--- a/pyspacer_example/example.ipynb
+++ b/pyspacer_example/example.ipynb
@@ -1,8 +1,9 @@
 {
  "cells": [
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "70fb0874ab49921",
+   "metadata": {},
    "source": [
     "For this example, ensure that:\n",
     "\n",
@@ -17,17 +18,18 @@
     "    - `SPACER_EXTRACTORS_CACHE_DIR`\n",
     "\n",
     "Then, this cell should do a training run:"
-   ],
-   "id": "70fb0874ab49921"
+   ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "initial_id",
    "metadata": {
     "collapsed": true
    },
-   "cell_type": "code",
+   "outputs": [],
    "source": [
-    "from mermaid_classifier.pyspacer.train import (\n",
-    "    DatasetOptions, MLflowTrainingRunner)\n",
+    "from mermaid_classifier.pyspacer.train import DatasetOptions, MLflowTrainingRunner\n",
     "\n",
     "runner = MLflowTrainingRunner(\n",
     "    dataset_options=DatasetOptions(\n",
@@ -39,46 +41,43 @@
     "    ),\n",
     ")\n",
     "runner.run()"
-   ],
-   "id": "initial_id",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
+   "id": "2ce9eca25ff3cd31",
+   "metadata": {},
    "source": [
     "The print output of that training run should include a line like:\n",
     "\n",
     "> Model ID: m-f9e4bd067e4f4517962f3768c7aee106\n",
     "\n",
     "Copy the model ID from this line, and use it in the cell below. This cell should show a MERMAID benthic image with points classified using this model:"
-   ],
-   "id": "2ce9eca25ff3cd31"
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "code",
+   "execution_count": null,
+   "id": "fffc3781b0522cee",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "from mermaid_classifier.pyspacer.annotation import AnnotationRun\n",
     "\n",
     "annotation_run = AnnotationRun(\n",
-    "    image='s3://coral-reef-training/mermaid/0032dba6-8357-42e2-bace-988f99032286.png',\n",
-    "    points_csv='0032dba6_points.csv',\n",
+    "    image=\"s3://coral-reef-training/mermaid/0032dba6-8357-42e2-bace-988f99032286.png\",\n",
+    "    points_csv=\"0032dba6_points.csv\",\n",
     "    # Replace this with the model ID you got from training.\n",
-    "    classifier='m-f9e4bd067e4f4517962f3768c7aee106',\n",
+    "    classifier=\"m-f9e4bd067e4f4517962f3768c7aee106\",\n",
     ")\n",
     "annotation_run.show()"
-   ],
-   "id": "fffc3781b0522cee",
-   "outputs": [],
-   "execution_count": null
+   ]
   },
   {
-   "metadata": {},
    "cell_type": "markdown",
-   "source": "The [docs](../docs/README.md) have more details on PySpacer training and annotation visualization, including additional options available.",
-   "id": "50027ffc037ddfc8"
+   "id": "50027ffc037ddfc8",
+   "metadata": {},
+   "source": "The [docs](../docs/README.md) have more details on PySpacer training and annotation visualization, including additional options available."
   }
  ],
  "metadata": {

--- a/scripts/build_feature_bucket.py
+++ b/scripts/build_feature_bucket.py
@@ -94,17 +94,22 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
+from typing import Any
 
 import boto3
 import pandas as pd
 from botocore.exceptions import ClientError
 
+
+def _tqdm_fallback[T](iterable: Iterable[T] | None = None, **_kwargs: object) -> Iterable[T]:
+    """No-op tqdm fallback used when tqdm is not installed."""
+    return iterable if iterable is not None else iter(())
+
+
 try:
     from tqdm import tqdm
 except ImportError:  # tqdm is convenient but not required.
-
-    def tqdm(iterable=None, **_kwargs):
-        return iterable if iterable is not None else iter(())
+    tqdm = _tqdm_fallback  # pyright: ignore[reportAssignmentType]  # intentional: tqdm class vs fallback function have compatible call signatures
 
 
 logger = logging.getLogger("build_feature_bucket")
@@ -132,7 +137,7 @@ IMAGE_PAGE_ID_RE = re.compile(r"/image/(\d+)/")
 
 def build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        description=__doc__.split("\n\n", 1)[0],
+        description=(__doc__ or "").split("\n\n", 1)[0],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     p.add_argument("--target-bucket", required=True, help="Destination bucket. Must already exist.")
@@ -265,7 +270,7 @@ def _client_error_code(exc: ClientError) -> str:
     return exc.response.get("Error", {}).get("Code", "")
 
 
-def head_ok(s3, bucket: str, key: str) -> bool:
+def head_ok(s3: Any, bucket: str, key: str) -> bool:  # s3: boto3 S3 resource (untyped)
     try:
         s3.meta.client.head_object(Bucket=bucket, Key=key)
         return True
@@ -276,7 +281,7 @@ def head_ok(s3, bucket: str, key: str) -> bool:
 
 
 def filter_to_available_sources(
-    s3,
+    s3: Any,  # boto3 S3 resource (untyped)
     source_bucket: str,
     source_prefix: str,
     source_ids: list[str],
@@ -329,7 +334,9 @@ def filter_to_available_sources(
     return present
 
 
-def list_existing_feature_image_ids(s3, target_bucket: str, source_id: str) -> set[str]:
+def list_existing_feature_image_ids(
+    s3: Any, target_bucket: str, source_id: str
+) -> set[str]:  # s3: boto3 S3 resource (untyped)
     """Return the set of image IDs that already have a feature file in target."""
     prefix = f"s{source_id}/features/"
     paginator = s3.meta.client.get_paginator("list_objects_v2")
@@ -383,7 +390,7 @@ def _build_device_caching_extractor_class():
           pass; outputs are copied back to CPU before .tolist().
         """
 
-        def __init__(self, *, device: str, batch_size: int, **kwargs):
+        def __init__(self, *, device: str, batch_size: int, **kwargs: Any):
             super().__init__(**kwargs)
             import torch
 
@@ -392,7 +399,7 @@ def _build_device_caching_extractor_class():
             self._cached_net = None
             self._cached_loaded_remote = False
 
-        def _ensure_net(self):
+        def _ensure_net(self) -> tuple[Any, bool]:  # net: untyped pyspacer/torch model
             if self._cached_net is not None:
                 return self._cached_net, False
             weights_ds, loaded_remote = self.load_datastream("weights")
@@ -405,7 +412,9 @@ def _build_device_caching_extractor_class():
             self._cached_loaded_remote = loaded_remote
             return net, loaded_remote
 
-        def patches_to_features(self, patch_list):
+        def patches_to_features(
+            self, patch_list: Any
+        ) -> Any:  # patch_list: pyspacer untyped interface
             import numpy as np
             import torch
             from spacer.extractors.torch_extractors import transformation
@@ -440,8 +449,8 @@ def _build_device_caching_extractor_class():
 
 
 def verify_device_numerics(
-    extractor,
-    weights_loc,
+    extractor: Any,  # _DeviceCachingExtractor (untyped pyspacer subclass)
+    weights_loc: Any,  # spacer DataLocation (untyped)
     batch_size: int,
     device: str,
     n_patches: int = 8,
@@ -454,7 +463,7 @@ def verify_device_numerics(
         return
 
     import numpy as np
-    import torch  # noqa: F401  (forces the same import order)
+    import torch  # noqa: F401  # pyright: ignore[reportUnusedImport]  # forces same import order as production path
     from PIL import Image
 
     rng = np.random.default_rng(seed=42)
@@ -510,11 +519,11 @@ def build_extract_msg(
     source_id: str,
     image_id: str,
     rowcols: list[tuple[int, int]],
-    extractor,
+    extractor: Any,  # _DeviceCachingExtractor (untyped pyspacer subclass)
     source_bucket: str,
     source_prefix: str,
     target_bucket: str,
-):
+) -> Any:  # spacer ExtractFeaturesMsg (untyped)
     from spacer.data_classes import DataLocation
     from spacer.messages import ExtractFeaturesMsg
 
@@ -558,7 +567,7 @@ class PreparedSource:
 
 
 def build_name_to_image_id_mapping(
-    s3,
+    s3: Any,  # boto3 S3 resource (untyped)
     source_bucket: str,
     source_prefix: str,
     source_id: str,
@@ -579,16 +588,16 @@ def build_name_to_image_id_mapping(
             f"s{source_id}/image_list.csv missing required columns; got {list(df.columns)}"
         )
     df = df[["Name", "Image Page"]].dropna()
-    df["image_id"] = df["Image Page"].astype(str).str.extract(IMAGE_PAGE_ID_RE.pattern)[0]
+    df["image_id"] = df["Image Page"].astype(str).str.extract(IMAGE_PAGE_ID_RE.pattern)[0]  # pyright: ignore[reportAttributeAccessIssue]  # pandas-stubs infers ndarray for .astype(str) column
     df["name_norm"] = (
-        df["Name"].astype(str).map(lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub("", n).strip())
+        df["Name"].astype(str).map(lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub("", n).strip())  # pyright: ignore[reportAttributeAccessIssue]  # pandas-stubs infers ndarray for .astype(str) column
     )
-    df = df.dropna(subset=["image_id"])
+    df = df.dropna(subset=["image_id"])  # pyright: ignore[reportCallIssue]  # pandas-stubs overload mismatch
     return dict(zip(df["name_norm"], df["image_id"], strict=False))
 
 
 def prepare_source(
-    s3,
+    s3: Any,  # boto3 S3 resource (untyped)
     source_bucket: str,
     source_prefix: str,
     source_id: str,
@@ -631,8 +640,8 @@ def prepare_source(
                 )
                 return None
             raise
-        norm = df["Name"].astype(str).map(lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub("", n).strip())
-        df["Image ID"] = norm.map(name_to_id)
+        norm = df["Name"].astype(str).map(lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub("", n).strip())  # pyright: ignore[reportAttributeAccessIssue]  # pandas-stubs infers ndarray for .astype(str) column
+        df["Image ID"] = norm.map(lambda n: name_to_id.get(n))  # pyright: ignore[reportAttributeAccessIssue]  # pandas-stubs infers ndarray; use get() to return None for missing keys
         n_unmapped = int(df["Image ID"].isna().sum())
         if n_unmapped:
             logger.warning(
@@ -662,7 +671,7 @@ def prepare_source(
 
 
 def upload_annotations_csv(
-    s3,
+    s3: Any,  # boto3 S3 resource (untyped)
     source_id: str,
     transformed_csv: bytes,
     target_bucket: str,
@@ -682,12 +691,12 @@ def upload_annotations_csv(
 def process_source(
     *,
     source_id: str,
-    extractor,
-    s3,
+    extractor: Any,  # _DeviceCachingExtractor (untyped pyspacer subclass)
+    s3: Any,  # boto3 S3 resource (untyped)
     args: argparse.Namespace,
     counters: RunCounters,
-    progress_writer,
-    error_writer,
+    progress_writer: Any,  # IO[str] | None
+    error_writer: Any,  # csv._writer | None
 ) -> None:
     # Lazy import: spacer is only needed inside the GPU loop.
     from spacer.tasks import extract_features
@@ -782,7 +791,9 @@ def process_source(
 # ---- Logging helpers ------------------------------------------------
 
 
-def record_progress(writer, source_id: str, image_id: str, outcome: str, **extra) -> None:
+def record_progress(
+    writer: Any, source_id: str, image_id: str, outcome: str, **extra: object
+) -> None:  # writer: IO[str] | None
     if writer is None:
         return
     rec = {
@@ -796,7 +807,9 @@ def record_progress(writer, source_id: str, image_id: str, outcome: str, **extra
     writer.flush()
 
 
-def record_failure(writer, source_id: str, image_id: str, error_type: str, error_msg: str) -> None:
+def record_failure(
+    writer: Any, source_id: str, image_id: str, error_type: str, error_msg: str
+) -> None:  # writer: csv._writer | None
     if writer is None:
         return
     writer.writerow(

--- a/scripts/build_feature_bucket.py
+++ b/scripts/build_feature_bucket.py
@@ -27,6 +27,7 @@ Example
         --sources-csv /path/to/sources.csv \\
         --aws-profile wcs
 """
+
 from __future__ import annotations
 
 # -- SSO bootstrap ----------------------------------------------------
@@ -38,7 +39,6 @@ import sys
 
 
 def _bootstrap_aws_env(profile: str | None) -> None:
-    import boto3
 
     if profile is None:
         # Container / ambient mode: let every consumer (pyspacer, our
@@ -47,22 +47,22 @@ def _bootstrap_aws_env(profile: str | None) -> None:
         # endpoint as the session token nears expiry. Pinning
         # AWS_PROFILE or copying frozen creds into SPACER_AWS_* here
         # would freeze a 1-hour token and break long-running jobs.
-        os.environ.pop('AWS_PROFILE', None)
-        os.environ.pop('SPACER_AWS_ACCESS_KEY_ID', None)
-        os.environ.pop('SPACER_AWS_SECRET_ACCESS_KEY', None)
-        os.environ.pop('SPACER_AWS_SESSION_TOKEN', None)
+        os.environ.pop("AWS_PROFILE", None)
+        os.environ.pop("SPACER_AWS_ACCESS_KEY_ID", None)
+        os.environ.pop("SPACER_AWS_SECRET_ACCESS_KEY", None)
+        os.environ.pop("SPACER_AWS_SESSION_TOKEN", None)
         return
 
-    os.environ['AWS_PROFILE'] = profile
+    os.environ["AWS_PROFILE"] = profile
     session = boto3.Session()
     credentials = session.get_credentials()
     if credentials is None:
         return
     creds = credentials.get_frozen_credentials()
-    os.environ['SPACER_AWS_ACCESS_KEY_ID'] = creds.access_key
-    os.environ['SPACER_AWS_SECRET_ACCESS_KEY'] = creds.secret_key
+    os.environ["SPACER_AWS_ACCESS_KEY_ID"] = creds.access_key
+    os.environ["SPACER_AWS_SECRET_ACCESS_KEY"] = creds.secret_key
     if creds.token:
-        os.environ['SPACER_AWS_SESSION_TOKEN'] = creds.token
+        os.environ["SPACER_AWS_SESSION_TOKEN"] = creds.token
 
 
 def _early_profile_from_argv(argv: list[str]) -> str | None:
@@ -71,14 +71,14 @@ def _early_profile_from_argv(argv: list[str]) -> str | None:
     Honors --no-aws-bootstrap (signals ambient credentials) and
     --aws-profile (otherwise). Default is 'wcs'.
     """
-    if '--no-aws-bootstrap' in argv:
+    if "--no-aws-bootstrap" in argv:
         return None
     for i, a in enumerate(argv):
-        if a == '--aws-profile' and i + 1 < len(argv):
+        if a == "--aws-profile" and i + 1 < len(argv):
             return argv[i + 1]
-        if a.startswith('--aws-profile='):
-            return a.split('=', 1)[1]
-    return 'wcs'
+        if a.startswith("--aws-profile="):
+            return a.split("=", 1)[1]
+    return "wcs"
 
 
 # -- main module imports ----------------------------------------------
@@ -88,12 +88,12 @@ import json
 import logging
 import re
 import time
+from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable
 
 import boto3
 import pandas as pd
@@ -102,28 +102,29 @@ from botocore.exceptions import ClientError
 try:
     from tqdm import tqdm
 except ImportError:  # tqdm is convenient but not required.
+
     def tqdm(iterable=None, **_kwargs):
         return iterable if iterable is not None else iter(())
 
-logger = logging.getLogger('build_feature_bucket')
 
-DEFAULT_SOURCE_BUCKET = 'source-image-bucket'
-DEFAULT_SOURCE_PREFIX = 'coralnet-public-images/'
-DEFAULT_AWS_PROFILE = 'wcs'
+logger = logging.getLogger("build_feature_bucket")
+
+DEFAULT_SOURCE_BUCKET = "source-image-bucket"
+DEFAULT_SOURCE_PREFIX = "coralnet-public-images/"
+DEFAULT_AWS_PROFILE = "wcs"
 DEFAULT_MAX_IO_WORKERS = 16
 
-SOURCE_ID_COLUMN_CANDIDATES = ('id', 'Source ID', 'source_id')
+SOURCE_ID_COLUMN_CANDIDATES = ("id", "Source ID", "source_id")
 
-FEATURE_KEY_RE = re.compile(r'.*/i([^/]+)\.featurevector$')
+FEATURE_KEY_RE = re.compile(r".*/i([^/]+)\.featurevector$")
 
 # `image_list.csv` Name values look like "001-CA2M-1.JPG - Confirmed".
 # `annotations.csv` Name values are the bare filename without the suffix.
 # Strip the trailing status to make them join.
-IMAGE_LIST_STATUS_SUFFIX_RE = re.compile(
-    r'\s+-\s+(?:Confirmed|Unconfirmed|Unclassified)\s*$')
+IMAGE_LIST_STATUS_SUFFIX_RE = re.compile(r"\s+-\s+(?:Confirmed|Unconfirmed|Unclassified)\s*$")
 
 # `Image Page` column in image_list.csv looks like "/image/1719202/view/".
-IMAGE_PAGE_ID_RE = re.compile(r'/image/(\d+)/')
+IMAGE_PAGE_ID_RE = re.compile(r"/image/(\d+)/")
 
 
 # ---- CLI -------------------------------------------------------------
@@ -131,56 +132,78 @@ IMAGE_PAGE_ID_RE = re.compile(r'/image/(\d+)/')
 
 def build_arg_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        description=__doc__.split('\n\n', 1)[0],
+        description=__doc__.split("\n\n", 1)[0],
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p.add_argument('--target-bucket', required=True,
-                   help='Destination bucket. Must already exist.')
+    p.add_argument("--target-bucket", required=True, help="Destination bucket. Must already exist.")
     src_group = p.add_mutually_exclusive_group(required=True)
-    src_group.add_argument('--sources-csv', type=Path,
-                           help='CSV with a source-ID column.')
-    src_group.add_argument('--source-ids',
-                           help='Comma-separated source IDs (testing).')
-    p.add_argument('--source-id-column',
-                   help='Override CSV column name for source ID. '
-                        f'Default: auto-detect {SOURCE_ID_COLUMN_CANDIDATES}.')
-    p.add_argument('--source-bucket', default=DEFAULT_SOURCE_BUCKET)
-    p.add_argument('--source-prefix', default=DEFAULT_SOURCE_PREFIX)
-    p.add_argument('--weights',
-                   help='EfficientNet weights URI (s3://... or path). '
-                        'Default: settings.weights_location.')
-    p.add_argument('--device', choices=['auto', 'mps', 'cuda', 'cpu'],
-                   default='auto',
-                   help='Torch device for the forward pass. "auto" picks '
-                        'mps if available, else cuda, else cpu. On Apple '
-                        'Silicon, mps is ~5-10x faster than cpu.')
-    p.add_argument('--batch-size', type=int, default=10,
-                   help='Patches per forward-pass batch (pyspacer default '
-                        'is 10; bump to 64-128 on mps for higher throughput).')
-    p.add_argument('--verify-numerics', action='store_true',
-                   help='Before processing, compare chosen-device features '
-                        'against CPU features on a random batch. Adds ~10s '
-                        'startup; catches MPS/CUDA numerical regressions.')
-    p.add_argument('--max-io-workers', type=int, default=DEFAULT_MAX_IO_WORKERS)
-    p.add_argument('--aws-profile', default=DEFAULT_AWS_PROFILE)
-    p.add_argument('--no-aws-bootstrap', action='store_true',
-                   help='Skip SSO bootstrap; use ambient AWS credentials '
-                        '(e.g. SageMaker task role, EC2 instance profile).')
+    src_group.add_argument("--sources-csv", type=Path, help="CSV with a source-ID column.")
+    src_group.add_argument("--source-ids", help="Comma-separated source IDs (testing).")
+    p.add_argument(
+        "--source-id-column",
+        help="Override CSV column name for source ID. "
+        f"Default: auto-detect {SOURCE_ID_COLUMN_CANDIDATES}.",
+    )
+    p.add_argument("--source-bucket", default=DEFAULT_SOURCE_BUCKET)
+    p.add_argument("--source-prefix", default=DEFAULT_SOURCE_PREFIX)
+    p.add_argument(
+        "--weights",
+        help="EfficientNet weights URI (s3://... or path). Default: settings.weights_location.",
+    )
+    p.add_argument(
+        "--device",
+        choices=["auto", "mps", "cuda", "cpu"],
+        default="auto",
+        help='Torch device for the forward pass. "auto" picks '
+        "mps if available, else cuda, else cpu. On Apple "
+        "Silicon, mps is ~5-10x faster than cpu.",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=10,
+        help="Patches per forward-pass batch (pyspacer default "
+        "is 10; bump to 64-128 on mps for higher throughput).",
+    )
+    p.add_argument(
+        "--verify-numerics",
+        action="store_true",
+        help="Before processing, compare chosen-device features "
+        "against CPU features on a random batch. Adds ~10s "
+        "startup; catches MPS/CUDA numerical regressions.",
+    )
+    p.add_argument("--max-io-workers", type=int, default=DEFAULT_MAX_IO_WORKERS)
+    p.add_argument("--aws-profile", default=DEFAULT_AWS_PROFILE)
+    p.add_argument(
+        "--no-aws-bootstrap",
+        action="store_true",
+        help="Skip SSO bootstrap; use ambient AWS credentials "
+        "(e.g. SageMaker task role, EC2 instance profile).",
+    )
     skip_group = p.add_mutually_exclusive_group()
-    skip_group.add_argument('--skip-existing', dest='skip_existing',
-                            action='store_true', default=True)
-    skip_group.add_argument('--force', dest='skip_existing',
-                            action='store_false',
-                            help='Re-extract even if feature file already exists.')
-    p.add_argument('--dry-run', action='store_true',
-                   help='Log planned work; do not write to S3.')
-    p.add_argument('--error-log', type=Path,
-                   help='Append-only CSV for per-image failures. '
-                        'Default: build_feature_bucket_errors_<ts>.csv')
-    p.add_argument('--progress-log', type=Path,
-                   help='Append-only JSONL for (source, image, outcome). '
-                        'Default: build_feature_bucket_progress_<ts>.jsonl')
-    p.add_argument('--log-level', default='INFO')
+    skip_group.add_argument(
+        "--skip-existing", dest="skip_existing", action="store_true", default=True
+    )
+    skip_group.add_argument(
+        "--force",
+        dest="skip_existing",
+        action="store_false",
+        help="Re-extract even if feature file already exists.",
+    )
+    p.add_argument("--dry-run", action="store_true", help="Log planned work; do not write to S3.")
+    p.add_argument(
+        "--error-log",
+        type=Path,
+        help="Append-only CSV for per-image failures. "
+        "Default: build_feature_bucket_errors_<ts>.csv",
+    )
+    p.add_argument(
+        "--progress-log",
+        type=Path,
+        help="Append-only JSONL for (source, image, outcome). "
+        "Default: build_feature_bucket_progress_<ts>.jsonl",
+    )
+    p.add_argument("--log-level", default="INFO")
     return p
 
 
@@ -191,8 +214,7 @@ def detect_id_column(columns: Iterable[str], override: str | None) -> str:
     cols = list(columns)
     if override:
         if override not in cols:
-            raise ValueError(
-                f"--source-id-column={override!r} not found in CSV columns: {cols}")
+            raise ValueError(f"--source-id-column={override!r} not found in CSV columns: {cols}")
         return override
     for candidate in SOURCE_ID_COLUMN_CANDIDATES:
         if candidate in cols:
@@ -200,7 +222,8 @@ def detect_id_column(columns: Iterable[str], override: str | None) -> str:
     raise ValueError(
         f"Could not find a source-ID column in CSV. "
         f"Tried {SOURCE_ID_COLUMN_CANDIDATES}; got columns: {cols}. "
-        f"Pass --source-id-column to override.")
+        f"Pass --source-id-column to override."
+    )
 
 
 def load_source_ids_from_csv(path: Path, override: str | None) -> list[str]:
@@ -208,7 +231,7 @@ def load_source_ids_from_csv(path: Path, override: str | None) -> list[str]:
     col = detect_id_column(df.columns, override)
     # Cast to string and strip whitespace; drop blanks.
     ids = [str(v).strip() for v in df[col].tolist()]
-    ids = [v for v in ids if v and v.lower() != 'nan']
+    ids = [v for v in ids if v and v.lower() != "nan"]
     # Normalize numeric "123.0" -> "123" while leaving non-numeric IDs alone.
     out = []
     for v in ids:
@@ -228,18 +251,18 @@ def load_source_ids_from_csv(path: Path, override: str | None) -> list[str]:
 def load_source_ids_from_args(args: argparse.Namespace) -> list[str]:
     if args.sources_csv:
         return load_source_ids_from_csv(args.sources_csv, args.source_id_column)
-    raw = [s.strip() for s in args.source_ids.split(',')]
+    raw = [s.strip() for s in args.source_ids.split(",")]
     return [s for s in raw if s]
 
 
 # ---- S3 helpers -----------------------------------------------------
 
 
-_NOT_FOUND_CODES = ('404', 'NoSuchKey', 'NotFound')
+_NOT_FOUND_CODES = ("404", "NoSuchKey", "NotFound")
 
 
 def _client_error_code(exc: ClientError) -> str:
-    return exc.response.get('Error', {}).get('Code', '')
+    return exc.response.get("Error", {}).get("Code", "")
 
 
 def head_ok(s3, bucket: str, key: str) -> bool:
@@ -253,8 +276,11 @@ def head_ok(s3, bucket: str, key: str) -> bool:
 
 
 def filter_to_available_sources(
-    s3, source_bucket: str, source_prefix: str,
-    source_ids: list[str], max_workers: int,
+    s3,
+    source_bucket: str,
+    source_prefix: str,
+    source_ids: list[str],
+    max_workers: int,
 ) -> list[str]:
     """Drop source IDs whose annotations.csv is missing in the source bucket.
 
@@ -265,7 +291,7 @@ def filter_to_available_sources(
     client = s3.meta.client
 
     def probe(sid: str) -> tuple[str, bool | ClientError]:
-        key = f'{source_prefix}s{sid}/annotations.csv'
+        key = f"{source_prefix}s{sid}/annotations.csv"
         try:
             client.head_object(Bucket=source_bucket, Key=key)
             return sid, True
@@ -277,13 +303,11 @@ def filter_to_available_sources(
     with ThreadPoolExecutor(max_workers=max_workers) as ex:
         results = dict(ex.map(probe, source_ids))
 
-    other_errors = {
-        sid: r for sid, r in results.items() if isinstance(r, ClientError)
-    }
+    other_errors = {sid: r for sid, r in results.items() if isinstance(r, ClientError)}
     if other_errors:
         sample_sid, sample_exc = next(iter(other_errors.items()))
         code = _client_error_code(sample_exc)
-        msg = sample_exc.response.get('Error', {}).get('Message', '')
+        msg = sample_exc.response.get("Error", {}).get("Message", "")
         raise RuntimeError(
             f"HEAD on s3://{source_bucket}/{source_prefix}s{{id}}/annotations.csv "
             f"failed with non-404 error for {len(other_errors)}/{len(source_ids)} "
@@ -297,19 +321,22 @@ def filter_to_available_sources(
     if missing:
         logger.warning(
             "%d source(s) skipped -- no annotations.csv in s3://%s/%s: %s",
-            len(missing), source_bucket, source_prefix,
-            ', '.join(missing[:20]) + (' ...' if len(missing) > 20 else ''))
+            len(missing),
+            source_bucket,
+            source_prefix,
+            ", ".join(missing[:20]) + (" ..." if len(missing) > 20 else ""),
+        )
     return present
 
 
 def list_existing_feature_image_ids(s3, target_bucket: str, source_id: str) -> set[str]:
     """Return the set of image IDs that already have a feature file in target."""
-    prefix = f's{source_id}/features/'
-    paginator = s3.meta.client.get_paginator('list_objects_v2')
+    prefix = f"s{source_id}/features/"
+    paginator = s3.meta.client.get_paginator("list_objects_v2")
     existing: set[str] = set()
     for page in paginator.paginate(Bucket=target_bucket, Prefix=prefix):
-        for obj in page.get('Contents', []):
-            m = FEATURE_KEY_RE.match(obj['Key'])
+        for obj in page.get("Contents", []):
+            m = FEATURE_KEY_RE.match(obj["Key"])
             if m:
                 existing.add(m.group(1))
     return existing
@@ -325,19 +352,16 @@ def resolve_device(name: str) -> str:
     """Resolve --device argument to a concrete torch device string."""
     import torch
 
-    if name == 'auto':
+    if name == "auto":
         if torch.backends.mps.is_available():
-            return 'mps'
+            return "mps"
         if torch.cuda.is_available():
-            return 'cuda'
-        return 'cpu'
-    if name == 'mps' and not torch.backends.mps.is_available():
-        raise RuntimeError(
-            "--device mps requested but torch.backends.mps.is_available() "
-            "is False.")
-    if name == 'cuda' and not torch.cuda.is_available():
-        raise RuntimeError(
-            "--device cuda requested but torch.cuda.is_available() is False.")
+            return "cuda"
+        return "cpu"
+    if name == "mps" and not torch.backends.mps.is_available():
+        raise RuntimeError("--device mps requested but torch.backends.mps.is_available() is False.")
+    if name == "cuda" and not torch.cuda.is_available():
+        raise RuntimeError("--device cuda requested but torch.cuda.is_available() is False.")
     return name
 
 
@@ -362,6 +386,7 @@ def _build_device_caching_extractor_class():
         def __init__(self, *, device: str, batch_size: int, **kwargs):
             super().__init__(**kwargs)
             import torch
+
             self._device = torch.device(device)
             self._batch_size = int(batch_size)
             self._cached_net = None
@@ -370,7 +395,7 @@ def _build_device_caching_extractor_class():
         def _ensure_net(self):
             if self._cached_net is not None:
                 return self._cached_net, False
-            weights_ds, loaded_remote = self.load_datastream('weights')
+            weights_ds, loaded_remote = self.load_datastream("weights")
             # Parent's load_weights builds an untrained model on CPU and
             # loads the state_dict into it. We then move it to our device.
             net = type(self).__mro__[1].load_weights(weights_ds)
@@ -392,22 +417,22 @@ def _build_device_caching_extractor_class():
             num_batches = int(np.ceil(n / bs))
             feats: list[list[float]] = []
             for b in range(num_batches):
-                batch_imgs = patch_list[b * bs:(b + 1) * bs]
-                batch_t = torch.stack(
-                    [transformer(i) for i in batch_imgs]
-                ).to(self._device, non_blocking=True)
+                batch_imgs = patch_list[b * bs : (b + 1) * bs]
+                batch_t = torch.stack([transformer(i) for i in batch_imgs]).to(
+                    self._device, non_blocking=True
+                )
                 with torch.no_grad():
                     out = net.extract_features(batch_t)
                 # Bring back to CPU before .tolist() -- MPS tensors can't
                 # be iterated as Python floats directly on some torch builds.
-                feats.extend(out.detach().to('cpu').tolist())
+                feats.extend(out.detach().to("cpu").tolist())
                 del batch_t, out
             # Release MPS/CUDA allocator cache so the OS can reclaim memory
             # between images. Without this on Apple Silicon the allocator
             # fragments over a long run and pushes the system into swap.
-            if self._device.type == 'mps' and hasattr(torch, 'mps'):
+            if self._device.type == "mps" and hasattr(torch, "mps"):
                 torch.mps.empty_cache()
-            elif self._device.type == 'cuda':
+            elif self._device.type == "cuda":
                 torch.cuda.empty_cache()
             return feats, loaded_remote
 
@@ -415,13 +440,17 @@ def _build_device_caching_extractor_class():
 
 
 def verify_device_numerics(
-    extractor, weights_loc, batch_size: int, device: str, n_patches: int = 8,
+    extractor,
+    weights_loc,
+    batch_size: int,
+    device: str,
+    n_patches: int = 8,
     threshold: float = 0.999,
 ) -> None:
     """Sanity check: feature vectors on the chosen device match CPU output
     on a fixed random batch. Raises RuntimeError if min cosine similarity
     drops below ``threshold``."""
-    if device == 'cpu':
+    if device == "cpu":
         return
 
     import numpy as np
@@ -436,8 +465,9 @@ def verify_device_numerics(
 
     cls = _build_device_caching_extractor_class()
     cpu_extractor = cls(
-        data_locations=dict(weights=weights_loc),
-        device='cpu', batch_size=batch_size,
+        data_locations={"weights": weights_loc},
+        device="cpu",
+        batch_size=batch_size,
     )
 
     device_feats, _ = extractor.patches_to_features(patches)
@@ -445,52 +475,61 @@ def verify_device_numerics(
 
     A = np.asarray(device_feats)
     B = np.asarray(cpu_feats)
-    sims = (A * B).sum(axis=1) / (
-        np.linalg.norm(A, axis=1) * np.linalg.norm(B, axis=1) + 1e-12)
+    sims = (A * B).sum(axis=1) / (np.linalg.norm(A, axis=1) * np.linalg.norm(B, axis=1) + 1e-12)
     logger.info(
         "Device numerics check (%s vs cpu, %d random patches): "
         "min_cos=%.6f median=%.6f max_abs_diff=%.4g",
-        device, n_patches, float(sims.min()), float(np.median(sims)),
-        float(np.abs(A - B).max()))
+        device,
+        n_patches,
+        float(sims.min()),
+        float(np.median(sims)),
+        float(np.abs(A - B).max()),
+    )
     if sims.min() < threshold:
         raise RuntimeError(
             f"Device numerics check FAILED on {device}: min cosine "
             f"similarity {sims.min():.6f} < {threshold}. The features "
-            f"would not be safe to mix with previously CPU-extracted ones.")
+            f"would not be safe to mix with previously CPU-extracted ones."
+        )
 
 
 def parse_weights_location(uri: str):
     """Parse an s3://bucket/key or filesystem path into a DataLocation."""
     from spacer.data_classes import DataLocation
 
-    if uri.startswith('s3://'):
-        rest = uri[len('s3://'):]
-        bucket, _, key = rest.partition('/')
+    if uri.startswith("s3://"):
+        rest = uri[len("s3://") :]
+        bucket, _, key = rest.partition("/")
         if not bucket or not key:
             raise ValueError(f"Bad S3 URI for weights: {uri!r}")
-        return DataLocation(storage_type='s3', key=key, bucket_name=bucket)
-    return DataLocation(storage_type='filesystem', key=uri)
+        return DataLocation(storage_type="s3", key=key, bucket_name=bucket)
+    return DataLocation(storage_type="filesystem", key=uri)
 
 
 def build_extract_msg(
-    source_id: str, image_id: str, rowcols: list[tuple[int, int]],
-    extractor, source_bucket: str, source_prefix: str, target_bucket: str,
+    source_id: str,
+    image_id: str,
+    rowcols: list[tuple[int, int]],
+    extractor,
+    source_bucket: str,
+    source_prefix: str,
+    target_bucket: str,
 ):
     from spacer.data_classes import DataLocation
     from spacer.messages import ExtractFeaturesMsg
 
     return ExtractFeaturesMsg(
-        job_token=f's{source_id}_i{image_id}',
+        job_token=f"s{source_id}_i{image_id}",
         extractor=extractor,
         rowcols=rowcols,
         image_loc=DataLocation(
-            storage_type='s3',
-            key=f'{source_prefix}s{source_id}/images/{image_id}.jpg',
+            storage_type="s3",
+            key=f"{source_prefix}s{source_id}/images/{image_id}.jpg",
             bucket_name=source_bucket,
         ),
         feature_loc=DataLocation(
-            storage_type='s3',
-            key=f's{source_id}/features/i{image_id}.featurevector',
+            storage_type="s3",
+            key=f"s{source_id}/features/i{image_id}.featurevector",
             bucket_name=target_bucket,
         ),
     )
@@ -519,7 +558,10 @@ class PreparedSource:
 
 
 def build_name_to_image_id_mapping(
-    s3, source_bucket: str, source_prefix: str, source_id: str,
+    s3,
+    source_bucket: str,
+    source_prefix: str,
+    source_id: str,
 ) -> dict[str, str]:
     """Read s{id}/image_list.csv and build {filename: numeric_image_id}.
 
@@ -529,27 +571,27 @@ def build_name_to_image_id_mapping(
     annotations.csv carries the bare filename ("001-CA2M-1.JPG"), so we
     strip the status suffix before keying.
     """
-    key = f'{source_prefix}s{source_id}/image_list.csv'
-    body = s3.Object(source_bucket, key).get()['Body'].read()
+    key = f"{source_prefix}s{source_id}/image_list.csv"
+    body = s3.Object(source_bucket, key).get()["Body"].read()
     df = pd.read_csv(BytesIO(body))
-    if 'Name' not in df.columns or 'Image Page' not in df.columns:
+    if "Name" not in df.columns or "Image Page" not in df.columns:
         raise ValueError(
-            f"s{source_id}/image_list.csv missing required columns; "
-            f"got {list(df.columns)}")
-    df = df[['Name', 'Image Page']].dropna()
-    df['image_id'] = (
-        df['Image Page'].astype(str).str.extract(IMAGE_PAGE_ID_RE.pattern)[0]
+            f"s{source_id}/image_list.csv missing required columns; got {list(df.columns)}"
+        )
+    df = df[["Name", "Image Page"]].dropna()
+    df["image_id"] = df["Image Page"].astype(str).str.extract(IMAGE_PAGE_ID_RE.pattern)[0]
+    df["name_norm"] = (
+        df["Name"].astype(str).map(lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub("", n).strip())
     )
-    df['name_norm'] = (
-        df['Name'].astype(str).map(
-            lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub('', n).strip())
-    )
-    df = df.dropna(subset=['image_id'])
-    return dict(zip(df['name_norm'], df['image_id']))
+    df = df.dropna(subset=["image_id"])
+    return dict(zip(df["name_norm"], df["image_id"], strict=False))
 
 
 def prepare_source(
-    s3, source_bucket: str, source_prefix: str, source_id: str,
+    s3,
+    source_bucket: str,
+    source_prefix: str,
+    source_id: str,
 ) -> PreparedSource | None:
     """Read source annotations.csv (and image_list.csv if needed), augment
     with an `Image ID` column when only `Name` is present, group rowcols
@@ -557,95 +599,106 @@ def prepare_source(
 
     Returns None if the source is unusable (missing files/columns).
     """
-    ann_key = f'{source_prefix}s{source_id}/annotations.csv'
-    body = s3.Object(source_bucket, ann_key).get()['Body'].read()
+    ann_key = f"{source_prefix}s{source_id}/annotations.csv"
+    body = s3.Object(source_bucket, ann_key).get()["Body"].read()
     df = pd.read_csv(BytesIO(body))
 
-    required_basic = {'Row', 'Column', 'Label ID'}
+    required_basic = {"Row", "Column", "Label ID"}
     missing_basic = required_basic - set(df.columns)
     if missing_basic:
         logger.warning(
             "s%s: annotations.csv missing required columns %s; skipping source",
-            source_id, missing_basic)
+            source_id,
+            missing_basic,
+        )
         return None
 
     n_unmapped = 0
-    if 'Image ID' not in df.columns:
-        if 'Name' not in df.columns:
+    if "Image ID" not in df.columns:
+        if "Name" not in df.columns:
             logger.warning(
-                "s%s: annotations.csv has neither 'Image ID' nor 'Name'; "
-                "skipping source", source_id)
+                "s%s: annotations.csv has neither 'Image ID' nor 'Name'; skipping source", source_id
+            )
             return None
         try:
-            name_to_id = build_name_to_image_id_mapping(
-                s3, source_bucket, source_prefix, source_id)
+            name_to_id = build_name_to_image_id_mapping(s3, source_bucket, source_prefix, source_id)
         except ClientError as exc:
             code = _client_error_code(exc)
             if code in _NOT_FOUND_CODES:
                 logger.warning(
-                    "s%s: image_list.csv missing -- cannot map Name->Image ID; "
-                    "skipping source", source_id)
+                    "s%s: image_list.csv missing -- cannot map Name->Image ID; skipping source",
+                    source_id,
+                )
                 return None
             raise
-        norm = df['Name'].astype(str).map(
-            lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub('', n).strip())
-        df['Image ID'] = norm.map(name_to_id)
-        n_unmapped = int(df['Image ID'].isna().sum())
+        norm = df["Name"].astype(str).map(lambda n: IMAGE_LIST_STATUS_SUFFIX_RE.sub("", n).strip())
+        df["Image ID"] = norm.map(name_to_id)
+        n_unmapped = int(df["Image ID"].isna().sum())
         if n_unmapped:
             logger.warning(
                 "s%s: dropping %d/%d annotation row(s) with unmappable Name",
-                source_id, n_unmapped, len(df))
-            df = df.dropna(subset=['Image ID']).copy()
-        df['Image ID'] = df['Image ID'].astype(int).astype(str)
+                source_id,
+                n_unmapped,
+                len(df),
+            )
+            df = df.dropna(subset=["Image ID"]).copy()
+        df["Image ID"] = df["Image ID"].astype(int).astype(str)
     else:
-        df['Image ID'] = df['Image ID'].astype(str)
+        df["Image ID"] = df["Image ID"].astype(str)
 
     # Group rowcols by Image ID.
-    sub = df[['Image ID', 'Row', 'Column']].copy()
-    sub['Row'] = sub['Row'].astype(int)
-    sub['Column'] = sub['Column'].astype(int)
+    sub = df[["Image ID", "Row", "Column"]].copy()
+    sub["Row"] = sub["Row"].astype(int)
+    sub["Column"] = sub["Column"].astype(int)
     images: dict[str, list[tuple[int, int]]] = {}
-    for image_id, g in sub.groupby('Image ID', sort=True):
-        pairs = sorted({(r, c) for r, c in zip(g['Row'], g['Column'])})
+    for image_id, g in sub.groupby("Image ID", sort=True):
+        pairs = sorted({(r, c) for r, c in zip(g["Row"], g["Column"], strict=False)})
         images[str(image_id)] = pairs
 
     # Emit transformed CSV bytes (Image ID added; everything else preserved).
     buf = BytesIO()
     df.to_csv(buf, index=False)
-    return PreparedSource(
-        transformed_csv=buf.getvalue(), images=images,
-        n_unmapped_rows=n_unmapped)
+    return PreparedSource(transformed_csv=buf.getvalue(), images=images, n_unmapped_rows=n_unmapped)
 
 
 def upload_annotations_csv(
-    s3, source_id: str, transformed_csv: bytes,
-    target_bucket: str, skip_existing: bool, dry_run: bool,
+    s3,
+    source_id: str,
+    transformed_csv: bytes,
+    target_bucket: str,
+    skip_existing: bool,
+    dry_run: bool,
 ) -> str:
     """Return 'uploaded' or 'skipped'."""
-    tgt_key = f's{source_id}/annotations.csv'
+    tgt_key = f"s{source_id}/annotations.csv"
     if skip_existing and head_ok(s3, target_bucket, tgt_key):
-        return 'skipped'
+        return "skipped"
     if dry_run:
-        return 'uploaded'
-    s3.meta.client.put_object(
-        Bucket=target_bucket, Key=tgt_key, Body=transformed_csv)
-    return 'uploaded'
+        return "uploaded"
+    s3.meta.client.put_object(Bucket=target_bucket, Key=tgt_key, Body=transformed_csv)
+    return "uploaded"
 
 
 def process_source(
-    *, source_id: str, extractor, s3, args: argparse.Namespace,
-    counters: RunCounters, progress_writer, error_writer,
+    *,
+    source_id: str,
+    extractor,
+    s3,
+    args: argparse.Namespace,
+    counters: RunCounters,
+    progress_writer,
+    error_writer,
 ) -> None:
     # Lazy import: spacer is only needed inside the GPU loop.
     from spacer.tasks import extract_features
 
     try:
-        prepared = prepare_source(
-            s3, args.source_bucket, args.source_prefix, source_id)
+        prepared = prepare_source(s3, args.source_bucket, args.source_prefix, source_id)
     except ClientError as exc:
         logger.error("s%s: failed to read source: %s", source_id, exc)
-        record_failure(error_writer, source_id, image_id='',
-                       error_type=type(exc).__name__, error_msg=str(exc))
+        record_failure(
+            error_writer, source_id, image_id="", error_type=type(exc).__name__, error_msg=str(exc)
+        )
         counters.sources_skipped += 1
         return
 
@@ -655,68 +708,73 @@ def process_source(
 
     try:
         ann_outcome = upload_annotations_csv(
-            s3, source_id, prepared.transformed_csv,
+            s3,
+            source_id,
+            prepared.transformed_csv,
             target_bucket=args.target_bucket,
-            skip_existing=args.skip_existing, dry_run=args.dry_run)
+            skip_existing=args.skip_existing,
+            dry_run=args.dry_run,
+        )
     except ClientError as exc:
-        logger.error("s%s: failed to upload annotations.csv: %s",
-                     source_id, exc)
-        record_failure(error_writer, source_id, image_id='',
-                       error_type=type(exc).__name__, error_msg=str(exc))
+        logger.error("s%s: failed to upload annotations.csv: %s", source_id, exc)
+        record_failure(
+            error_writer, source_id, image_id="", error_type=type(exc).__name__, error_msg=str(exc)
+        )
         counters.sources_skipped += 1
         return
 
-    if ann_outcome == 'uploaded':
+    if ann_outcome == "uploaded":
         counters.annotations_copied += 1
     else:
         counters.annotations_skipped += 1
 
     existing = (
         list_existing_feature_image_ids(s3, args.target_bucket, source_id)
-        if args.skip_existing else set()
+        if args.skip_existing
+        else set()
     )
 
     grouped = prepared.images
     image_ids = sorted(grouped.keys())
-    inner = tqdm(image_ids, desc=f's{source_id}', leave=False, unit='img')
+    inner = tqdm(image_ids, desc=f"s{source_id}", leave=False, unit="img")
     for image_id in inner:
         rowcols = grouped[image_id]
         if not rowcols:
             counters.images_skipped += 1
-            record_progress(progress_writer, source_id, image_id, 'skipped',
-                            reason='no_rowcols')
+            record_progress(progress_writer, source_id, image_id, "skipped", reason="no_rowcols")
             continue
         if image_id in existing:
             counters.images_skipped += 1
-            record_progress(progress_writer, source_id, image_id, 'skipped',
-                            reason='exists')
+            record_progress(progress_writer, source_id, image_id, "skipped", reason="exists")
             continue
 
         if args.dry_run:
             counters.images_ok += 1
-            record_progress(progress_writer, source_id, image_id, 'ok',
-                            dry_run=True)
+            record_progress(progress_writer, source_id, image_id, "ok", dry_run=True)
             continue
 
         msg = build_extract_msg(
-            source_id=source_id, image_id=image_id, rowcols=rowcols,
-            extractor=extractor, source_bucket=args.source_bucket,
+            source_id=source_id,
+            image_id=image_id,
+            rowcols=rowcols,
+            extractor=extractor,
+            source_bucket=args.source_bucket,
             source_prefix=args.source_prefix,
-            target_bucket=args.target_bucket)
+            target_bucket=args.target_bucket,
+        )
         try:
             extract_features(msg)
             counters.images_ok += 1
-            record_progress(progress_writer, source_id, image_id, 'ok')
+            record_progress(progress_writer, source_id, image_id, "ok")
         except KeyboardInterrupt:
             raise
         except Exception as exc:
             counters.images_failed += 1
-            logger.warning("s%s i%s: extract_features failed: %s",
-                           source_id, image_id, exc)
-            record_failure(error_writer, source_id, image_id,
-                           type(exc).__name__, str(exc))
-            record_progress(progress_writer, source_id, image_id, 'failed',
-                            error_type=type(exc).__name__)
+            logger.warning("s%s i%s: extract_features failed: %s", source_id, image_id, exc)
+            record_failure(error_writer, source_id, image_id, type(exc).__name__, str(exc))
+            record_progress(
+                progress_writer, source_id, image_id, "failed", error_type=type(exc).__name__
+            )
 
     counters.sources_done += 1
 
@@ -724,29 +782,32 @@ def process_source(
 # ---- Logging helpers ------------------------------------------------
 
 
-def record_progress(writer, source_id: str, image_id: str, outcome: str,
-                    **extra) -> None:
+def record_progress(writer, source_id: str, image_id: str, outcome: str, **extra) -> None:
     if writer is None:
         return
     rec = {
-        'ts': datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-        'source_id': source_id,
-        'image_id': image_id,
-        'outcome': outcome,
+        "ts": datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_id": source_id,
+        "image_id": image_id,
+        "outcome": outcome,
         **extra,
     }
-    writer.write(json.dumps(rec) + '\n')
+    writer.write(json.dumps(rec) + "\n")
     writer.flush()
 
 
-def record_failure(writer, source_id: str, image_id: str,
-                   error_type: str, error_msg: str) -> None:
+def record_failure(writer, source_id: str, image_id: str, error_type: str, error_msg: str) -> None:
     if writer is None:
         return
-    writer.writerow([
-        datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'),
-        source_id, image_id, error_type, error_msg,
-    ])
+    writer.writerow(
+        [
+            datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            source_id,
+            image_id,
+            error_type,
+            error_msg,
+        ]
+    )
 
 
 # ---- main -----------------------------------------------------------
@@ -758,18 +819,20 @@ def main(argv: list[str] | None = None) -> int:
     _bootstrap_aws_env(_early_profile_from_argv(argv))
 
     args = build_arg_parser().parse_args(argv)
-    logging.basicConfig(level=args.log_level,
-                        format='%(asctime)s %(levelname)s %(name)s %(message)s')
+    logging.basicConfig(
+        level=args.log_level, format="%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
 
     # Imports that depend on env-resolved settings.
-    from mermaid_classifier.pyspacer.settings import settings
     from spacer.aws import get_s3_resource
+
+    from mermaid_classifier.pyspacer.settings import settings
 
     weights_uri = args.weights or settings.weights_location
     if not weights_uri:
         logger.error(
-            "No EfficientNet weights configured. Pass --weights or set "
-            "WEIGHTS_LOCATION in .env.")
+            "No EfficientNet weights configured. Pass --weights or set WEIGHTS_LOCATION in .env."
+        )
         return 2
     weights_loc = parse_weights_location(weights_uri)
 
@@ -777,63 +840,71 @@ def main(argv: list[str] | None = None) -> int:
     logger.info("Compute device: %s (batch_size=%d)", device, args.batch_size)
     extractor_cls = _build_device_caching_extractor_class()
     extractor = extractor_cls(
-        data_locations=dict(weights=weights_loc),
-        device=device, batch_size=args.batch_size,
+        data_locations={"weights": weights_loc},
+        device=device,
+        batch_size=args.batch_size,
     )
     if args.verify_numerics:
-        verify_device_numerics(
-            extractor, weights_loc, args.batch_size, device)
+        verify_device_numerics(extractor, weights_loc, args.batch_size, device)
 
     s3 = get_s3_resource()
 
     source_ids = load_source_ids_from_args(args)
     logger.info("Requested %d source(s).", len(source_ids))
     source_ids = filter_to_available_sources(
-        s3, args.source_bucket, args.source_prefix, source_ids,
-        args.max_io_workers)
-    logger.info("%d source(s) have annotations.csv and will be processed.",
-                len(source_ids))
+        s3, args.source_bucket, args.source_prefix, source_ids, args.max_io_workers
+    )
+    logger.info("%d source(s) have annotations.csv and will be processed.", len(source_ids))
 
-    ts = datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')
-    error_log_path = args.error_log or Path(f'build_feature_bucket_errors_{ts}.csv')
-    progress_log_path = args.progress_log or Path(
-        f'build_feature_bucket_progress_{ts}.jsonl')
+    ts = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    error_log_path = args.error_log or Path(f"build_feature_bucket_errors_{ts}.csv")
+    progress_log_path = args.progress_log or Path(f"build_feature_bucket_progress_{ts}.jsonl")
 
     counters = RunCounters()
-    error_f = open(error_log_path, 'a', newline='')
-    error_writer = csv.writer(error_f)
-    if error_f.tell() == 0:
-        error_writer.writerow(['ts', 'source_id', 'image_id', 'error_type', 'error_msg'])
-    progress_f = open(progress_log_path, 'a')
+    with (
+        open(error_log_path, "a", newline="") as error_f,
+        open(progress_log_path, "a") as progress_f,
+    ):
+        error_writer = csv.writer(error_f)
+        if error_f.tell() == 0:
+            error_writer.writerow(["ts", "source_id", "image_id", "error_type", "error_msg"])
 
-    logger.info("Errors -> %s", error_log_path)
-    logger.info("Progress -> %s", progress_log_path)
-    if args.dry_run:
-        logger.warning("DRY RUN -- no S3 writes will occur.")
+        logger.info("Errors -> %s", error_log_path)
+        logger.info("Progress -> %s", progress_log_path)
+        if args.dry_run:
+            logger.warning("DRY RUN -- no S3 writes will occur.")
 
-    try:
-        for source_id in tqdm(source_ids, desc='sources', unit='src'):
-            process_source(
-                source_id=source_id, extractor=extractor, s3=s3, args=args,
-                counters=counters,
-                progress_writer=progress_f, error_writer=error_writer)
-    except KeyboardInterrupt:
-        logger.warning("Interrupted by user; printing partial summary.")
-    finally:
-        error_f.close()
-        progress_f.close()
-        elapsed = time.monotonic() - counters.started
-        logger.info(
-            "Done. sources_done=%d sources_skipped=%d "
-            "images_ok=%d images_skipped=%d images_failed=%d "
-            "annotations_copied=%d annotations_skipped=%d elapsed=%.1fs",
-            counters.sources_done, counters.sources_skipped,
-            counters.images_ok, counters.images_skipped, counters.images_failed,
-            counters.annotations_copied, counters.annotations_skipped,
-            elapsed)
+        try:
+            for source_id in tqdm(source_ids, desc="sources", unit="src"):
+                process_source(
+                    source_id=source_id,
+                    extractor=extractor,
+                    s3=s3,
+                    args=args,
+                    counters=counters,
+                    progress_writer=progress_f,
+                    error_writer=error_writer,
+                )
+        except KeyboardInterrupt:
+            logger.warning("Interrupted by user; printing partial summary.")
+        finally:
+            elapsed = time.monotonic() - counters.started
+            logger.info(
+                "Done. sources_done=%d sources_skipped=%d "
+                "images_ok=%d images_skipped=%d images_failed=%d "
+                "annotations_copied=%d annotations_skipped=%d elapsed=%.1fs",
+                counters.sources_done,
+                counters.sources_skipped,
+                counters.images_ok,
+                counters.images_skipped,
+                counters.images_failed,
+                counters.annotations_copied,
+                counters.annotations_skipped,
+                elapsed,
+            )
 
     return 0 if counters.images_failed == 0 else 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/classifier_train.py
+++ b/scripts/classifier_train.py
@@ -1,30 +1,34 @@
 import os
+
 import boto3
 
 # Resolve AWS SSO credentials before importing mermaid_classifier,
 # whose Settings() object is created at import time and reads env vars then.
-os.environ['AWS_PROFILE'] = 'wcs'
+os.environ["AWS_PROFILE"] = "wcs"
 session = boto3.Session()
 credentials = session.get_credentials()
 if credentials:
     creds = credentials.get_frozen_credentials()
-    os.environ['SPACER_AWS_ACCESS_KEY_ID'] = creds.access_key
-    os.environ['SPACER_AWS_SECRET_ACCESS_KEY'] = creds.secret_key
+    os.environ["SPACER_AWS_ACCESS_KEY_ID"] = creds.access_key
+    os.environ["SPACER_AWS_SECRET_ACCESS_KEY"] = creds.secret_key
     if creds.token:
-        os.environ['SPACER_AWS_SESSION_TOKEN'] = creds.token
+        os.environ["SPACER_AWS_SESSION_TOKEN"] = creds.token
 
 # Normalize Settings -> SPACER_*/MLFLOW_* env vars now (this used to be an import
 # side effect of mermaid_classifier.pyspacer). MLflowTrainingRunner.__init__ also
 # calls this; it is idempotent.
 from mermaid_classifier.pyspacer.settings import set_env_vars_for_packages
+
 set_env_vars_for_packages()
 
 from mermaid_classifier.pyspacer.train import (
-        DatasetOptions, MLflowOptions, MLflowTrainingRunner, TrainingOptions)
-from mermaid_classifier.training.sample_weighting import (
-        SampleWeightingOptions)
+    DatasetOptions,
+    MLflowOptions,
+    MLflowTrainingRunner,
+    TrainingOptions,
+)
+from mermaid_classifier.training.sample_weighting import SampleWeightingOptions
 from mermaid_classifier.training.subsample import SubsampleOptions
-
 
 # Production recipe, validated on the 20-source / 80-class
 # tiela77_top100_min1k dataset (~1.77M annotations after rollup).
@@ -44,8 +48,8 @@ if __name__ == "__main__":
         dataset_options=DatasetOptions(
             # Specifying False here means you're only training on CoralNet sources.
             include_mermaid=True,
-            coralnet_sources_csv='../sagemaker/configs/tiela77_top108_hierarchy/sources.csv',
-            label_rollup_spec_csv='../sagemaker/configs/tiela77_top108_hierarchy/rollups.csv',
+            coralnet_sources_csv="../sagemaker/configs/tiela77_top108_hierarchy/sources.csv",
+            label_rollup_spec_csv="../sagemaker/configs/tiela77_top108_hierarchy/rollups.csv",
             included_labels_csv="../sagemaker/configs/tiela77_top108_hierarchy/included_labels.csv",
             # Local-dev alternative for fast smoke runs (10 sources):
             # coralnet_sources_csv='../sagemaker/sources/CoralNetSourcesFirst10.csv',
@@ -58,7 +62,7 @@ if __name__ == "__main__":
             # they aren't dropped entirely. Realized subsample on the
             # tiela77 dataset is ~457K rows.
             subsample=SubsampleOptions(
-                strategy='balanced',
+                strategy="balanced",
                 total_annotations=FULL_DATA_TOTAL,
                 min_per_class=200,
             ),
@@ -81,10 +85,10 @@ if __name__ == "__main__":
         ),
         mlflow_options=MLflowOptions(
             experiment_name="pyspacer-beta-test",
-            model_name='GregTest',
+            model_name="GregTest",
             # Logs all input annotations to MLflow (in addition to the
             # always-logged validation split). Also possible to just log a subset.
-            #extra_annotations_to_log='all',
+            # extra_annotations_to_log='all',
         ),
     )
     runner.run()

--- a/scripts/extract_reference_features.py
+++ b/scripts/extract_reference_features.py
@@ -23,6 +23,7 @@ Then run the live gate:
 from __future__ import annotations
 
 import argparse
+from typing import Any
 from urllib.parse import urlparse
 
 import numpy as np
@@ -46,7 +47,7 @@ def main() -> None:
     )
     args = ap.parse_args()
 
-    vectors: list[list[float]] = []
+    vectors: list[Any] = []
     for loc in args.features:
         feats = ImageFeatures.load(_data_location(loc))
         for pf in feats.point_features:

--- a/scripts/extract_reference_features.py
+++ b/scripts/extract_reference_features.py
@@ -19,6 +19,7 @@ Then run the live gate:
   cd tests && uv run --no-sync python -m unittest -v \\
       pyspacer.test_portable_artifact.LiveModelParityTest
 """
+
 from __future__ import annotations
 
 import argparse
@@ -31,8 +32,7 @@ from spacer.data_classes import DataLocation, ImageFeatures
 def _data_location(loc: str) -> DataLocation:
     uri = urlparse(loc)
     if uri.scheme == "s3":
-        return DataLocation(
-            "s3", bucket_name=uri.netloc, key=uri.path.strip("/"))
+        return DataLocation("s3", bucket_name=uri.netloc, key=uri.path.strip("/"))
     return DataLocation("filesystem", key=loc)
 
 
@@ -40,7 +40,8 @@ def main() -> None:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--out", required=True, help="output .npy path")
     ap.add_argument(
-        "features", nargs="+",
+        "features",
+        nargs="+",
         help="pyspacer feature files (.featurevector), local paths or s3:// URIs",
     )
     args = ap.parse_args()
@@ -55,8 +56,7 @@ def main() -> None:
     if X.ndim != 2:
         raise SystemExit(f"expected a 2-D feature matrix; got shape {X.shape}")
     np.save(args.out, X)
-    print(f"wrote {X.shape[0]} real feature vectors "
-          f"(dim {X.shape[1]}) to {args.out}")
+    print(f"wrote {X.shape[0]} real feature vectors (dim {X.shape[1]}) to {args.out}")
 
 
 if __name__ == "__main__":

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -27,8 +27,10 @@ import logging
 import tempfile
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, TypedDict
 
 import mlflow
+import mlflow.artifacts
 import pandas as pd
 import yaml
 from jinja2 import Environment, FileSystemLoader
@@ -79,7 +81,17 @@ TAXONOMIC_METRICS = [
 # (artifact_path, loader_key): loader_key is 'png', 'csv', or 'yaml'.
 # Organized by section for building the template context.
 
-EVALUATION_SECTIONS = {
+
+class _SectionDefRequired(TypedDict):
+    title: str
+    artifacts: list[tuple[str, str]]
+
+
+class _SectionDef(_SectionDefRequired, total=False):
+    optional: bool
+
+
+EVALUATION_SECTIONS: dict[str, _SectionDef] = {
     "confusion_matrix": {
         "title": "Confusion Matrices",
         "artifacts": [
@@ -199,13 +211,15 @@ def load_csv_as_html_table(
     )
 
 
-def load_yaml_file(yaml_path: Path) -> dict:
+def load_yaml_file(yaml_path: Path) -> dict[str, Any]:
     """Read a YAML file and return the parsed dict."""
     with open(yaml_path) as f:
         return yaml.safe_load(f)
 
 
-def _load_artifact(artifact_dir: Path, artifact_path: str, loader_key: str):
+def _load_artifact(
+    artifact_dir: Path, artifact_path: str, loader_key: str
+) -> str | dict[str, Any] | None:
     """Load a single artifact if it exists, return None otherwise."""
     full_path = artifact_dir / artifact_path
     if not full_path.exists():
@@ -239,7 +253,7 @@ def _artifact_key(artifact_path: str) -> str:
 # -- Data fetching --
 
 
-def fetch_run_metadata(client: MlflowClient, run) -> dict:
+def fetch_run_metadata(client: MlflowClient, run: Any) -> dict[str, Any]:
     """Extract run info, params, tags, and experiment name."""
     experiment = client.get_experiment(run.info.experiment_id)
 
@@ -267,7 +281,7 @@ def fetch_run_metadata(client: MlflowClient, run) -> dict:
     }
 
 
-def fetch_scalar_metrics(run) -> dict:
+def fetch_scalar_metrics(run: Any) -> dict[str, Any]:
     """Organize run.data.metrics into named groups for the template.
 
     Each group is a list of (label, value) tuples, or None if no
@@ -275,8 +289,8 @@ def fetch_scalar_metrics(run) -> dict:
     """
     all_metrics = run.data.metrics
 
-    def _build_group(spec):
-        items = []
+    def _build_group(spec: list[tuple[str, str]]) -> list[tuple[str, Any]] | None:
+        items: list[tuple[str, Any]] = []
         for key, label in spec:
             if key in all_metrics:
                 items.append((label, all_metrics[key]))
@@ -314,7 +328,7 @@ def download_run_artifacts(run_id: str, dst_dir: Path) -> Path:
     return dst_dir
 
 
-def load_artifact_data(artifact_dir: Path) -> dict:
+def load_artifact_data(artifact_dir: Path) -> dict[str, Any]:
     """Load all known artifacts from the downloaded directory.
 
     Returns a nested dict suitable for the Jinja2 template context.
@@ -364,11 +378,11 @@ def load_artifact_data(artifact_dir: Path) -> dict:
 
 
 def build_template_context(
-    metadata: dict,
-    metrics: dict,
-    artifacts: dict,
+    metadata: dict[str, Any],
+    metrics: dict[str, Any],
+    artifacts: dict[str, Any],
     title: str | None = None,
-) -> dict:
+) -> dict[str, Any]:
     """Assemble everything into the context dict for Jinja2."""
     if title is None:
         title = f"Classifier Report - {metadata['experiment_name']} - {metadata['run_name']}"
@@ -400,7 +414,7 @@ def build_template_context(
     }
 
 
-def render_report(context: dict, output_path: Path):
+def render_report(context: dict[str, Any], output_path: Path) -> None:
     """Load the Jinja2 template, render with context, write to output_path."""
     template_dir = Path(__file__).parent
     env = Environment(

--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -20,11 +20,12 @@ Usage:
         --mlflow-tracking-uri arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-2OMU4VP53ZS2 \
         --output report.html
 """
+
 import argparse
 import base64
 import logging
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import mlflow
@@ -41,37 +42,37 @@ logger = logging.getLogger(__name__)
 # -- Metric groupings for the executive summary --
 
 EXECUTIVE_METRICS = [
-    ('accuracy', 'Accuracy'),
-    ('balanced_accuracy', 'Balanced Accuracy'),
-    ('f1_macro', 'F1 (Macro)'),
-    ('precision_macro', 'Precision (Macro)'),
-    ('recall_macro', 'Recall (Macro)'),
-    ('mcc', 'MCC'),
-    ('ece', 'ECE'),
-    ('log_loss', 'Log Loss'),
+    ("accuracy", "Accuracy"),
+    ("balanced_accuracy", "Balanced Accuracy"),
+    ("f1_macro", "F1 (Macro)"),
+    ("precision_macro", "Precision (Macro)"),
+    ("recall_macro", "Recall (Macro)"),
+    ("mcc", "MCC"),
+    ("ece", "ECE"),
+    ("log_loss", "Log Loss"),
 ]
 
 TOPK_METRICS = [
-    ('top_1_accuracy', 'Top-1'),
-    ('top_3_accuracy', 'Top-3'),
-    ('top_5_accuracy', 'Top-5'),
-    ('top_10_accuracy', 'Top-10'),
-    ('mrr', 'MRR'),
-    ('hierarchical_top_5_mean_similarity', 'Hierarchical Top-5 Similarity'),
+    ("top_1_accuracy", "Top-1"),
+    ("top_3_accuracy", "Top-3"),
+    ("top_5_accuracy", "Top-5"),
+    ("top_10_accuracy", "Top-10"),
+    ("mrr", "MRR"),
+    ("hierarchical_top_5_mean_similarity", "Hierarchical Top-5 Similarity"),
 ]
 
 COVER_METRICS = [
-    ('cover_mean_abs_bias_pct', 'Mean Abs Bias %'),
-    ('cover_mean_rmse_pct', 'Mean RMSE %'),
-    ('cover_mean_mae_pct', 'Mean MAE %'),
-    ('cover_median_r_squared', 'Median R-squared'),
+    ("cover_mean_abs_bias_pct", "Mean Abs Bias %"),
+    ("cover_mean_rmse_pct", "Mean RMSE %"),
+    ("cover_mean_mae_pct", "Mean MAE %"),
+    ("cover_median_r_squared", "Median R-squared"),
 ]
 
 TAXONOMIC_METRICS = [
-    ('cross_branch_error_rate', 'Cross-Branch Error Rate'),
-    ('within_branch_error_rate', 'Within-Branch Error Rate'),
-    ('gf_accuracy_gf_relevant', 'GF Accuracy (GF-relevant)'),
-    ('within_ba_gf_accuracy', 'Within-BA GF Accuracy'),
+    ("cross_branch_error_rate", "Cross-Branch Error Rate"),
+    ("within_branch_error_rate", "Within-Branch Error Rate"),
+    ("gf_accuracy_gf_relevant", "GF Accuracy (GF-relevant)"),
+    ("within_ba_gf_accuracy", "Within-BA GF Accuracy"),
 ]
 
 # -- Artifact manifest --
@@ -79,99 +80,100 @@ TAXONOMIC_METRICS = [
 # Organized by section for building the template context.
 
 EVALUATION_SECTIONS = {
-    'confusion_matrix': {
-        'title': 'Confusion Matrices',
-        'artifacts': [
-            ('confusion_matrix/frequencies.png', 'png'),
-            ('confusion_matrix/percents.png', 'png'),
-            ('confusion_matrix/frequencies.csv', 'csv'),
-            ('confusion_matrix/percents.csv', 'csv'),
+    "confusion_matrix": {
+        "title": "Confusion Matrices",
+        "artifacts": [
+            ("confusion_matrix/frequencies.png", "png"),
+            ("confusion_matrix/percents.png", "png"),
+            ("confusion_matrix/frequencies.csv", "csv"),
+            ("confusion_matrix/percents.csv", "csv"),
         ],
     },
-    'calibration': {
-        'title': 'Calibration',
-        'artifacts': [
-            ('calibration/reliability_diagram.png', 'png'),
-            ('calibration/per_bin_details.csv', 'csv'),
-            ('calibration/per_category_ece.csv', 'csv'),
+    "calibration": {
+        "title": "Calibration",
+        "artifacts": [
+            ("calibration/reliability_diagram.png", "png"),
+            ("calibration/per_bin_details.csv", "csv"),
+            ("calibration/per_category_ece.csv", "csv"),
         ],
     },
-    'cover': {
-        'title': 'Cover Analysis',
-        'optional': True,
-        'artifacts': [
-            ('cover/per_class_bias.png', 'png'),
-            ('cover/per_class_cover_metrics.csv', 'csv'),
+    "cover": {
+        "title": "Cover Analysis",
+        "optional": True,
+        "artifacts": [
+            ("cover/per_class_bias.png", "png"),
+            ("cover/per_class_cover_metrics.csv", "csv"),
         ],
     },
-    'probability': {
-        'title': 'Probability / Log Loss',
-        'optional': True,
-        'artifacts': [
-            ('probability/per_category_log_loss.png', 'png'),
-            ('probability/per_category_log_loss.csv', 'csv'),
+    "probability": {
+        "title": "Probability / Log Loss",
+        "optional": True,
+        "artifacts": [
+            ("probability/per_category_log_loss.png", "png"),
+            ("probability/per_category_log_loss.csv", "csv"),
         ],
     },
-    'ranking': {
-        'title': 'Ranking',
-        'optional': True,
-        'artifacts': [
-            ('ranking/per_category_topk.png', 'png'),
-            ('ranking/per_category_topk.csv', 'csv'),
-            ('ranking/hierarchical_topk.csv', 'csv'),
+    "ranking": {
+        "title": "Ranking",
+        "optional": True,
+        "artifacts": [
+            ("ranking/per_category_topk.png", "png"),
+            ("ranking/per_category_topk.csv", "csv"),
+            ("ranking/hierarchical_topk.csv", "csv"),
         ],
     },
-    'taxonomic': {
-        'title': 'Taxonomic Error Analysis',
-        'artifacts': [
-            ('taxonomic/error_attribution.png', 'png'),
-            ('taxonomic/error_attribution.csv', 'csv'),
-            ('taxonomic/top_level_confusion.png', 'png'),
-            ('taxonomic/top_level_confusions.csv', 'csv'),
-            ('taxonomic/gf_confusion.png', 'png'),
-            ('taxonomic/gf_precision_recall_f1.csv', 'csv'),
+    "taxonomic": {
+        "title": "Taxonomic Error Analysis",
+        "artifacts": [
+            ("taxonomic/error_attribution.png", "png"),
+            ("taxonomic/error_attribution.csv", "csv"),
+            ("taxonomic/top_level_confusion.png", "png"),
+            ("taxonomic/top_level_confusions.csv", "csv"),
+            ("taxonomic/gf_confusion.png", "png"),
+            ("taxonomic/gf_precision_recall_f1.csv", "csv"),
         ],
     },
-    'per_source': {
-        'title': 'Per-Source Breakdown',
-        'optional': True,
-        'artifacts': [
-            ('per_source/accuracy_by_source.png', 'png'),
-            ('per_source/metrics.csv', 'csv'),
+    "per_source": {
+        "title": "Per-Source Breakdown",
+        "optional": True,
+        "artifacts": [
+            ("per_source/accuracy_by_source.png", "png"),
+            ("per_source/metrics.csv", "csv"),
         ],
     },
 }
 
 ROOT_EVALUATION_ARTIFACTS = [
-    ('metrics_per_label.csv', 'csv'),
-    ('metrics_overall.yaml', 'yaml'),
+    ("metrics_per_label.csv", "csv"),
+    ("metrics_overall.yaml", "yaml"),
 ]
 
 TRAINING_ARTIFACTS = [
-    ('system_specs.yaml', 'yaml'),
-    ('train_summary.yaml', 'yaml'),
-    ('other_options.yaml', 'yaml'),
-    ('epoch_ref_accuracies.yaml', 'yaml'),
-    ('coralnet_sources_included.csv', 'csv'),
-    ('labels_included.csv', 'csv'),
-    ('labels_excluded.csv', 'csv'),
-    ('rollup_spec.csv', 'csv'),
-    ('project_stats_raw.csv', 'csv'),
-    ('project_stats_train_data.csv', 'csv'),
-    ('ba_counts.csv', 'csv'),
-    ('bagf_counts.csv', 'csv'),
-    ('coralnet_label_mapping.csv', 'csv'),
-    ('unmapped_labels.csv', 'csv'),
+    ("system_specs.yaml", "yaml"),
+    ("train_summary.yaml", "yaml"),
+    ("other_options.yaml", "yaml"),
+    ("epoch_ref_accuracies.yaml", "yaml"),
+    ("coralnet_sources_included.csv", "csv"),
+    ("labels_included.csv", "csv"),
+    ("labels_excluded.csv", "csv"),
+    ("rollup_spec.csv", "csv"),
+    ("project_stats_raw.csv", "csv"),
+    ("project_stats_train_data.csv", "csv"),
+    ("ba_counts.csv", "csv"),
+    ("bagf_counts.csv", "csv"),
+    ("coralnet_label_mapping.csv", "csv"),
+    ("unmapped_labels.csv", "csv"),
 ]
 
 
 # -- Leaf loaders --
 
+
 def encode_png_as_base64(png_path: Path) -> str:
     """Read a PNG file and return a data URI string."""
     data = png_path.read_bytes()
-    b64 = base64.b64encode(data).decode('ascii')
-    return f'data:image/png;base64,{b64}'
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:image/png;base64,{b64}"
 
 
 def load_csv_as_html_table(
@@ -186,14 +188,14 @@ def load_csv_as_html_table(
         # Optional artifacts (e.g. excluded labels or a rollup spec) that
         # weren't specified in the training parameters are still logged as
         # empty (0-cell) CSVs, which pandas can't parse.
-        return '<span>(Empty)</span>'
+        return "<span>(Empty)</span>"
     if sort_by is not None and sort_by in df.columns:
         df = df.sort_values(by=sort_by, ascending=ascending)
     return df.to_html(
         index=False,
-        classes='dataframe',
-        float_format=lambda x: f'{x:.4f}' if abs(x) < 100 else f'{x:.1f}',
-        na_rep='',
+        classes="dataframe",
+        float_format=lambda x: f"{x:.4f}" if abs(x) < 100 else f"{x:.1f}",
+        na_rep="",
     )
 
 
@@ -209,18 +211,18 @@ def _load_artifact(artifact_dir: Path, artifact_path: str, loader_key: str):
     if not full_path.exists():
         return None
 
-    if loader_key == 'png':
+    if loader_key == "png":
         return encode_png_as_base64(full_path)
-    elif loader_key == 'csv':
+    if loader_key == "csv":
         if full_path.stat().st_size == 0:
             return None
         try:
-            if artifact_path == 'metrics_per_label.csv':
-                return load_csv_as_html_table(full_path, sort_by='f1_score', ascending=True)
+            if artifact_path == "metrics_per_label.csv":
+                return load_csv_as_html_table(full_path, sort_by="f1_score", ascending=True)
             return load_csv_as_html_table(full_path)
         except pd.errors.EmptyDataError:
             return None
-    elif loader_key == 'yaml':
+    elif loader_key == "yaml":
         return load_yaml_file(full_path)
     else:
         logger.warning(f"Unknown loader key: {loader_key}")
@@ -231,10 +233,11 @@ def _artifact_key(artifact_path: str) -> str:
     """Convert an artifact path like 'confusion_matrix/frequencies.png'
     to a template key like 'frequencies_png'."""
     name = Path(artifact_path).name
-    return name.replace('.', '_')
+    return name.replace(".", "_")
 
 
 # -- Data fetching --
+
 
 def fetch_run_metadata(client: MlflowClient, run) -> dict:
     """Extract run info, params, tags, and experiment name."""
@@ -242,10 +245,8 @@ def fetch_run_metadata(client: MlflowClient, run) -> dict:
 
     start_ms = run.info.start_time
     end_ms = run.info.end_time
-    start_time = (datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc)
-                  if start_ms else None)
-    end_time = (datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc)
-                if end_ms else None)
+    start_time = datetime.fromtimestamp(start_ms / 1000, tz=UTC) if start_ms else None
+    end_time = datetime.fromtimestamp(end_ms / 1000, tz=UTC) if end_ms else None
     duration = None
     if start_time and end_time:
         delta = end_time - start_time
@@ -254,16 +255,15 @@ def fetch_run_metadata(client: MlflowClient, run) -> dict:
         duration = f"{hours}h {minutes}m {seconds}s"
 
     return {
-        'run_id': run.info.run_id,
-        'run_name': run.info.run_name or run.info.run_id[:8],
-        'experiment_name': experiment.name,
-        'start_time': start_time.strftime('%Y-%m-%d %H:%M UTC') if start_time else 'N/A',
-        'end_time': end_time.strftime('%Y-%m-%d %H:%M UTC') if end_time else 'N/A',
-        'duration': duration or 'N/A',
-        'status': run.info.status,
-        'params': dict(run.data.params),
-        'tags': {k: v for k, v in run.data.tags.items()
-                 if not k.startswith('mlflow.')},
+        "run_id": run.info.run_id,
+        "run_name": run.info.run_name or run.info.run_id[:8],
+        "experiment_name": experiment.name,
+        "start_time": start_time.strftime("%Y-%m-%d %H:%M UTC") if start_time else "N/A",
+        "end_time": end_time.strftime("%Y-%m-%d %H:%M UTC") if end_time else "N/A",
+        "duration": duration or "N/A",
+        "status": run.info.status,
+        "params": dict(run.data.params),
+        "tags": {k: v for k, v in run.data.tags.items() if not k.startswith("mlflow.")},
     }
 
 
@@ -283,10 +283,10 @@ def fetch_scalar_metrics(run) -> dict:
         return items if items else None
 
     return {
-        'executive': _build_group(EXECUTIVE_METRICS),
-        'topk': _build_group(TOPK_METRICS),
-        'cover': _build_group(COVER_METRICS),
-        'taxonomic': _build_group(TAXONOMIC_METRICS),
+        "executive": _build_group(EXECUTIVE_METRICS),
+        "topk": _build_group(TOPK_METRICS),
+        "cover": _build_group(COVER_METRICS),
+        "taxonomic": _build_group(TAXONOMIC_METRICS),
     }
 
 
@@ -302,7 +302,7 @@ def download_run_artifacts(run_id: str, dst_dir: Path) -> Path:
 
     for artifact in top_level:
         # Skip registered model artifacts (can be hundreds of MB).
-        if artifact.path.startswith('model'):
+        if artifact.path.startswith("model"):
             logger.info(f"Skipping model artifact: {artifact.path}")
             continue
         mlflow.artifacts.download_artifacts(
@@ -324,7 +324,7 @@ def load_artifact_data(artifact_dir: Path) -> dict:
     for section_id, section_def in EVALUATION_SECTIONS.items():
         section_data = {}
         has_any = False
-        for artifact_path, loader_key in section_def['artifacts']:
+        for artifact_path, loader_key in section_def["artifacts"]:
             key = _artifact_key(artifact_path)
             value = _load_artifact(artifact_dir, artifact_path, loader_key)
             section_data[key] = value
@@ -332,11 +332,11 @@ def load_artifact_data(artifact_dir: Path) -> dict:
                 has_any = True
 
         if has_any:
-            section_data['title'] = section_def['title']
+            section_data["title"] = section_def["title"]
             sections[section_id] = section_data
-        elif not section_def.get('optional'):
+        elif not section_def.get("optional"):
             # Required section with no artifacts — include with empty data.
-            section_data['title'] = section_def['title']
+            section_data["title"] = section_def["title"]
             sections[section_id] = section_data
 
     # Load root-level evaluation artifacts.
@@ -356,10 +356,10 @@ def load_artifact_data(artifact_dir: Path) -> dict:
             has_training = True
 
     return {
-        'sections': sections,
-        'root_eval': root_eval,
-        'training': training,
-        'has_training': has_training,
+        "sections": sections,
+        "root_eval": root_eval,
+        "training": training,
+        "has_training": has_training,
     }
 
 
@@ -371,28 +371,32 @@ def build_template_context(
 ) -> dict:
     """Assemble everything into the context dict for Jinja2."""
     if title is None:
-        title = (f"Classifier Report - {metadata['experiment_name']} - "
-                 f"{metadata['run_name']}")
+        title = f"Classifier Report - {metadata['experiment_name']} - {metadata['run_name']}"
 
-    params = metadata.get('params') or {}
-    n_classes = params.get('num_classes', '')
-    n_predictions = params.get('num_predictions', '')
+    params = metadata.get("params") or {}
+    n_classes = params.get("num_classes", "")
+    n_predictions = params.get("num_predictions", "")
 
     return {
-        'title': title,
-        'generated_at': datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC'),
-        'metadata': metadata,
-        'metrics': metrics,
-        'sections': artifacts['sections'],
-        'root_eval': artifacts['root_eval'],
-        'training': artifacts['training'],
-        'has_training': artifacts['has_training'],
-        'section_order': [
-            'confusion_matrix', 'calibration', 'cover', 'probability',
-            'ranking', 'taxonomic', 'per_source',
+        "title": title,
+        "generated_at": datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC"),
+        "metadata": metadata,
+        "metrics": metrics,
+        "sections": artifacts["sections"],
+        "root_eval": artifacts["root_eval"],
+        "training": artifacts["training"],
+        "has_training": artifacts["has_training"],
+        "section_order": [
+            "confusion_matrix",
+            "calibration",
+            "cover",
+            "probability",
+            "ranking",
+            "taxonomic",
+            "per_source",
         ],
-        'n_classes': n_classes,
-        'n_predictions': n_predictions,
+        "n_classes": n_classes,
+        "n_predictions": n_predictions,
     }
 
 
@@ -403,7 +407,7 @@ def render_report(context: dict, output_path: Path):
         loader=FileSystemLoader(str(template_dir)),
         autoescape=False,
     )
-    template = env.get_template('report_template.html.j2')
+    template = env.get_template("report_template.html.j2")
     html = template.render(**context)
     output_path.write_text(html)
     size_mb = output_path.stat().st_size / (1024 * 1024)
@@ -413,20 +417,25 @@ def render_report(context: dict, output_path: Path):
 def main():
     set_env_vars_for_packages()
     parser = argparse.ArgumentParser(
-        description="Generate a self-contained HTML report from an MLflow run.")
+        description="Generate a self-contained HTML report from an MLflow run."
+    )
+    parser.add_argument("--run-id", required=True, help="MLflow run ID (32-char hex string)")
     parser.add_argument(
-        "--run-id", required=True,
-        help="MLflow run ID (32-char hex string)")
+        "--output", default=None, help="Output HTML file path (default: report_<run_id>.html)"
+    )
     parser.add_argument(
-        "--output", default=None,
-        help="Output HTML file path (default: report_<run_id>.html)")
+        "--title",
+        default=None,
+        help="Custom report title (default: auto-generated from experiment/run)",
+    )
     parser.add_argument(
-        "--title", default=None,
-        help="Custom report title (default: auto-generated from experiment/run)")
-    parser.add_argument(
-        "--mlflow-tracking-uri", default=None,
-        help=("Override MLflow tracking URI (e.g. a SageMaker MLflow App ARN). "
-              "Defaults to the MLFLOW_TRACKING_SERVER env var / .env value."))
+        "--mlflow-tracking-uri",
+        default=None,
+        help=(
+            "Override MLflow tracking URI (e.g. a SageMaker MLflow App ARN). "
+            "Defaults to the MLFLOW_TRACKING_SERVER env var / .env value."
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -454,13 +463,11 @@ def main():
         artifacts = load_artifact_data(artifact_dir)
 
     # Build context and render.
-    context = build_template_context(metadata, metrics, artifacts,
-                                     title=args.title)
+    context = build_template_context(metadata, metrics, artifacts, title=args.title)
 
-    output_path = Path(args.output) if args.output else Path(
-        f"report_{args.run_id[:8]}.html")
+    output_path = Path(args.output) if args.output else Path(f"report_{args.run_id[:8]}.html")
     render_report(context, output_path)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/scripts/generate_training_config.py
+++ b/scripts/generate_training_config.py
@@ -35,6 +35,7 @@ import logging
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any, TypedDict
 
 import pandas as pd
 
@@ -116,7 +117,7 @@ def _load_species_gf_lookup(labels_df: pd.DataFrame) -> dict[str, str]:
         if "," in raw:
             continue  # multi-value: bucket choices, not inherent GF
         bucket = _porites_bucket(raw)
-        lookup[row["id"]] = bucket
+        lookup[str(row["id"])] = bucket
     return lookup
 
 
@@ -133,10 +134,23 @@ def _build_bucket_gf_uuid_lookup(gf_library: GrowthFormLibrary) -> dict[str, str
     return out
 
 
+class _FileAudit(TypedDict):
+    path: str
+    mtime: str
+    sha1_prefix: str
+
+
+class _Audits(TypedDict):
+    labels: _FileAudit
+    sources: _FileAudit
+    ba_api: str
+    cn_api: str
+
+
 # ---------- File audit ----------
 
 
-def _file_audit(path: Path) -> dict:
+def _file_audit(path: Path) -> _FileAudit:
     if not path.exists():
         return {"path": str(path), "mtime": "MISSING", "sha1_prefix": "MISSING"}
     stat = path.stat()
@@ -153,7 +167,7 @@ def _file_audit(path: Path) -> dict:
     }
 
 
-def _iter_audit(items, key=None) -> str:
+def _iter_audit(items: Any, key: Any = None) -> str:
     """sha1 prefix of a JSON-stringified iterable.
 
     `key` extracts a hashable representation of each item; defaults to
@@ -381,7 +395,7 @@ def build_included_label_rows(
 # ---------- Step D: writers ----------
 
 
-def write_rollups_csv(rows, out_path: Path) -> int:
+def write_rollups_csv(rows: list[tuple[str, str, str, str]], out_path: Path) -> int:
     with out_path.open("w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["from_ba_id", "from_gf_id", "to_ba_id", "to_gf_id"])
@@ -390,7 +404,7 @@ def write_rollups_csv(rows, out_path: Path) -> int:
     return len(rows)
 
 
-def write_included_labels_csv(rows, out_path: Path) -> int:
+def write_included_labels_csv(rows: list[tuple[str, str]], out_path: Path) -> int:
     with out_path.open("w", newline="") as f:
         w = csv.writer(f)
         w.writerow(["ba_id", "gf_id"])
@@ -417,8 +431,8 @@ def copy_sources_csv(in_path: Path, out_path: Path) -> int:
 
 def write_readme(
     out_path: Path,
-    audits: dict[str, dict],
-    counts: dict,
+    audits: _Audits,
+    counts: dict[str, Any],
     unresolved_top108: list[str],
     excluded_top108_seen: list[str],
 ) -> None:
@@ -558,7 +572,7 @@ def validate_outputs(out_dir: Path) -> None:
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description=__doc__.split("\n", 1)[0],
+        description=(__doc__ or "").split("\n", 1)[0],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
@@ -589,7 +603,7 @@ def main(argv: list[str] | None = None) -> int:
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
-    audits = {
+    audits: _Audits = {
         "labels": _file_audit(args.labels_csv),
         "sources": _file_audit(args.sources_csv),
         "ba_api": "n/a",
@@ -605,7 +619,9 @@ def main(argv: list[str] | None = None) -> int:
     missing = required - set(labels_df.columns)
     if missing:
         raise ValueError(f"labels CSV {args.labels_csv} missing columns: {sorted(missing)}")
-    top108_df = labels_df[labels_df["top100"].fillna(0).astype(int) == 1].reset_index(drop=True)
+    top108_df: pd.DataFrame = labels_df[labels_df["top100"].fillna(0).astype(int) == 1].reset_index(
+        drop=True
+    )  # pyright: ignore[reportAssignmentType]  # pandas boolean-index always returns DataFrame here
     logger.info(
         "Loaded %d top-108 rows from %s",
         len(top108_df),

--- a/scripts/generate_training_config.py
+++ b/scripts/generate_training_config.py
@@ -24,6 +24,7 @@ Run from the mermaid-classifier directory:
 The script is the documented way to regenerate the training config on
 demand. See `--help`.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -32,7 +33,7 @@ import hashlib
 import json
 import logging
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pandas as pd
@@ -47,28 +48,31 @@ from mermaid_classifier.pyspacer.settings import set_env_vars_for_packages
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKSPACE_ROOT = REPO_ROOT.parent
 
-DEFAULT_OUTPUT_DIR = WORKSPACE_ROOT / 'sagemaker' / 'configs' / 'coralnet_top108'
-DEFAULT_SOURCES_CSV = WORKSPACE_ROOT / 'sagemaker' / 'sources' / 'CoralNetSourcesKept.csv'
-DEFAULT_LABELS_CSV = WORKSPACE_ROOT / 'drive_label_mappings' / (
-    'coralnet_labels_mermaid_mapping_annotations - mapped_to_mermaid_attributes.csv'
+DEFAULT_OUTPUT_DIR = WORKSPACE_ROOT / "sagemaker" / "configs" / "coralnet_top108"
+DEFAULT_SOURCES_CSV = WORKSPACE_ROOT / "sagemaker" / "sources" / "CoralNetSourcesKept.csv"
+DEFAULT_LABELS_CSV = (
+    WORKSPACE_ROOT
+    / "drive_label_mappings"
+    / ("coralnet_labels_mermaid_mapping_annotations - mapped_to_mermaid_attributes.csv")
 )
 
 # Porites is the only genus that retains GF distinctions (Iain confirmed
 # with Emily 2026-05-08). The bucket names are MERMAID growth-form names
 # resolved to UUIDs at runtime via GrowthFormLibrary.
-PORITES_NAME = 'Porites'
-PORITES_KEPT_GF_NAMES = ('Branching', 'Massive')
+PORITES_NAME = "Porites"
+PORITES_KEPT_GF_NAMES = ("Branching", "Massive")
 
 # Excluded by name; defensive against the labels CSV being updated to
 # set top100=1 for any of these. Annotations of these labels are dropped
 # entirely (not rolled up to a parent — see priority_notes in the labels
 # CSV for rationale; e.g. Dead coral would otherwise pollute Bare substrate).
-EXCLUDED_NAMES = ('Dead coral', 'Bleached coral', 'Other invertebrates')
+EXCLUDED_NAMES = ("Dead coral", "Bleached coral", "Other invertebrates")
 
 logger = logging.getLogger(__name__)
 
 
 # ---------- API client constructors (injection points for tests) ----------
+
 
 def _load_ba_library() -> BenthicAttributeLibrary:
     return BenthicAttributeLibrary()
@@ -84,12 +88,13 @@ def _load_cn_mapping() -> CoralNetMermaidMapping:
 
 # ---------- Porites GF helpers ----------
 
+
 def _porites_bucket(gf_name: str) -> str:
     """Map any GF name to one of PORITES_KEPT_GF_NAMES, or '' for the
     'other/none' bucket. Case-insensitive.
     """
-    canonical = (gf_name or '').strip().title()
-    return canonical if canonical in PORITES_KEPT_GF_NAMES else ''
+    canonical = (gf_name or "").strip().title()
+    return canonical if canonical in PORITES_KEPT_GF_NAMES else ""
 
 
 def _load_species_gf_lookup(labels_df: pd.DataFrame) -> dict[str, str]:
@@ -101,49 +106,50 @@ def _load_species_gf_lookup(labels_df: pd.DataFrame) -> dict[str, str]:
     'branching, massive, other/none') describe bucket *choices* for a
     parent rather than an inherent GF, so they're skipped.
     """
-    if 'growth forms' not in labels_df.columns:
+    if "growth forms" not in labels_df.columns:
         return {}
     lookup: dict[str, str] = {}
     for _, row in labels_df.iterrows():
-        raw = row.get('growth forms')
+        raw = row.get("growth forms")
         if not isinstance(raw, str) or not raw.strip():
             continue
-        if ',' in raw:
+        if "," in raw:
             continue  # multi-value: bucket choices, not inherent GF
         bucket = _porites_bucket(raw)
-        lookup[row['id']] = bucket
+        lookup[row["id"]] = bucket
     return lookup
 
 
 def _build_bucket_gf_uuid_lookup(gf_library: GrowthFormLibrary) -> dict[str, str]:
     """{'': '', 'Branching': <uuid>, 'Massive': <uuid>}."""
     name_to_uuid = {name: uuid for uuid, name in gf_library.by_id.items()}
-    out = {'': ''}
+    out = {"": ""}
     for bucket in PORITES_KEPT_GF_NAMES:
         if bucket not in name_to_uuid:
             raise KeyError(
-                f"GrowthFormLibrary has no '{bucket}' growth form;"
-                f" cannot build Porites buckets.")
+                f"GrowthFormLibrary has no '{bucket}' growth form; cannot build Porites buckets."
+            )
         out[bucket] = name_to_uuid[bucket]
     return out
 
 
 # ---------- File audit ----------
 
+
 def _file_audit(path: Path) -> dict:
     if not path.exists():
-        return {'path': str(path), 'mtime': 'MISSING', 'sha1_prefix': 'MISSING'}
+        return {"path": str(path), "mtime": "MISSING", "sha1_prefix": "MISSING"}
     stat = path.stat()
     h = hashlib.sha1()
-    with path.open('rb') as f:
+    with path.open("rb") as f:
         while chunk := f.read(65536):
             h.update(chunk)
     return {
-        'path': str(path.relative_to(WORKSPACE_ROOT))
-                if path.is_relative_to(WORKSPACE_ROOT) else str(path),
-        'mtime': datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc)
-                  .strftime('%Y-%m-%d %H:%M:%S UTC'),
-        'sha1_prefix': h.hexdigest()[:10],
+        "path": str(path.relative_to(WORKSPACE_ROOT))
+        if path.is_relative_to(WORKSPACE_ROOT)
+        else str(path),
+        "mtime": datetime.fromtimestamp(stat.st_mtime, tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC"),
+        "sha1_prefix": h.hexdigest()[:10],
     }
 
 
@@ -157,16 +163,16 @@ def _iter_audit(items, key=None) -> str:
     for item in items:
         if key is not None:
             payload = key(item)
-        elif hasattr(item, '__dict__'):
+        elif hasattr(item, "__dict__"):
             payload = item.__dict__
         else:
             payload = item
-        h.update(json.dumps(payload, sort_keys=True, default=str)
-                 .encode('utf-8'))
+        h.update(json.dumps(payload, sort_keys=True, default=str).encode("utf-8"))
     return h.hexdigest()[:10]
 
 
 # ---------- Step A: top-108 set ----------
+
 
 def resolve_top108_uuids(
     top108_df: pd.DataFrame,
@@ -184,7 +190,7 @@ def resolve_top108_uuids(
     uuids: set[str] = set()
     unresolved: list[str] = []
     excluded_seen: list[str] = []
-    for name in top108_df['name']:
+    for name in top108_df["name"]:
         if name in EXCLUDED_NAMES:
             excluded_seen.append(name)
             continue
@@ -195,12 +201,14 @@ def resolve_top108_uuids(
     if unresolved:
         logger.warning(
             "%d top-108 name(s) not in MERMAID API: %s",
-            len(unresolved), sorted(unresolved),
+            len(unresolved),
+            sorted(unresolved),
         )
     if excluded_seen:
         logger.warning(
             "%d top-108 name(s) excluded by EXCLUDED_NAMES: %s",
-            len(excluded_seen), sorted(excluded_seen),
+            len(excluded_seen),
+            sorted(excluded_seen),
         )
     return uuids, unresolved, excluded_seen
 
@@ -224,6 +232,7 @@ def resolve_excluded_uuids(
 
 # ---------- Step B: hierarchy walk -> rollup rows ----------
 
+
 def build_rollup_rows(
     cn_mapping: CoralNetMermaidMapping,
     ba_lib: BenthicAttributeLibrary,
@@ -246,24 +255,26 @@ def build_rollup_rows(
     """
     rollups: dict[tuple[str, str], tuple[str, str]] = {}
     dropped = {
-        'no_top_level': 0, 'unknown_uuid': 0, 'null_ba': 0,
-        'excluded': 0,
+        "no_top_level": 0,
+        "unknown_uuid": 0,
+        "null_ba": 0,
+        "excluded": 0,
     }
     for entry in cn_mapping.mapping.values():
         src_ba = entry.benthic_attribute_id
-        src_gf = entry.growth_form_id or ''
+        src_gf = entry.growth_form_id or ""
         if not src_ba:
-            dropped['null_ba'] += 1
+            dropped["null_ba"] += 1
             continue
         if src_ba in excluded_uuids:
-            dropped['excluded'] += 1
+            dropped["excluded"] += 1
             continue
         if src_ba not in ba_lib.by_id:
-            dropped['unknown_uuid'] += 1
+            dropped["unknown_uuid"] += 1
             logger.warning(
-                "CoralNet provider_id %s maps to BA UUID %s not in the live"
-                " MERMAID API; dropping.",
-                entry.provider_id, src_ba,
+                "CoralNet provider_id %s maps to BA UUID %s not in the live MERMAID API; dropping.",
+                entry.provider_id,
+                src_ba,
             )
             continue
 
@@ -271,12 +282,10 @@ def build_rollup_rows(
         if src_ba in top108_uuids:
             target_ba = src_ba
         else:
-            ancestors_leaf_first = list(
-                reversed(ba_lib.get_ancestor_ids(src_ba)))
-            target_ba = next(
-                (a for a in ancestors_leaf_first if a in top108_uuids), None)
+            ancestors_leaf_first = list(reversed(ba_lib.get_ancestor_ids(src_ba)))
+            target_ba = next((a for a in ancestors_leaf_first if a in top108_uuids), None)
             if target_ba is None:
-                dropped['no_top_level'] += 1
+                dropped["no_top_level"] += 1
                 continue
 
         # Determine target_gf. Porites is special; everyone else collapses.
@@ -285,13 +294,13 @@ def build_rollup_rows(
                 bucket_name = _porites_bucket(gf_library.id_to_name(src_gf))
             elif src_ba == porites_uuid:
                 # Porites genus, no CN GF -> the empty bucket.
-                bucket_name = ''
+                bucket_name = ""
             else:
                 # Porites species, no CN GF -> use species' inherent.
-                bucket_name = species_gf_lookup.get(src_ba, '')
+                bucket_name = species_gf_lookup.get(src_ba, "")
             target_gf = bucket_gf_uuid_lookup[bucket_name]
         else:
-            target_gf = ''
+            target_gf = ""
 
         # Skip self-mappings (no rollup needed).
         if (src_ba, src_gf) == (target_ba, target_gf):
@@ -299,18 +308,17 @@ def build_rollup_rows(
         rollups[(src_ba, src_gf)] = (target_ba, target_gf)
 
     rows = sorted(
-        (src_ba, src_gf, to_ba, to_gf)
-        for (src_ba, src_gf), (to_ba, to_gf) in rollups.items()
+        (src_ba, src_gf, to_ba, to_gf) for (src_ba, src_gf), (to_ba, to_gf) in rollups.items()
     )
     # Categorize the deduped rollup rows for README reporting.
     breakdown = {
-        'gf_collapse': sum(
-            1 for (sb, _), (tb, _) in rollups.items() if sb == tb),
-        'cross_ba': sum(
-            1 for (sb, _), (tb, _) in rollups.items() if sb != tb),
+        "gf_collapse": sum(1 for (sb, _), (tb, _) in rollups.items() if sb == tb),
+        "cross_ba": sum(1 for (sb, _), (tb, _) in rollups.items() if sb != tb),
     }
     porites_breakdown = _categorize_porites_rollups(
-        rollups, porites_uuid, bucket_gf_uuid_lookup,
+        rollups,
+        porites_uuid,
+        bucket_gf_uuid_lookup,
     )
     return rows, {**dropped, **breakdown, **porites_breakdown}
 
@@ -327,30 +335,31 @@ def _categorize_porites_rollups(
     (from_ba, from_gf) key).
     """
     out = {
-        'porites_genus_gf_collapse': 0,
-        'porites_species_to_branching': 0,
-        'porites_species_to_massive': 0,
-        'porites_species_to_other': 0,
+        "porites_genus_gf_collapse": 0,
+        "porites_species_to_branching": 0,
+        "porites_species_to_massive": 0,
+        "porites_species_to_other": 0,
     }
     if porites_uuid is None:
         return out
-    branching_uuid = bucket_gf_uuid_lookup.get('Branching', '')
-    massive_uuid = bucket_gf_uuid_lookup.get('Massive', '')
+    branching_uuid = bucket_gf_uuid_lookup.get("Branching", "")
+    massive_uuid = bucket_gf_uuid_lookup.get("Massive", "")
     for (src_ba, _src_gf), (to_ba, to_gf) in rollups.items():
         if to_ba != porites_uuid:
             continue
         if src_ba == porites_uuid:
-            out['porites_genus_gf_collapse'] += 1
+            out["porites_genus_gf_collapse"] += 1
         elif to_gf == branching_uuid:
-            out['porites_species_to_branching'] += 1
+            out["porites_species_to_branching"] += 1
         elif to_gf == massive_uuid:
-            out['porites_species_to_massive'] += 1
+            out["porites_species_to_massive"] += 1
         else:
-            out['porites_species_to_other'] += 1
+            out["porites_species_to_other"] += 1
     return out
 
 
 # ---------- Step C: included labels ----------
+
 
 def build_included_label_rows(
     top108_uuids: set[str],
@@ -361,29 +370,30 @@ def build_included_label_rows(
     rows: set[tuple[str, str]] = set()
     for uuid in top108_uuids:
         if porites_uuid is not None and uuid == porites_uuid:
-            rows.add((porites_uuid, ''))
+            rows.add((porites_uuid, ""))
             for bucket in PORITES_KEPT_GF_NAMES:
                 rows.add((porites_uuid, bucket_gf_uuid_lookup[bucket]))
         else:
-            rows.add((uuid, ''))
+            rows.add((uuid, ""))
     return sorted(rows)
 
 
 # ---------- Step D: writers ----------
 
+
 def write_rollups_csv(rows, out_path: Path) -> int:
-    with out_path.open('w', newline='') as f:
+    with out_path.open("w", newline="") as f:
         w = csv.writer(f)
-        w.writerow(['from_ba_id', 'from_gf_id', 'to_ba_id', 'to_gf_id'])
+        w.writerow(["from_ba_id", "from_gf_id", "to_ba_id", "to_gf_id"])
         for r in rows:
             w.writerow(r)
     return len(rows)
 
 
 def write_included_labels_csv(rows, out_path: Path) -> int:
-    with out_path.open('w', newline='') as f:
+    with out_path.open("w", newline="") as f:
         w = csv.writer(f)
-        w.writerow(['ba_id', 'gf_id'])
+        w.writerow(["ba_id", "gf_id"])
         for r in rows:
             w.writerow(r)
     return len(rows)
@@ -392,20 +402,18 @@ def write_included_labels_csv(rows, out_path: Path) -> int:
 def copy_sources_csv(in_path: Path, out_path: Path) -> int:
     """Pass-through: read input, normalize id-or-Source-ID column, write."""
     df = pd.read_csv(in_path)
-    if 'id' in df.columns:
-        col = 'id'
-    elif 'Source ID' in df.columns:
-        col = 'Source ID'
+    if "id" in df.columns:
+        col = "id"
+    elif "Source ID" in df.columns:
+        col = "Source ID"
     else:
-        raise ValueError(
-            f"{in_path}: must have an 'id' or 'Source ID' column")
-    out_path.write_text(
-        'id\n' + '\n'.join(str(int(s)) for s in df[col]) + '\n'
-    )
+        raise ValueError(f"{in_path}: must have an 'id' or 'Source ID' column")
+    out_path.write_text("id\n" + "\n".join(str(int(s)) for s in df[col]) + "\n")
     return len(df)
 
 
 # ---------- Step E: README ----------
+
 
 def write_readme(
     out_path: Path,
@@ -414,17 +422,17 @@ def write_readme(
     unresolved_top108: list[str],
     excluded_top108_seen: list[str],
 ) -> None:
-    cli = ' '.join(sys.argv)
-    unresolved_block = ''
+    cli = " ".join(sys.argv)
+    unresolved_block = ""
     if unresolved_top108:
         unresolved_block = (
             "\n## Unresolved top-108 names\n\n"
             f"The following {len(unresolved_top108)} top-108 name(s) were"
             " not found in the live MERMAID API and were skipped (not in"
             " `included_labels.csv`):\n\n"
-            + ''.join(f"- `{n}`\n" for n in sorted(unresolved_top108))
+            + "".join(f"- `{n}`\n" for n in sorted(unresolved_top108))
         )
-    excluded_top108_block = ''
+    excluded_top108_block = ""
     if excluded_top108_seen:
         excluded_top108_block = (
             "\n*Note*: the labels CSV currently sets `top100=1` for"
@@ -433,7 +441,7 @@ def write_readme(
         )
     body = f"""# Training Config: {out_path.parent.name}
 
-Generated {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} by
+Generated {datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")} by
 `scripts/generate_training_config.py`. Regenerate with:
 
 ```
@@ -447,7 +455,7 @@ Replicates the validated EDA notebook
 in CoralNet -> MERMAID -> top-108 hierarchy-walk space, against the live
 MERMAID API. For each CoralNet-mapped benthic attribute:
 
-1. If the BA is in `EXCLUDED_NAMES` ({', '.join(EXCLUDED_NAMES)}), drop entirely.
+1. If the BA is in `EXCLUDED_NAMES` ({", ".join(EXCLUDED_NAMES)}), drop entirely.
 2. If already in the top-108 set, keep as-is.
 3. Otherwise walk parents (nearest first) to find a top-108 ancestor.
 4. Otherwise drop the label (`LabelFilter` removes it at training time).
@@ -456,22 +464,22 @@ MERMAID API. For each CoralNet-mapped benthic attribute:
 
 | File | Modified | sha1[:10] |
 | --- | --- | --- |
-| `{audits['labels']['path']}` | {audits['labels']['mtime']} | `{audits['labels']['sha1_prefix']}` |
-| `{audits['sources']['path']}` | {audits['sources']['mtime']} | `{audits['sources']['sha1_prefix']}` |
+| `{audits["labels"]["path"]}` | {audits["labels"]["mtime"]} | `{audits["labels"]["sha1_prefix"]}` |
+| `{audits["sources"]["path"]}` | {audits["sources"]["mtime"]} | `{audits["sources"]["sha1_prefix"]}` |
 
 Live MERMAID API (snapshotted at run time):
-- `https://api.datamermaid.org/v1/benthicattributes/?limit=5000` -> sha1 `{audits['ba_api']}`
-- `https://api.datamermaid.org/v1/classification/labelmappings/?provider=CoralNet` -> sha1 `{audits['cn_api']}`
+- `https://api.datamermaid.org/v1/benthicattributes/?limit=5000` -> sha1 `{audits["ba_api"]}`
+- `https://api.datamermaid.org/v1/classification/labelmappings/?provider=CoralNet` -> sha1 `{audits["cn_api"]}`
 
 ## Outputs
 
-- `sources.csv` - **{counts['n_sources']}** CoralNet source IDs (pass-through; no filtering).
-- `included_labels.csv` - **{counts['n_included']}** `(ba_id, gf_id)` rows
+- `sources.csv` - **{counts["n_sources"]}** CoralNet source IDs (pass-through; no filtering).
+- `included_labels.csv` - **{counts["n_included"]}** `(ba_id, gf_id)` rows
   (Porites contributes 3 rows for the Branching / Massive / other-none buckets;
   every other top-108 BA contributes 1 row).
-- `rollups.csv` - **{counts['n_rollups']}** unique `(from_ba, from_gf)` rows:
-    - GF-collapse rows (top-108 BA with non-bucket GF -> same BA, empty GF): {counts['n_gf_collapse']}
-    - cross-BA rollups (species or genus -> top-108 ancestor): {counts['n_cross_ba']}
+- `rollups.csv` - **{counts["n_rollups"]}** unique `(from_ba, from_gf)` rows:
+    - GF-collapse rows (top-108 BA with non-bucket GF -> same BA, empty GF): {counts["n_gf_collapse"]}
+    - cross-BA rollups (species or genus -> top-108 ancestor): {counts["n_cross_ba"]}
 
 ### Porites buckets
 
@@ -480,10 +488,10 @@ growth-form distinctions. `included_labels.csv` has three Porites rows:
 `(Porites, Branching)`, `(Porites, Massive)`, `(Porites, '')`.
 
 Rollups feeding the buckets:
-- Porites genus with non-Branching/non-Massive GF -> `(Porites, '')`: {counts['n_porites_genus_gf_collapse']}
-- Porites species -> `(Porites, Branching)`: {counts['n_porites_species_to_branching']}
-- Porites species -> `(Porites, Massive)`: {counts['n_porites_species_to_massive']}
-- Porites species -> `(Porites, '')` (other/no inherent GF): {counts['n_porites_species_to_other']}
+- Porites genus with non-Branching/non-Massive GF -> `(Porites, '')`: {counts["n_porites_genus_gf_collapse"]}
+- Porites species -> `(Porites, Branching)`: {counts["n_porites_species_to_branching"]}
+- Porites species -> `(Porites, Massive)`: {counts["n_porites_species_to_massive"]}
+- Porites species -> `(Porites, '')` (other/no inherent GF): {counts["n_porites_species_to_other"]}
 
 Species' inherent GF comes from the labels CSV's `growth forms` column
 (single-value rows only). CN-supplied GF wins over the inherent GF when
@@ -494,13 +502,13 @@ both are present.
 These labels are excluded from training entirely (no rollup, no class):
 {chr(10).join(f"- `{n}`" for n in EXCLUDED_NAMES)}
 
-CoralNet mappings dropped because their BA is in EXCLUDED_NAMES: {counts['n_excluded']}.
+CoralNet mappings dropped because their BA is in EXCLUDED_NAMES: {counts["n_excluded"]}.
 {excluded_top108_block}
 ### Other dropped CoralNet mappings
 
-- Source BA UUID not in MERMAID API: {counts['n_unknown_uuid']}
-- No top-108 ancestor in the parent chain: {counts['n_no_top_level']}
-- CoralNet mapping with null benthic_attribute_id: {counts['n_null_ba']}
+- Source BA UUID not in MERMAID API: {counts["n_unknown_uuid"]}
+- No top-108 ancestor in the parent chain: {counts["n_no_top_level"]}
+- CoralNet mapping with null benthic_attribute_id: {counts["n_null_ba"]}
 
 ## Deviation from notebook (justified)
 
@@ -518,17 +526,20 @@ Porites is the only exception (see above).
 
 # ---------- Validation ----------
 
+
 def validate_outputs(out_dir: Path) -> None:
     """Round-trip the produced CSVs through the pipeline's CsvSpec subclasses."""
     from mermaid_classifier.pyspacer.train import (
-        CNSourceFilter, LabelFilter, LabelRollupSpec,
+        CNSourceFilter,
+        LabelFilter,
+        LabelRollupSpec,
     )
 
-    with (out_dir / 'sources.csv').open() as f:
+    with (out_dir / "sources.csv").open() as f:
         CNSourceFilter(f)
-    with (out_dir / 'included_labels.csv').open() as f:
+    with (out_dir / "included_labels.csv").open() as f:
         included = LabelFilter(f, inclusion=True)
-    with (out_dir / 'rollups.csv').open() as f:
+    with (out_dir / "rollups.csv").open() as f:
         rollups = LabelRollupSpec(f)
 
     # Soft consistency: every rollup target must be in included_labels.
@@ -544,109 +555,115 @@ def validate_outputs(out_dir: Path) -> None:
 
 # ---------- Main ----------
 
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
-        description=__doc__.split('\n', 1)[0],
+        description=__doc__.split("\n", 1)[0],
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
-    p.add_argument('--output-dir', type=Path, default=DEFAULT_OUTPUT_DIR)
-    p.add_argument('--sources-csv', type=Path, default=DEFAULT_SOURCES_CSV,
-                   help='Pass-through input. Must have an `id` or'
-                        ' `Source ID` column.')
-    p.add_argument('--labels-csv', type=Path, default=DEFAULT_LABELS_CSV,
-                   help='Top-108 source-of-truth. Filter is `top100 == 1`.')
-    p.add_argument('--skip-validation', action='store_true',
-                   help='Skip round-tripping outputs through pipeline'
-                        ' schemas (useful for tests).')
+    p.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR)
+    p.add_argument(
+        "--sources-csv",
+        type=Path,
+        default=DEFAULT_SOURCES_CSV,
+        help="Pass-through input. Must have an `id` or `Source ID` column.",
+    )
+    p.add_argument(
+        "--labels-csv",
+        type=Path,
+        default=DEFAULT_LABELS_CSV,
+        help="Top-108 source-of-truth. Filter is `top100 == 1`.",
+    )
+    p.add_argument(
+        "--skip-validation",
+        action="store_true",
+        help="Skip round-tripping outputs through pipeline schemas (useful for tests).",
+    )
     return p.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
     set_env_vars_for_packages()
-    logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s %(levelname)s %(message)s')
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     args = parse_args(argv)
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     audits = {
-        'labels': _file_audit(args.labels_csv),
-        'sources': _file_audit(args.sources_csv),
-        'ba_api': 'n/a',
-        'cn_api': 'n/a',
+        "labels": _file_audit(args.labels_csv),
+        "sources": _file_audit(args.sources_csv),
+        "ba_api": "n/a",
+        "cn_api": "n/a",
     }
-    if audits['labels']['mtime'] == 'MISSING':
+    if audits["labels"]["mtime"] == "MISSING":
         raise FileNotFoundError(f"labels CSV not found: {args.labels_csv}")
-    if audits['sources']['mtime'] == 'MISSING':
+    if audits["sources"]["mtime"] == "MISSING":
         raise FileNotFoundError(f"sources CSV not found: {args.sources_csv}")
 
     labels_df = pd.read_csv(args.labels_csv)
-    required = {'id', 'name', 'top100'}
+    required = {"id", "name", "top100"}
     missing = required - set(labels_df.columns)
     if missing:
-        raise ValueError(
-            f"labels CSV {args.labels_csv} missing columns: {sorted(missing)}")
-    top108_df = labels_df[
-        labels_df['top100'].fillna(0).astype(int) == 1].reset_index(drop=True)
+        raise ValueError(f"labels CSV {args.labels_csv} missing columns: {sorted(missing)}")
+    top108_df = labels_df[labels_df["top100"].fillna(0).astype(int) == 1].reset_index(drop=True)
     logger.info(
         "Loaded %d top-108 rows from %s",
-        len(top108_df), args.labels_csv.name,
+        len(top108_df),
+        args.labels_csv.name,
     )
 
     ba_lib = _load_ba_library()
-    audits['ba_api'] = _iter_audit(ba_lib.raw_results)
+    audits["ba_api"] = _iter_audit(ba_lib.raw_results)
     gf_library = _load_gf_library()
     cn_mapping = _load_cn_mapping()
     # Touch .mapping to trigger lazy load before fingerprinting.
-    audits['cn_api'] = _iter_audit(cn_mapping.mapping.values())
+    audits["cn_api"] = _iter_audit(cn_mapping.mapping.values())
 
-    top108_uuids, unresolved, excluded_top108_seen = resolve_top108_uuids(
-        top108_df, ba_lib)
+    top108_uuids, unresolved, excluded_top108_seen = resolve_top108_uuids(top108_df, ba_lib)
     excluded_uuids = resolve_excluded_uuids(ba_lib)
     try:
         porites_uuid: str | None = ba_lib.name_to_id(PORITES_NAME)
     except KeyError:
-        logger.warning(
-            "Porites not found in MERMAID API; Porites bucket logic disabled.")
+        logger.warning("Porites not found in MERMAID API; Porites bucket logic disabled.")
         porites_uuid = None
     bucket_gf_uuid_lookup = (
-        _build_bucket_gf_uuid_lookup(gf_library)
-        if porites_uuid is not None else {'': ''}
+        _build_bucket_gf_uuid_lookup(gf_library) if porites_uuid is not None else {"": ""}
     )
     species_gf_lookup = _load_species_gf_lookup(labels_df)
 
     rollup_rows, stats = build_rollup_rows(
-        cn_mapping, ba_lib, gf_library, top108_uuids,
-        porites_uuid, excluded_uuids,
-        bucket_gf_uuid_lookup, species_gf_lookup,
+        cn_mapping,
+        ba_lib,
+        gf_library,
+        top108_uuids,
+        porites_uuid,
+        excluded_uuids,
+        bucket_gf_uuid_lookup,
+        species_gf_lookup,
     )
-    included_rows = build_included_label_rows(
-        top108_uuids, porites_uuid, bucket_gf_uuid_lookup)
+    included_rows = build_included_label_rows(top108_uuids, porites_uuid, bucket_gf_uuid_lookup)
 
-    n_sources = copy_sources_csv(
-        args.sources_csv, args.output_dir / 'sources.csv')
-    n_rollups = write_rollups_csv(
-        rollup_rows, args.output_dir / 'rollups.csv')
-    n_included = write_included_labels_csv(
-        included_rows, args.output_dir / 'included_labels.csv')
+    n_sources = copy_sources_csv(args.sources_csv, args.output_dir / "sources.csv")
+    n_rollups = write_rollups_csv(rollup_rows, args.output_dir / "rollups.csv")
+    n_included = write_included_labels_csv(included_rows, args.output_dir / "included_labels.csv")
 
-    counts = dict(
-        n_sources=n_sources,
-        n_included=n_included,
-        n_rollups=n_rollups,
-        n_gf_collapse=stats['gf_collapse'],
-        n_cross_ba=stats['cross_ba'],
-        n_no_top_level=stats['no_top_level'],
-        n_unknown_uuid=stats['unknown_uuid'],
-        n_null_ba=stats['null_ba'],
-        n_excluded=stats['excluded'],
-        n_porites_genus_gf_collapse=stats['porites_genus_gf_collapse'],
-        n_porites_species_to_branching=stats['porites_species_to_branching'],
-        n_porites_species_to_massive=stats['porites_species_to_massive'],
-        n_porites_species_to_other=stats['porites_species_to_other'],
-    )
+    counts = {
+        "n_sources": n_sources,
+        "n_included": n_included,
+        "n_rollups": n_rollups,
+        "n_gf_collapse": stats["gf_collapse"],
+        "n_cross_ba": stats["cross_ba"],
+        "n_no_top_level": stats["no_top_level"],
+        "n_unknown_uuid": stats["unknown_uuid"],
+        "n_null_ba": stats["null_ba"],
+        "n_excluded": stats["excluded"],
+        "n_porites_genus_gf_collapse": stats["porites_genus_gf_collapse"],
+        "n_porites_species_to_branching": stats["porites_species_to_branching"],
+        "n_porites_species_to_massive": stats["porites_species_to_massive"],
+        "n_porites_species_to_other": stats["porites_species_to_other"],
+    }
     write_readme(
-        out_path=args.output_dir / 'README.md',
+        out_path=args.output_dir / "README.md",
         audits=audits,
         counts=counts,
         unresolved_top108=unresolved,
@@ -660,16 +677,19 @@ def main(argv: list[str] | None = None) -> int:
         "Wrote %d sources, %d included labels, %d rollups"
         " (%d cross-BA, %d GF collapses, %d Porites species buckets,"
         " %d excluded CN entries) to %s",
-        n_sources, n_included, n_rollups,
-        stats['cross_ba'], stats['gf_collapse'],
-        stats['porites_species_to_branching']
-        + stats['porites_species_to_massive']
-        + stats['porites_species_to_other'],
-        stats['excluded'],
+        n_sources,
+        n_included,
+        n_rollups,
+        stats["cross_ba"],
+        stats["gf_collapse"],
+        stats["porites_species_to_branching"]
+        + stats["porites_species_to_massive"]
+        + stats["porites_species_to_other"],
+        stats["excluded"],
         args.output_dir,
     )
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/launch_processing.py
+++ b/scripts/launch_processing.py
@@ -23,10 +23,11 @@ import sys
 import time
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import boto3
 
-from mermaid_classifier.sagemaker.launcher_config import RunConfig, parse_run_config
+from mermaid_classifier.sagemaker.launcher_config import parse_run_config
 
 ACCOUNT = "554812291621"
 REGION = "us-east-1"
@@ -69,22 +70,25 @@ def load_items(csv_path: Path, column: str | None) -> list[str]:
     """Load a column from a CSV. If column is None, use the first column."""
     with open(csv_path, newline="") as f:
         reader = csv.DictReader(f)
+        fieldnames = reader.fieldnames or []
         if column is None:
-            column = reader.fieldnames[0]
-        elif column not in reader.fieldnames:
-            raise ValueError(f"Column {column!r} not in {csv_path}: {reader.fieldnames}")
+            column = fieldnames[0]
+        elif column not in fieldnames:
+            raise ValueError(f"Column {column!r} not in {csv_path}: {fieldnames}")
         return [row[column] for row in reader if row[column]]
 
 
 def build_processing_request(
     *,
-    cfg: RunConfig,
+    cfg: Any,
     run_id: str,
     worker_idx: int,
     worker_items: list[str] | None,
-) -> dict:
+) -> dict[str, Any]:
     job = cfg.job
     proc = cfg.processing
+    if proc is None:
+        raise ValueError("cfg.processing must be set for a processing job")
     container_args = list(proc.container_args)
     if worker_items is not None:
         assert proc.shard is not None, "worker_items requires processing.shard"
@@ -128,7 +132,7 @@ def _configure_logging():
     )
 
 
-def _make_sagemaker_client():
+def _make_sagemaker_client() -> Any:
     from botocore.config import Config
 
     return boto3.client(
@@ -137,7 +141,11 @@ def _make_sagemaker_client():
     )
 
 
-def _wait_for_completion(client, job_names, poll_interval_s=DEFAULT_POLL_INTERVAL_S):
+def _wait_for_completion(
+    client: Any,
+    job_names: list[str],
+    poll_interval_s: float = DEFAULT_POLL_INTERVAL_S,
+) -> dict[str, str]:
     status = dict.fromkeys(job_names, "Pending")
     while True:
         for name in job_names:
@@ -157,7 +165,7 @@ def _wait_for_completion(client, job_names, poll_interval_s=DEFAULT_POLL_INTERVA
         time.sleep(poll_interval_s)
 
 
-def _upload_config_dir(config_dir: Path, run_id: str, s3_client):
+def _upload_config_dir(config_dir: Path, run_id: str, s3_client: Any) -> str:
     key_prefix = f"runs/{run_id}/config"
     for p in sorted(config_dir.rglob("*")):
         if not p.is_file():
@@ -167,7 +175,7 @@ def _upload_config_dir(config_dir: Path, run_id: str, s3_client):
     return f"s3://{STAGING_BUCKET}/{key_prefix}/"
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> None:
     _configure_logging()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--run-config", required=True, type=Path)

--- a/scripts/launch_processing.py
+++ b/scripts/launch_processing.py
@@ -13,6 +13,7 @@ Example
         --run-config sagemaker/runs/my-extraction.yaml \\
         --config-dir sagemaker/configs/my-extraction/
 """
+
 from __future__ import annotations
 
 import argparse
@@ -20,7 +21,7 @@ import csv
 import logging
 import sys
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import boto3
@@ -46,13 +47,12 @@ def expand_image_uri(image: str) -> str:
         raise ValueError(f"Image {image!r} must be `<repo>:<tag>` or a full ECR URI.")
     repo, _ = image.split(":", 1)
     if repo not in KNOWN_SHORT_REPOS:
-        raise ValueError(
-            f"Unknown short-form repo {repo!r}. Known: {sorted(KNOWN_SHORT_REPOS)}.")
+        raise ValueError(f"Unknown short-form repo {repo!r}. Known: {sorted(KNOWN_SHORT_REPOS)}.")
     return f"{ECR_HOST}/{image}"
 
 
 def make_run_id(prefix: str) -> str:
-    return f"{prefix}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    return f"{prefix}-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
 
 
 def chunk_items(items: list[str], n_workers: int) -> list[list[str]]:
@@ -110,9 +110,11 @@ def build_processing_request(
             **job.env,
         },
         "Tags": (
-            [{"Key": "Project", "Value": "mermaid-classifier"},
-             {"Key": "RunId", "Value": run_id},
-             {"Key": "WorkerIdx", "Value": str(worker_idx)}]
+            [
+                {"Key": "Project", "Value": "mermaid-classifier"},
+                {"Key": "RunId", "Value": run_id},
+                {"Key": "WorkerIdx", "Value": str(worker_idx)},
+            ]
             + [{"Key": k, "Value": v} for k, v in job.tags.items()]
         ),
     }
@@ -128,6 +130,7 @@ def _configure_logging():
 
 def _make_sagemaker_client():
     from botocore.config import Config
+
     return boto3.client(
         "sagemaker",
         config=Config(region_name=REGION, retries={"mode": "adaptive", "max_attempts": 10}),
@@ -135,7 +138,7 @@ def _make_sagemaker_client():
 
 
 def _wait_for_completion(client, job_names, poll_interval_s=DEFAULT_POLL_INTERVAL_S):
-    status = {n: "Pending" for n in job_names}
+    status = dict.fromkeys(job_names, "Pending")
     while True:
         for name in job_names:
             if status[name] in TERMINAL_STATES:
@@ -145,8 +148,12 @@ def _wait_for_completion(client, job_names, poll_interval_s=DEFAULT_POLL_INTERVA
         unfinished = [n for n, s in status.items() if s not in TERMINAL_STATES]
         if not unfinished:
             return status
-        log.info("Polling: %d/%d still running; sleeping %ds",
-                 len(unfinished), len(job_names), poll_interval_s)
+        log.info(
+            "Polling: %d/%d still running; sleeping %ds",
+            len(unfinished),
+            len(job_names),
+            poll_interval_s,
+        )
         time.sleep(poll_interval_s)
 
 
@@ -183,18 +190,18 @@ def main(argv=None):
     # Build the request list (with or without shard).
     if cfg.processing.shard:
         items = load_items(
-            args.config_dir / cfg.processing.shard.items_from,
-            cfg.processing.shard.items_column)
+            args.config_dir / cfg.processing.shard.items_from, cfg.processing.shard.items_column
+        )
         chunks = chunk_items(items, cfg.processing.shard.workers)
         log.info("Sharding %d items across %d workers", len(items), len(chunks))
         requests = [
-            build_processing_request(
-                cfg=cfg, run_id=run_id, worker_idx=i, worker_items=chunk)
+            build_processing_request(cfg=cfg, run_id=run_id, worker_idx=i, worker_items=chunk)
             for i, chunk in enumerate(chunks)
         ]
     else:
-        requests = [build_processing_request(
-            cfg=cfg, run_id=run_id, worker_idx=0, worker_items=None)]
+        requests = [
+            build_processing_request(cfg=cfg, run_id=run_id, worker_idx=0, worker_items=None)
+        ]
 
     if args.dry_run:
         print("=" * 60)
@@ -203,7 +210,7 @@ def main(argv=None):
         print(f"run_id:    {run_id}")
         print(f"workers:   {len(requests)}")
         print(f"image:     {expand_image_uri(cfg.job.image)}")
-        print(f"per-worker container_args:")
+        print("per-worker container_args:")
         for i, r in enumerate(requests):
             print(f"  [{i}] {r['AppSpecification']['ContainerArguments']}")
         return
@@ -221,7 +228,8 @@ def main(argv=None):
     cw_url = (
         f"https://{REGION}.console.aws.amazon.com/cloudwatch/home"
         f"?region={REGION}#logsV2:log-groups/log-group/"
-        f"$252Faws$252Fsagemaker$252FProcessingJobs")
+        f"$252Faws$252Fsagemaker$252FProcessingJobs"
+    )
     log.info("CloudWatch: %s", cw_url)
 
     if args.no_wait:

--- a/scripts/launch_training.py
+++ b/scripts/launch_training.py
@@ -21,13 +21,20 @@ import logging
 import sys
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 import boto3
-from sagemaker.estimator import Estimator
-from sagemaker.inputs import TrainingInput
-from sagemaker.session import Session
+from sagemaker.estimator import (  # pyright: ignore[reportMissingImports]  # sagemaker not in lint env
+    Estimator,
+)
+from sagemaker.inputs import (  # pyright: ignore[reportMissingImports]  # sagemaker not in lint env
+    TrainingInput,
+)
+from sagemaker.session import (  # pyright: ignore[reportMissingImports]  # sagemaker not in lint env
+    Session,
+)
 
-from mermaid_classifier.sagemaker.launcher_config import RunConfig, parse_run_config
+from mermaid_classifier.sagemaker.launcher_config import parse_run_config
 
 # Canonical ARNs (see convention doc). Hardcoded by intent; the
 # launcher is bound to the dev account.
@@ -66,12 +73,12 @@ def make_run_id(prefix: str) -> str:
 
 def build_estimator_kwargs(
     *,
-    cfg: RunConfig,
+    cfg: Any,
     run_id: str,
     staging_bucket: str,
     mlflow_uri: str,
-    sm_session,
-) -> dict:
+    sm_session: Any,
+) -> dict[str, Any]:
     job = cfg.job
     env = {
         "MLFLOW_TRACKING_SERVER": mlflow_uri,
@@ -105,7 +112,7 @@ def _configure_logging():
     )
 
 
-def _upload_config_dir(config_dir: Path, run_id: str, sm_session) -> str:
+def _upload_config_dir(config_dir: Path, run_id: str, sm_session: Any) -> str:
     key_prefix = f"runs/{run_id}/config"
     log.info("Uploading %s to s3://%s/%s/", config_dir, STAGING_BUCKET, key_prefix)
     sm_session.upload_data(path=str(config_dir), bucket=STAGING_BUCKET, key_prefix=key_prefix)

--- a/scripts/launch_training.py
+++ b/scripts/launch_training.py
@@ -13,12 +13,13 @@ Example
         --config-dir sagemaker/configs/my-run/ \\
         --mlflow-tracking-uri arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-2OMU4VP53ZS2
 """
+
 from __future__ import annotations
 
 import argparse
 import logging
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import boto3
@@ -54,12 +55,13 @@ def expand_image_uri(image: str) -> str:
     if repo not in KNOWN_SHORT_REPOS:
         raise ValueError(
             f"Unknown short-form repo {repo!r}. Known: {sorted(KNOWN_SHORT_REPOS)}. "
-            f"Use a full ECR URI to override.")
+            f"Use a full ECR URI to override."
+        )
     return f"{ECR_HOST}/{image}"
 
 
 def make_run_id(prefix: str) -> str:
-    return f"{prefix}-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+    return f"{prefix}-{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
 
 
 def build_estimator_kwargs(
@@ -76,19 +78,19 @@ def build_estimator_kwargs(
         "AWS_DEFAULT_REGION": REGION,
         **job.env,
     }
-    kwargs = dict(
-        image_uri=expand_image_uri(job.image),
-        role=EXEC_ROLE,
-        instance_count=job.instance_count,
-        instance_type=job.instance_type,
-        volume_size=job.volume_gb,
-        max_run=job.max_runtime_hours * 3600,
-        output_path=f"s3://{staging_bucket}/runs/{run_id}/output/",
-        environment=env,
-        sagemaker_session=sm_session,
-        base_job_name=job.name_prefix,
-        tags=[{"Key": k, "Value": v} for k, v in job.tags.items()],
-    )
+    kwargs = {
+        "image_uri": expand_image_uri(job.image),
+        "role": EXEC_ROLE,
+        "instance_count": job.instance_count,
+        "instance_type": job.instance_type,
+        "volume_size": job.volume_gb,
+        "max_run": job.max_runtime_hours * 3600,
+        "output_path": f"s3://{staging_bucket}/runs/{run_id}/output/",
+        "environment": env,
+        "sagemaker_session": sm_session,
+        "base_job_name": job.name_prefix,
+        "tags": [{"Key": k, "Value": v} for k, v in job.tags.items()],
+    }
     if job.use_spot:
         kwargs["use_spot_instances"] = True
         kwargs["max_wait"] = job.max_runtime_hours * 3600 + 3600
@@ -106,8 +108,7 @@ def _configure_logging():
 def _upload_config_dir(config_dir: Path, run_id: str, sm_session) -> str:
     key_prefix = f"runs/{run_id}/config"
     log.info("Uploading %s to s3://%s/%s/", config_dir, STAGING_BUCKET, key_prefix)
-    sm_session.upload_data(
-        path=str(config_dir), bucket=STAGING_BUCKET, key_prefix=key_prefix)
+    sm_session.upload_data(path=str(config_dir), bucket=STAGING_BUCKET, key_prefix=key_prefix)
     return f"s3://{STAGING_BUCKET}/{key_prefix}/"
 
 
@@ -116,7 +117,8 @@ def _cloudwatch_url(run_id: str) -> str:
         f"https://{REGION}.console.aws.amazon.com/cloudwatch/home"
         f"?region={REGION}#logsV2:log-groups/log-group/"
         f"$252Faws$252Fsagemaker$252FTrainingJobs"
-        f"/log-events/{run_id}")
+        f"/log-events/{run_id}"
+    )
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -128,8 +130,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--dry-run", action="store_true")
     args = parser.parse_args(argv)
 
-    cfg = parse_run_config(
-        args.run_config.read_text(), kind="training", strict=False)
+    cfg = parse_run_config(args.run_config.read_text(), kind="training", strict=False)
 
     if not args.config_dir.is_dir():
         log.error("Config dir does not exist: %s", args.config_dir)
@@ -158,8 +159,12 @@ def main(argv: list[str] | None = None) -> None:
     _upload_config_dir(args.config_dir.resolve(), run_id, sm_session)
 
     kwargs = build_estimator_kwargs(
-        cfg=cfg, run_id=run_id, staging_bucket=STAGING_BUCKET,
-        mlflow_uri=args.mlflow_tracking_uri, sm_session=sm_session)
+        cfg=cfg,
+        run_id=run_id,
+        staging_bucket=STAGING_BUCKET,
+        mlflow_uri=args.mlflow_tracking_uri,
+        sm_session=sm_session,
+    )
 
     log.info("Run ID:       %s", run_id)
     log.info("CloudWatch:   %s", cw_url)
@@ -168,8 +173,8 @@ def main(argv: list[str] | None = None) -> None:
     estimator = Estimator(**kwargs)
     inputs = {
         "config": TrainingInput(
-            s3_data=f"s3://{STAGING_BUCKET}/runs/{run_id}/config/",
-            input_mode="File"),
+            s3_data=f"s3://{STAGING_BUCKET}/runs/{run_id}/config/", input_mode="File"
+        ),
     }
     # Additional channels from cfg.training.channels:
     if cfg.training:

--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -7,9 +7,11 @@ S3 URIs. The GitHub workflow wraps this with OIDC auth and `gh release create`.
 
 Run: uv run python scripts/release_artifact.py --mlflow-model-id m-... --version vN
 """
+
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import re
 import shutil
@@ -22,29 +24,30 @@ from botocore.exceptions import ClientError
 
 from mermaid_classifier.pyspacer.annotation import resolve_classifier_artifact
 from mermaid_classifier.pyspacer.inference import (
-    SCHEMA_VERSION, TASK_NAME, load_predictor,
+    SCHEMA_VERSION,
+    TASK_NAME,
+    load_predictor,
 )
 
-DEFAULT_DEST_BUCKET = 'mermaid-config'
-DEFAULT_DEST_PREFIX = 'classifier'
-DEFAULT_WEIGHTS_URI = 's3://mermaid-config/classifier/efficientnet.pt'
+DEFAULT_DEST_BUCKET = "mermaid-config"
+DEFAULT_DEST_PREFIX = "classifier"
+DEFAULT_WEIGHTS_URI = "s3://mermaid-config/classifier/efficientnet.pt"
 
-_VERSION_RE = re.compile(r'^v\d+$')
+_VERSION_RE = re.compile(r"^v\d+$")
 
 
 def validate_version(version: str) -> None:
     """Raise ValueError unless version matches ^v\\d+$ (e.g. v3)."""
     if not _VERSION_RE.fullmatch(version):
-        raise ValueError(
-            f"version must match ^v\\d+$ (e.g. v3); got {version!r}")
+        raise ValueError(f"version must match ^v\\d+$ (e.g. v3); got {version!r}")
 
 
 def parse_s3_uri(uri: str) -> tuple[str, str]:
     """Split an s3://bucket/key URI into (bucket, key)."""
     parsed = urlparse(uri)
-    if parsed.scheme != 's3' or not parsed.netloc or not parsed.path.strip('/'):
+    if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.strip("/"):
         raise ValueError(f"not an s3://bucket/key URI: {uri!r}")
-    return parsed.netloc, parsed.path.lstrip('/')
+    return parsed.netloc, parsed.path.lstrip("/")
 
 
 def validate_artifact(model_pt: Path, model_json: Path) -> dict:
@@ -58,23 +61,22 @@ def validate_artifact(model_pt: Path, model_json: Path) -> dict:
     load_predictor(model_pt, model_json)  # ManifestError on graph/manifest skew
     manifest = json.loads(Path(model_json).read_text())
 
-    if manifest.get('task') != TASK_NAME:
-        raise ValueError(
-            f"manifest task={manifest.get('task')!r} != {TASK_NAME!r}")
-    if not manifest.get('classes'):
+    if manifest.get("task") != TASK_NAME:
+        raise ValueError(f"manifest task={manifest.get('task')!r} != {TASK_NAME!r}")
+    if not manifest.get("classes"):
         raise ValueError("manifest has empty/missing 'classes'")
-    if not manifest.get('trained_with'):
+    if not manifest.get("trained_with"):
         raise ValueError("manifest missing 'trained_with' provenance")
     # SCHEMA_VERSION is enforced by load_predictor; assert it stays referenced
     # so a future loader change that drops the check is caught here too.
-    if manifest.get('schema_version') != SCHEMA_VERSION:
+    if manifest.get("schema_version") != SCHEMA_VERSION:
         raise ValueError(
-            f"manifest schema_version={manifest.get('schema_version')!r}"
-            f" != {SCHEMA_VERSION}")
+            f"manifest schema_version={manifest.get('schema_version')!r} != {SCHEMA_VERSION}"
+        )
     return manifest
 
 
-_NOT_FOUND_CODES = {'404', 'NoSuchKey', 'NotFound'}
+_NOT_FOUND_CODES = {"404", "NoSuchKey", "NotFound"}
 
 
 def s3_object_exists(s3_client, bucket: str, key: str) -> bool:
@@ -83,7 +85,7 @@ def s3_object_exists(s3_client, bucket: str, key: str) -> bool:
         s3_client.head_object(Bucket=bucket, Key=key)
         return True
     except ClientError as exc:
-        if exc.response.get('Error', {}).get('Code') in _NOT_FOUND_CODES:
+        if exc.response.get("Error", {}).get("Code") in _NOT_FOUND_CODES:
             return False
         raise
 
@@ -110,7 +112,7 @@ def assemble_s3_layout(
     # trip main()'s immutability precheck and permanently block reruns of vN.
     written: list[str] = []
     try:
-        for path, name in [(model_pt, 'model.pt'), (model_json, 'model.json')]:
+        for path, name in [(model_pt, "model.pt"), (model_json, "model.json")]:
             key = f"{base_key}/{name}"
             s3_client.upload_file(str(path), dest_bucket, key)
             written.append(key)
@@ -120,28 +122,27 @@ def assemble_s3_layout(
         s3_client.copy_object(
             Bucket=dest_bucket,
             Key=weights_key,
-            CopySource={'Bucket': src_bucket, 'Key': src_key},
+            CopySource={"Bucket": src_bucket, "Key": src_key},
         )
         written.append(weights_key)
     except Exception:
         for key in written:
-            try:
+            with contextlib.suppress(
+                Exception
+            ):  # cleanup is best-effort; surface the original failure
                 s3_client.delete_object(Bucket=dest_bucket, Key=key)
-            except Exception:
-                pass  # cleanup is best-effort; surface the original failure
         raise
 
-    return {name: _uri(name)
-            for name in ('model.pt', 'model.json', 'efficientnet.pt')}
+    return {name: _uri(name) for name in ("model.pt", "model.json", "efficientnet.pt")}
 
 
 def _parse_args(argv):
     p = argparse.ArgumentParser(description="Release a trained classifier as vN.")
-    p.add_argument('--mlflow-model-id', required=True)
-    p.add_argument('--version', required=True)
-    p.add_argument('--extractor-weights-uri', default=DEFAULT_WEIGHTS_URI)
-    p.add_argument('--dest-bucket', default=DEFAULT_DEST_BUCKET)
-    p.add_argument('--dest-prefix', default=DEFAULT_DEST_PREFIX)
+    p.add_argument("--mlflow-model-id", required=True)
+    p.add_argument("--version", required=True)
+    p.add_argument("--extractor-weights-uri", default=DEFAULT_WEIGHTS_URI)
+    p.add_argument("--dest-bucket", default=DEFAULT_DEST_BUCKET)
+    p.add_argument("--dest-prefix", default=DEFAULT_DEST_PREFIX)
     return p.parse_args(argv)
 
 
@@ -149,7 +150,7 @@ def main(argv=None) -> int:
     args = _parse_args(argv)
     validate_version(args.version)
 
-    s3 = boto3.client('s3')
+    s3 = boto3.client("s3")
 
     # Prechecks — all before any write, so a version folder is never partial.
     weights_bucket, weights_key = parse_s3_uri(args.extractor_weights_uri)
@@ -161,7 +162,8 @@ def main(argv=None) -> int:
         sys.exit(
             f"version {args.version} already exists at "
             f"s3://{args.dest_bucket}/{dest_model_pt_key}; versions are "
-            f"immutable. Use a new version tag.")
+            f"immutable. Use a new version tag."
+        )
 
     # Fetch the parity-proven artifact by MLflow model ID (PR #64 resolver).
     model_pt, model_json = resolve_classifier_artifact(args.mlflow_model_id)
@@ -182,8 +184,8 @@ def main(argv=None) -> int:
     # Copy artifacts into CWD (fixed names) for the workflow to attach to the
     # release (resolve_classifier_artifact returns temp-dir paths).
     cwd = Path.cwd()
-    shutil.copy(model_pt, cwd / 'model.pt')
-    shutil.copy(model_json, cwd / 'model.json')
+    shutil.copy(model_pt, cwd / "model.pt")
+    shutil.copy(model_json, cwd / "model.json")
 
     print(f"Released {args.version} from MLflow model {args.mlflow_model_id}")
     for name, uri in uris.items():
@@ -191,5 +193,5 @@ def main(argv=None) -> int:
     return 0
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import sys
 from pathlib import Path
+from typing import Any
 from urllib.parse import urlparse
 
 import boto3
@@ -50,7 +51,7 @@ def parse_s3_uri(uri: str) -> tuple[str, str]:
     return parsed.netloc, parsed.path.lstrip("/")
 
 
-def validate_artifact(model_pt: Path, model_json: Path) -> dict:
+def validate_artifact(model_pt: Path, model_json: Path) -> dict[str, Any]:
     """Re-validate the artifact at release time (the release "parity gate").
 
     load_predictor raises ManifestError on schema_version / input_dim /
@@ -79,7 +80,7 @@ def validate_artifact(model_pt: Path, model_json: Path) -> dict:
 _NOT_FOUND_CODES = {"404", "NoSuchKey", "NotFound"}
 
 
-def s3_object_exists(s3_client, bucket: str, key: str) -> bool:
+def s3_object_exists(s3_client: Any, bucket: str, key: str) -> bool:
     """True if the object exists; False on 404/NotFound; re-raise otherwise."""
     try:
         s3_client.head_object(Bucket=bucket, Key=key)
@@ -91,7 +92,7 @@ def s3_object_exists(s3_client, bucket: str, key: str) -> bool:
 
 
 def assemble_s3_layout(
-    s3_client,
+    s3_client: Any,
     *,
     dest_bucket: str,
     dest_prefix: str,
@@ -136,7 +137,7 @@ def assemble_s3_layout(
     return {name: _uri(name) for name in ("model.pt", "model.json", "efficientnet.pt")}
 
 
-def _parse_args(argv):
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Release a trained classifier as vN.")
     p.add_argument("--mlflow-model-id", required=True)
     p.add_argument("--version", required=True)
@@ -146,7 +147,7 @@ def _parse_args(argv):
     return p.parse_args(argv)
 
 
-def main(argv=None) -> int:
+def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     validate_version(args.version)
 

--- a/scripts/sagemaker_train_entrypoint.py
+++ b/scripts/sagemaker_train_entrypoint.py
@@ -14,6 +14,7 @@ Lifecycle inside the container:
 If anything raises, the traceback is logged and the process exits 1
 so SageMaker marks the job Failed.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -23,7 +24,6 @@ import sys
 import traceback
 from contextlib import contextmanager
 from pathlib import Path
-
 
 DEFAULT_CONFIG_DIR = "/opt/ml/input/data/config"
 CONFIG_FILENAME = "training_config.yaml"
@@ -72,8 +72,8 @@ def _first_line_dump(config_dir: Path) -> None:
     log.info("python: %s", sys.version.replace("\n", " "))
     try:
         from importlib.metadata import version
-        for pkg in ("pyspacer", "mlflow", "duckdb", "torch",
-                    "pydantic", "pyyaml"):
+
+        for pkg in ("pyspacer", "mlflow", "duckdb", "torch", "pydantic", "pyyaml"):
             try:
                 log.info("pkg %s: %s", pkg, version(pkg))
             except Exception:
@@ -107,6 +107,7 @@ def _resolve_runner_factory():
     the pyspacer import side effects.
     """
     from mermaid_classifier.pyspacer.train import MLflowTrainingRunner
+
     return MLflowTrainingRunner
 
 
@@ -115,8 +116,7 @@ def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--config-dir",
-        default=os.environ.get(
-            "SAGEMAKER_CONFIG_DIR", DEFAULT_CONFIG_DIR),
+        default=os.environ.get("SAGEMAKER_CONFIG_DIR", DEFAULT_CONFIG_DIR),
         help=(
             "Directory containing training_config.yaml and sibling "
             "CSVs. Default: /opt/ml/input/data/config (where SageMaker "
@@ -133,15 +133,16 @@ def main(argv: list[str] | None = None) -> None:
             from mermaid_classifier.sagemaker.config import (
                 TrainingRunConfig,
             )
-            config = TrainingRunConfig.from_yaml_path(
-                config_dir / CONFIG_FILENAME)
+
+            config = TrainingRunConfig.from_yaml_path(config_dir / CONFIG_FILENAME)
 
         with _stage("apply_env"):
             config.apply_env()
 
         with _stage("build_options"):
-            dataset_options, training_options, mlflow_options = (
-                config.build_options(config_dir=config_dir))
+            dataset_options, training_options, mlflow_options = config.build_options(
+                config_dir=config_dir
+            )
             # build_options imports mermaid_classifier.pyspacer.train,
             # whose module-level logging.config.dictConfig call sets
             # disable_existing_loggers=True (the default), which marks

--- a/tests/pyspacer/_calibrated_model_fixture.py
+++ b/tests/pyspacer/_calibrated_model_fixture.py
@@ -1,6 +1,7 @@
 """Builds a small fitted CalibratedClassifierCV(TorchMLPClassifier) the same
 way MermaidTrainer does, with no network or MLflow. Shared across artifact
 tests."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -27,8 +28,7 @@ def make_calibrated_model(
     # Separable-ish features so calibration has signal.
     centers = rng.normal(0, 3, size=(n_classes, n_features)).astype(np.float32)
     y_idx = rng.integers(0, n_classes, size=n_samples)
-    X = (centers[y_idx] + rng.normal(0, 1, size=(n_samples, n_features))
-         ).astype(np.float32)
+    X = (centers[y_idx] + rng.normal(0, 1, size=(n_samples, n_features))).astype(np.float32)
     y = classes[y_idx]
 
     clf = TorchMLPClassifier(hidden_layer_sizes=(16,), random_state=0)
@@ -38,8 +38,7 @@ def make_calibrated_model(
     # CalibratedClassifierCV has no decision_function on TorchMLPClassifier,
     # so calibration runs on predict_proba (softmax) outputs.
     predictions = clf.predict_proba(X)
-    calibrated_inner = _fit_calibrator(
-        clf, predictions, y, clf.classes_, method="sigmoid")
+    calibrated_inner = _fit_calibrator(clf, predictions, y, clf.classes_, method="sigmoid")
     wrapper = CalibratedClassifierCV(clf, cv="prefit")
     wrapper.calibrated_classifiers_ = [calibrated_inner]
     wrapper.classes_ = clf.classes_

--- a/tests/pyspacer/metrics_test_helpers.py
+++ b/tests/pyspacer/metrics_test_helpers.py
@@ -16,38 +16,38 @@ class MockBALibrary:
 
     def __init__(self):
         self.by_id = {
-            'A': {'id': 'A', 'name': 'TopA', 'parent': None},
-            'A1': {'id': 'A1', 'name': 'ChildA1', 'parent': 'A'},
-            'A2': {'id': 'A2', 'name': 'ChildA2', 'parent': 'A'},
-            'B': {'id': 'B', 'name': 'TopB', 'parent': None},
-            'B1': {'id': 'B1', 'name': 'ChildB1', 'parent': 'B'},
-            'B2': {'id': 'B2', 'name': 'ChildB2', 'parent': 'B'},
+            "A": {"id": "A", "name": "TopA", "parent": None},
+            "A1": {"id": "A1", "name": "ChildA1", "parent": "A"},
+            "A2": {"id": "A2", "name": "ChildA2", "parent": "A"},
+            "B": {"id": "B", "name": "TopB", "parent": None},
+            "B1": {"id": "B1", "name": "ChildB1", "parent": "B"},
+            "B2": {"id": "B2", "name": "ChildB2", "parent": "B"},
         }
         self.by_parent = defaultdict(list)
         for ba in self.by_id.values():
-            self.by_parent[ba['parent']].append(ba)
+            self.by_parent[ba["parent"]].append(ba)
 
     def get_ancestor_ids(self, ba_id):
-        parent = self.by_id[ba_id]['parent']
+        parent = self.by_id[ba_id]["parent"]
         if parent is None:
             return []
         return self.get_ancestor_ids(parent) + [parent]
 
     def id_to_name(self, ba_id):
-        if ba_id == '':
-            return ''
-        return self.by_id[ba_id]['name']
+        if ba_id == "":
+            return ""
+        return self.by_id[ba_id]["name"]
 
     def bagf_id_to_name(self, bagf_id, gf_library):
-        return f'name_{bagf_id}'
+        return f"name_{bagf_id}"
 
     def get_descendants(self, ba_id):
         if ba_id not in self.by_parent:
             return []
         children = self.by_parent[ba_id]
         result = []
-        for child in sorted(children, key=lambda c: c['name']):
-            result.extend(self.get_descendants(child['id']))
+        for child in sorted(children, key=lambda c: c["name"]):
+            result.extend(self.get_descendants(child["id"]))
         return children + result
 
 
@@ -55,16 +55,17 @@ class MockGFLibrary:
     """Mock of GrowthFormLibrary for testing."""
 
     def __init__(self):
-        self.by_id = {'gf1': 'Branching', 'gf2': 'Massive', 'gf3': 'Encrusting'}
+        self.by_id = {"gf1": "Branching", "gf2": "Massive", "gf3": "Encrusting"}
 
     def id_to_name(self, gf_id):
-        if gf_id == '':
-            return ''
+        if gf_id == "":
+            return ""
         return self.by_id[gf_id]
 
 
 class MockClf:
     """Mock classifier with classes_ attribute."""
+
     def __init__(self, classes):
         self.classes_ = np.array(classes)
 

--- a/tests/pyspacer/test_annotation_resolver.py
+++ b/tests/pyspacer/test_annotation_resolver.py
@@ -1,6 +1,7 @@
 """Tests for annotation.py's classifier-artifact resolver: turning an MLflow
 model ID, S3 directory, or local directory into local (model.pt, model.json)
 paths for load_predictor."""
+
 import tempfile
 import unittest
 from pathlib import Path
@@ -16,6 +17,7 @@ class ResolveFilesystemDirectoryTest(unittest.TestCase):
         from mermaid_classifier.pyspacer.annotation import (
             resolve_classifier_artifact,
         )
+
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "model.pt").write_bytes(b"pt")
             (Path(d) / "model.json").write_text("{}")
@@ -29,6 +31,7 @@ class ResolveFilesystemDirectoryTest(unittest.TestCase):
         from mermaid_classifier.pyspacer.annotation import (
             resolve_classifier_artifact,
         )
+
         with tempfile.TemporaryDirectory() as d:
             (Path(d) / "model.pt").write_bytes(b"pt")
             (Path(d) / "model.json").write_text("{}")
@@ -42,11 +45,13 @@ class ResolveFilesystemDirectoryTest(unittest.TestCase):
 class ResolveMlflowModelIdTest(unittest.TestCase):
     def test_round_trip_resolves_and_matches_source(self):
         import mlflow
+
         from mermaid_classifier.pyspacer.annotation import (
             resolve_classifier_artifact,
         )
         from mermaid_classifier.pyspacer.inference import (
-            export_artifact, load_predictor,
+            export_artifact,
+            load_predictor,
         )
         from mermaid_classifier.pyspacer.mlflow_model import log_artifact_model
 
@@ -59,11 +64,10 @@ class ResolveMlflowModelIdTest(unittest.TestCase):
             artifacts_root = d / "artifacts"
             mlflow.set_tracking_uri(f"sqlite:///{d / 'mlflow.db'}")
             exp_id = mlflow.create_experiment(
-                "test-resolver",
-                artifact_location=artifacts_root.as_uri())
+                "test-resolver", artifact_location=artifacts_root.as_uri()
+            )
             with mlflow.start_run(experiment_id=exp_id):
-                info = log_artifact_model(
-                    model_pt, model_json, registered_model_name=None)
+                info = log_artifact_model(model_pt, model_json, registered_model_name=None)
 
             # mlflow_connect() would reset the tracking URI to the production
             # server; patch it to a no-op so resolution stays on sqlite.
@@ -76,8 +80,7 @@ class ResolveMlflowModelIdTest(unittest.TestCase):
             predictor = load_predictor(pt, js)
             got = predictor.predict_proba(X)
 
-        self.assertLess(
-            float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
+        self.assertLess(float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
 
 
 class PyspacerPickleGuardTest(unittest.TestCase):
@@ -85,6 +88,7 @@ class PyspacerPickleGuardTest(unittest.TestCase):
 
     def _source(self):
         from mermaid_classifier.pyspacer import annotation
+
         return Path(annotation.__file__).read_text()
 
     def test_no_classify_image_or_classifyimagemsg(self):

--- a/tests/pyspacer/test_build_feature_bucket.py
+++ b/tests/pyspacer/test_build_feature_bucket.py
@@ -4,6 +4,7 @@ All S3 and pyspacer interactions are mocked. We don't run the real
 EfficientNet extractor here -- that's covered upstream in pyspacer's
 own test suite.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -21,33 +22,32 @@ import pandas as pd
 
 # Make scripts/ importable.
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SCRIPTS_DIR = REPO_ROOT / 'scripts'
+SCRIPTS_DIR = REPO_ROOT / "scripts"
 if str(SCRIPTS_DIR) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_DIR))
 
 import build_feature_bucket as bfb  # noqa: E402
 
-
 # ---- helpers --------------------------------------------------------
 
 
 def make_args(**overrides) -> argparse.Namespace:
-    defaults = dict(
-        target_bucket='tgt-bucket',
-        source_bucket='src-bucket',
-        source_prefix='coralnet-public-images/',
-        weights=None,
-        max_io_workers=4,
-        aws_profile='wcs',
-        skip_existing=True,
-        dry_run=False,
-        error_log=None,
-        progress_log=None,
-        log_level='INFO',
-        sources_csv=None,
-        source_ids=None,
-        source_id_column=None,
-    )
+    defaults = {
+        "target_bucket": "tgt-bucket",
+        "source_bucket": "src-bucket",
+        "source_prefix": "coralnet-public-images/",
+        "weights": None,
+        "max_io_workers": 4,
+        "aws_profile": "wcs",
+        "skip_existing": True,
+        "dry_run": False,
+        "error_log": None,
+        "progress_log": None,
+        "log_level": "INFO",
+        "sources_csv": None,
+        "source_ids": None,
+        "source_id_column": None,
+    }
     defaults.update(overrides)
     return argparse.Namespace(**defaults)
 
@@ -75,63 +75,60 @@ class FakeErrorWriter:
 
 
 class SourceIdCsvParsingTest(unittest.TestCase):
-
     def _write_csv(self, header: str, rows: list[str]) -> Path:
-        f = tempfile.NamedTemporaryFile('w', suffix='.csv',
-                                        delete=False, newline='')
-        f.write(header + '\n')
-        for r in rows:
-            f.write(r + '\n')
-        f.close()
-        return Path(f.name)
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False, newline="") as f:
+            f.write(header + "\n")
+            for r in rows:
+                f.write(r + "\n")
+            return Path(f.name)
 
     def test_id_column(self):
-        path = self._write_csv('id,', ['23,', '57,', '99,'])
+        path = self._write_csv("id,", ["23,", "57,", "99,"])
         ids = bfb.load_source_ids_from_csv(path, override=None)
-        self.assertEqual(ids, ['23', '57', '99'])
+        self.assertEqual(ids, ["23", "57", "99"])
 
     def test_source_id_column_with_space(self):
         # Matches the "Source ID" header used in coralnet_best_sources CSV.
-        path = self._write_csv('Source ID,Source name',
-                               ['1968,Biofouling', '2855,Kauai', '3581,NFWF'])
+        path = self._write_csv(
+            "Source ID,Source name", ["1968,Biofouling", "2855,Kauai", "3581,NFWF"]
+        )
         ids = bfb.load_source_ids_from_csv(path, override=None)
-        self.assertEqual(ids, ['1968', '2855', '3581'])
+        self.assertEqual(ids, ["1968", "2855", "3581"])
 
     def test_underscore_source_id_column(self):
-        path = self._write_csv('source_id,note', ['12,a', '34,b'])
+        path = self._write_csv("source_id,note", ["12,a", "34,b"])
         ids = bfb.load_source_ids_from_csv(path, override=None)
-        self.assertEqual(ids, ['12', '34'])
+        self.assertEqual(ids, ["12", "34"])
 
     def test_missing_column_raises(self):
-        path = self._write_csv('foo,bar', ['1,2', '3,4'])
+        path = self._write_csv("foo,bar", ["1,2", "3,4"])
         with self.assertRaises(ValueError) as cm:
             bfb.load_source_ids_from_csv(path, override=None)
-        self.assertIn('source-ID column', str(cm.exception))
+        self.assertIn("source-ID column", str(cm.exception))
 
     def test_explicit_override(self):
-        path = self._write_csv('SID,note', ['7,x', '8,y'])
-        ids = bfb.load_source_ids_from_csv(path, override='SID')
-        self.assertEqual(ids, ['7', '8'])
+        path = self._write_csv("SID,note", ["7,x", "8,y"])
+        ids = bfb.load_source_ids_from_csv(path, override="SID")
+        self.assertEqual(ids, ["7", "8"])
 
     def test_duplicates_dropped_preserve_order(self):
-        path = self._write_csv('id,', ['5,', '7,', '5,', '9,'])
+        path = self._write_csv("id,", ["5,", "7,", "5,", "9,"])
         ids = bfb.load_source_ids_from_csv(path, override=None)
-        self.assertEqual(ids, ['5', '7', '9'])
+        self.assertEqual(ids, ["5", "7", "9"])
 
 
 # ---- 2) URI construction -------------------------------------------
 
 
 class BuildExtractMsgTest(unittest.TestCase):
-
     def test_uri_construction(self):
         # We stub the pyspacer imports inside build_extract_msg by
         # patching the symbols it looks up at call time.
         with mock.patch.dict(sys.modules) as mods:
             fake_dc = mock.MagicMock()
             fake_msg = mock.MagicMock()
-            mods['spacer.data_classes'] = fake_dc
-            mods['spacer.messages'] = fake_msg
+            mods["spacer.data_classes"] = fake_dc
+            mods["spacer.messages"] = fake_msg
 
             DataLocation = fake_dc.DataLocation
             ExtractFeaturesMsg = fake_msg.ExtractFeaturesMsg
@@ -140,12 +137,13 @@ class BuildExtractMsgTest(unittest.TestCase):
             ExtractFeaturesMsg.side_effect = lambda **kw: kw
 
             bfb.build_extract_msg(
-                source_id='7', image_id='42',
+                source_id="7",
+                image_id="42",
                 rowcols=[(10, 20), (30, 40)],
-                extractor='STUB',
-                source_bucket='src-bucket',
-                source_prefix='coralnet-public-images/',
-                target_bucket='tgt-bucket',
+                extractor="STUB",
+                source_bucket="src-bucket",
+                source_prefix="coralnet-public-images/",
+                target_bucket="tgt-bucket",
             )
 
         # Two DataLocation calls: image_loc then feature_loc.
@@ -153,18 +151,16 @@ class BuildExtractMsgTest(unittest.TestCase):
         feature_call = DataLocation.call_args_list[1].kwargs
         msg_call = ExtractFeaturesMsg.call_args.kwargs
 
-        self.assertEqual(image_call['storage_type'], 's3')
-        self.assertEqual(image_call['bucket_name'], 'src-bucket')
-        self.assertEqual(image_call['key'],
-                         'coralnet-public-images/s7/images/42.jpg')
+        self.assertEqual(image_call["storage_type"], "s3")
+        self.assertEqual(image_call["bucket_name"], "src-bucket")
+        self.assertEqual(image_call["key"], "coralnet-public-images/s7/images/42.jpg")
 
-        self.assertEqual(feature_call['storage_type'], 's3')
-        self.assertEqual(feature_call['bucket_name'], 'tgt-bucket')
-        self.assertEqual(feature_call['key'],
-                         's7/features/i42.featurevector')
+        self.assertEqual(feature_call["storage_type"], "s3")
+        self.assertEqual(feature_call["bucket_name"], "tgt-bucket")
+        self.assertEqual(feature_call["key"], "s7/features/i42.featurevector")
 
-        self.assertEqual(msg_call['rowcols'], [(10, 20), (30, 40)])
-        self.assertEqual(msg_call['job_token'], 's7_i42')
+        self.assertEqual(msg_call["rowcols"], [(10, 20), (30, 40)])
+        self.assertEqual(msg_call["job_token"], "s7_i42")
 
 
 # ---- shared fakes for process_source tests --------------------------
@@ -183,7 +179,7 @@ class _FakeObject:
         self._payload = payload
 
     def get(self):
-        return {'Body': _FakeBody(self._payload)}
+        return {"Body": _FakeBody(self._payload)}
 
 
 class _FakePaginator:
@@ -209,8 +205,8 @@ class _FakeClient:
         if self.head_exists:
             return {}
         from botocore.exceptions import ClientError
-        raise ClientError(
-            {'Error': {'Code': '404', 'Message': 'Not Found'}}, 'HeadObject')
+
+        raise ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
 
     def put_object(self, **kwargs):
         self.put_calls.append(kwargs)
@@ -245,50 +241,53 @@ def _make_csv_payload(image_rows: dict[str, list[tuple[int, int]]]) -> bytes:
     """Build an annotations.csv payload with an `Image ID` column."""
     buf = io.StringIO()
     w = csv.writer(buf)
-    w.writerow(['Image ID', 'Row', 'Column', 'Label ID'])
+    w.writerow(["Image ID", "Row", "Column", "Label ID"])
     for image_id, rcs in image_rows.items():
         for r, c in rcs:
-            w.writerow([image_id, r, c, 'L'])
-    return buf.getvalue().encode('utf-8')
+            w.writerow([image_id, r, c, "L"])
+    return buf.getvalue().encode("utf-8")
 
 
 def _make_name_csv_payload(name_rows: dict[str, list[tuple[int, int]]]) -> bytes:
     """Build an annotations.csv payload with the new bucket's `Name` column."""
     buf = io.StringIO()
     w = csv.writer(buf)
-    w.writerow(['Name', 'Row', 'Column', 'Label ID'])
+    w.writerow(["Name", "Row", "Column", "Label ID"])
     for name, rcs in name_rows.items():
         for r, c in rcs:
-            w.writerow([name, r, c, 'L'])
-    return buf.getvalue().encode('utf-8')
+            w.writerow([name, r, c, "L"])
+    return buf.getvalue().encode("utf-8")
 
 
 def _make_image_list_payload(name_to_id: dict[str, str]) -> bytes:
     buf = io.StringIO()
     w = csv.writer(buf)
-    w.writerow(['Name', 'Image Page', 'Image URL'])
+    w.writerow(["Name", "Image Page", "Image URL"])
     for name, iid in name_to_id.items():
         # Mirror the real format: "<filename> - Confirmed" / "/image/<id>/view/".
-        w.writerow([f'{name} - Confirmed', f'/image/{iid}/view/', 'https://example/'])
-    return buf.getvalue().encode('utf-8')
+        w.writerow([f"{name} - Confirmed", f"/image/{iid}/view/", "https://example/"])
+    return buf.getvalue().encode("utf-8")
 
 
 # ---- 3) Skip-existing -----------------------------------------------
 
 
 class SkipExistingTest(unittest.TestCase):
-
     def test_skips_existing_image_only(self):
-        csv_payload = _make_csv_payload({
-            '42': [(10, 20)],
-            '43': [(30, 40)],
-        })
+        csv_payload = _make_csv_payload(
+            {
+                "42": [(10, 20)],
+                "43": [(30, 40)],
+            }
+        )
         # Pre-existing skip set says image 42 is already done.
-        list_pages = [{
-            'Contents': [
-                {'Key': 's7/features/i42.featurevector'},
-            ],
-        }]
+        list_pages = [
+            {
+                "Contents": [
+                    {"Key": "s7/features/i42.featurevector"},
+                ],
+            }
+        ]
         client = _FakeClient(list_pages=list_pages, head_exists=True)
         s3 = _FakeS3(client, csv_payload)
 
@@ -298,45 +297,53 @@ class SkipExistingTest(unittest.TestCase):
         args = make_args()
 
         fake_extract = mock.MagicMock()
-        with mock.patch.dict(sys.modules, {
-            'spacer.tasks': mock.MagicMock(extract_features=fake_extract),
-            'spacer.data_classes': mock.MagicMock(
-                DataLocation=lambda **kw: dict(kw)),
-            'spacer.messages': mock.MagicMock(
-                ExtractFeaturesMsg=lambda **kw: dict(kw)),
-        }):
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "spacer.tasks": mock.MagicMock(extract_features=fake_extract),
+                "spacer.data_classes": mock.MagicMock(DataLocation=lambda **kw: dict(kw)),
+                "spacer.messages": mock.MagicMock(ExtractFeaturesMsg=lambda **kw: dict(kw)),
+            },
+        ):
             bfb.process_source(
-                source_id='7', extractor='STUB', s3=s3, args=args,
+                source_id="7",
+                extractor="STUB",
+                s3=s3,
+                args=args,
                 counters=counters,
-                progress_writer=progress, error_writer=errors)
+                progress_writer=progress,
+                error_writer=errors,
+            )
 
         self.assertEqual(fake_extract.call_count, 1)
         sent_msg = fake_extract.call_args.args[0]
-        self.assertEqual(sent_msg['feature_loc']['key'],
-                         's7/features/i43.featurevector')
+        self.assertEqual(sent_msg["feature_loc"]["key"], "s7/features/i43.featurevector")
         # Image 42 should appear as a 'skipped/exists' progress record.
-        outcomes = [(r['image_id'], r['outcome']) for r in progress.records]
-        self.assertIn(('42', 'skipped'), outcomes)
-        self.assertIn(('43', 'ok'), outcomes)
+        outcomes = [(r["image_id"], r["outcome"]) for r in progress.records]
+        self.assertIn(("42", "skipped"), outcomes)
+        self.assertIn(("43", "ok"), outcomes)
 
 
 # ---- 4) Resume after crash ------------------------------------------
 
 
 class ResumeAfterCrashTest(unittest.TestCase):
-
     def test_resume_finishes_remaining_images(self):
-        csv_payload = _make_csv_payload({
-            '42': [(1, 1)],
-            '43': [(2, 2)],
-            '44': [(3, 3)],
-        })
+        csv_payload = _make_csv_payload(
+            {
+                "42": [(1, 1)],
+                "43": [(2, 2)],
+                "44": [(3, 3)],
+            }
+        )
         # Skip-set already contains image 42 from a prior run.
-        list_pages = [{
-            'Contents': [
-                {'Key': 's7/features/i42.featurevector'},
-            ],
-        }]
+        list_pages = [
+            {
+                "Contents": [
+                    {"Key": "s7/features/i42.featurevector"},
+                ],
+            }
+        ]
         # head_exists=True simulates s7/annotations.csv already present in
         # the target bucket -- the copy step must be skipped.
         client = _FakeClient(list_pages=list_pages, head_exists=True)
@@ -348,37 +355,43 @@ class ResumeAfterCrashTest(unittest.TestCase):
         args = make_args()
 
         fake_extract = mock.MagicMock()
-        with mock.patch.dict(sys.modules, {
-            'spacer.tasks': mock.MagicMock(extract_features=fake_extract),
-            'spacer.data_classes': mock.MagicMock(
-                DataLocation=lambda **kw: dict(kw)),
-            'spacer.messages': mock.MagicMock(
-                ExtractFeaturesMsg=lambda **kw: dict(kw)),
-        }):
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "spacer.tasks": mock.MagicMock(extract_features=fake_extract),
+                "spacer.data_classes": mock.MagicMock(DataLocation=lambda **kw: dict(kw)),
+                "spacer.messages": mock.MagicMock(ExtractFeaturesMsg=lambda **kw: dict(kw)),
+            },
+        ):
             bfb.process_source(
-                source_id='7', extractor='STUB', s3=s3, args=args,
+                source_id="7",
+                extractor="STUB",
+                s3=s3,
+                args=args,
                 counters=counters,
-                progress_writer=progress, error_writer=errors)
+                progress_writer=progress,
+                error_writer=errors,
+            )
 
         # Exactly two new extractions: i43 and i44.
         self.assertEqual(fake_extract.call_count, 2)
-        keys = [
-            call.args[0]['feature_loc']['key']
-            for call in fake_extract.call_args_list
-        ]
-        self.assertEqual(sorted(keys), [
-            's7/features/i43.featurevector',
-            's7/features/i44.featurevector',
-        ])
+        keys = [call.args[0]["feature_loc"]["key"] for call in fake_extract.call_args_list]
+        self.assertEqual(
+            sorted(keys),
+            [
+                "s7/features/i43.featurevector",
+                "s7/features/i44.featurevector",
+            ],
+        )
 
         # No upload of annotations.csv (target version already present).
         self.assertEqual(client.put_calls, [])
 
         # Progress log: i42 skipped, i43 + i44 ok.
-        outcomes = {(r['image_id'], r['outcome']) for r in progress.records}
-        self.assertIn(('42', 'skipped'), outcomes)
-        self.assertIn(('43', 'ok'), outcomes)
-        self.assertIn(('44', 'ok'), outcomes)
+        outcomes = {(r["image_id"], r["outcome"]) for r in progress.records}
+        self.assertIn(("42", "skipped"), outcomes)
+        self.assertIn(("43", "ok"), outcomes)
+        self.assertIn(("44", "ok"), outcomes)
 
         # Counters reflect the resume.
         self.assertEqual(counters.images_ok, 2)
@@ -392,145 +405,164 @@ class ResumeAfterCrashTest(unittest.TestCase):
 
 
 class NameToImageIdMappingTest(unittest.TestCase):
-
     def test_prepare_source_maps_name_to_numeric_id(self):
         # annotations.csv has Name (no Image ID); image_list.csv has the
         # filename + " - Confirmed" status suffix and an /image/<id>/view/
         # page URL.
-        annotations = _make_name_csv_payload({
-            '001-CA2M-1.JPG': [(10, 20), (30, 40)],
-            '002-CA2M-2.JPG': [(5, 5)],
-            'unknown.JPG':    [(0, 0)],   # unmappable -> should be dropped
-        })
-        image_list = _make_image_list_payload({
-            '001-CA2M-1.JPG': '1719202',
-            '002-CA2M-2.JPG': '1750080',
-        })
+        annotations = _make_name_csv_payload(
+            {
+                "001-CA2M-1.JPG": [(10, 20), (30, 40)],
+                "002-CA2M-2.JPG": [(5, 5)],
+                "unknown.JPG": [(0, 0)],  # unmappable -> should be dropped
+            }
+        )
+        image_list = _make_image_list_payload(
+            {
+                "001-CA2M-1.JPG": "1719202",
+                "002-CA2M-2.JPG": "1750080",
+            }
+        )
         s3 = _FakeS3(
             client=_FakeClient(list_pages=[]),
             key_to_payload={
-                'coralnet-public-images/s1968/annotations.csv': annotations,
-                'coralnet-public-images/s1968/image_list.csv': image_list,
+                "coralnet-public-images/s1968/annotations.csv": annotations,
+                "coralnet-public-images/s1968/image_list.csv": image_list,
             },
         )
 
         prepared = bfb.prepare_source(
-            s3=s3, source_bucket='src-bucket',
-            source_prefix='coralnet-public-images/', source_id='1968')
+            s3=s3,
+            source_bucket="src-bucket",
+            source_prefix="coralnet-public-images/",
+            source_id="1968",
+        )
 
         self.assertIsNotNone(prepared)
         self.assertEqual(prepared.n_unmapped_rows, 1)
         # Image IDs come back as strings keyed by the numeric value.
-        self.assertEqual(
-            sorted(prepared.images.keys()), ['1719202', '1750080'])
-        self.assertEqual(prepared.images['1719202'], [(10, 20), (30, 40)])
-        self.assertEqual(prepared.images['1750080'], [(5, 5)])
+        self.assertEqual(sorted(prepared.images.keys()), ["1719202", "1750080"])
+        self.assertEqual(prepared.images["1719202"], [(10, 20), (30, 40)])
+        self.assertEqual(prepared.images["1750080"], [(5, 5)])
 
         # The transformed CSV body must contain an `Image ID` column whose
         # values are the looked-up numeric IDs -- this is what the
         # classifier's read_coralnet_data expects.
         out_df = pd.read_csv(io.BytesIO(prepared.transformed_csv))
-        self.assertIn('Image ID', out_df.columns)
-        self.assertEqual(set(out_df['Image ID'].astype(str)),
-                         {'1719202', '1750080'})
+        self.assertIn("Image ID", out_df.columns)
+        self.assertEqual(set(out_df["Image ID"].astype(str)), {"1719202", "1750080"})
 
     def test_status_suffix_variants_are_stripped(self):
         # image_list.csv may report Unconfirmed / Unclassified statuses too.
-        annotations = _make_name_csv_payload({
-            'a.JPG': [(1, 1)],
-            'b.JPG': [(2, 2)],
-            'c.JPG': [(3, 3)],
-        })
+        annotations = _make_name_csv_payload(
+            {
+                "a.JPG": [(1, 1)],
+                "b.JPG": [(2, 2)],
+                "c.JPG": [(3, 3)],
+            }
+        )
         # Hand-craft image_list to use varied statuses.
         buf = io.StringIO()
         w = csv.writer(buf)
-        w.writerow(['Name', 'Image Page', 'Image URL'])
-        w.writerow(['a.JPG - Confirmed',    '/image/100/view/', ''])
-        w.writerow(['b.JPG - Unconfirmed',  '/image/200/view/', ''])
-        w.writerow(['c.JPG - Unclassified', '/image/300/view/', ''])
+        w.writerow(["Name", "Image Page", "Image URL"])
+        w.writerow(["a.JPG - Confirmed", "/image/100/view/", ""])
+        w.writerow(["b.JPG - Unconfirmed", "/image/200/view/", ""])
+        w.writerow(["c.JPG - Unclassified", "/image/300/view/", ""])
         image_list = buf.getvalue().encode()
 
         s3 = _FakeS3(
             client=_FakeClient(list_pages=[]),
             key_to_payload={
-                'coralnet-public-images/s7/annotations.csv': annotations,
-                'coralnet-public-images/s7/image_list.csv': image_list,
+                "coralnet-public-images/s7/annotations.csv": annotations,
+                "coralnet-public-images/s7/image_list.csv": image_list,
             },
         )
         prepared = bfb.prepare_source(
-            s3=s3, source_bucket='src-bucket',
-            source_prefix='coralnet-public-images/', source_id='7')
+            s3=s3,
+            source_bucket="src-bucket",
+            source_prefix="coralnet-public-images/",
+            source_id="7",
+        )
 
         self.assertIsNotNone(prepared)
         self.assertEqual(prepared.n_unmapped_rows, 0)
-        self.assertEqual(sorted(prepared.images.keys()), ['100', '200', '300'])
+        self.assertEqual(sorted(prepared.images.keys()), ["100", "200", "300"])
 
 
 # ---- 6) resolve_device ---------------------------------------------
 
 
 class ResolveDeviceTest(unittest.TestCase):
-
     def _mock_torch(self, mps: bool, cuda: bool):
-        return mock.patch.dict(sys.modules, {
-            'torch': mock.MagicMock(
-                cuda=mock.MagicMock(is_available=mock.MagicMock(return_value=cuda)),
-                backends=mock.MagicMock(
-                    mps=mock.MagicMock(is_available=mock.MagicMock(return_value=mps)),
+        return mock.patch.dict(
+            sys.modules,
+            {
+                "torch": mock.MagicMock(
+                    cuda=mock.MagicMock(is_available=mock.MagicMock(return_value=cuda)),
+                    backends=mock.MagicMock(
+                        mps=mock.MagicMock(is_available=mock.MagicMock(return_value=mps)),
+                    ),
                 ),
-            ),
-        })
+            },
+        )
 
     def test_auto_prefers_mps(self):
         with self._mock_torch(mps=True, cuda=True):
-            self.assertEqual(bfb.resolve_device('auto'), 'mps')
+            self.assertEqual(bfb.resolve_device("auto"), "mps")
 
     def test_auto_falls_back_to_cuda(self):
         with self._mock_torch(mps=False, cuda=True):
-            self.assertEqual(bfb.resolve_device('auto'), 'cuda')
+            self.assertEqual(bfb.resolve_device("auto"), "cuda")
 
     def test_auto_falls_back_to_cpu(self):
         with self._mock_torch(mps=False, cuda=False):
-            self.assertEqual(bfb.resolve_device('auto'), 'cpu')
+            self.assertEqual(bfb.resolve_device("auto"), "cpu")
 
     def test_explicit_mps_when_unavailable_raises(self):
-        with self._mock_torch(mps=False, cuda=False):
-            with self.assertRaises(RuntimeError):
-                bfb.resolve_device('mps')
+        with self._mock_torch(mps=False, cuda=False), self.assertRaises(RuntimeError):
+            bfb.resolve_device("mps")
 
     def test_explicit_cpu_always_works(self):
         with self._mock_torch(mps=False, cuda=False):
-            self.assertEqual(bfb.resolve_device('cpu'), 'cpu')
+            self.assertEqual(bfb.resolve_device("cpu"), "cpu")
 
 
 # ---- bonus sanity: parse_weights_location ---------------------------
 
 
 class ParseWeightsLocationTest(unittest.TestCase):
-
     def test_s3_uri(self):
-        with mock.patch.dict(sys.modules, {
-            'spacer.data_classes': mock.MagicMock(
-                DataLocation=lambda **kw: dict(kw)),
-        }):
-            loc = bfb.parse_weights_location('s3://my-bucket/models/eff.pt')
-        self.assertEqual(loc, {
-            'storage_type': 's3',
-            'key': 'models/eff.pt',
-            'bucket_name': 'my-bucket',
-        })
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "spacer.data_classes": mock.MagicMock(DataLocation=lambda **kw: dict(kw)),
+            },
+        ):
+            loc = bfb.parse_weights_location("s3://my-bucket/models/eff.pt")
+        self.assertEqual(
+            loc,
+            {
+                "storage_type": "s3",
+                "key": "models/eff.pt",
+                "bucket_name": "my-bucket",
+            },
+        )
 
     def test_filesystem_path(self):
-        with mock.patch.dict(sys.modules, {
-            'spacer.data_classes': mock.MagicMock(
-                DataLocation=lambda **kw: dict(kw)),
-        }):
-            loc = bfb.parse_weights_location('/tmp/eff.pt')
-        self.assertEqual(loc, {
-            'storage_type': 'filesystem',
-            'key': '/tmp/eff.pt',
-        })
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "spacer.data_classes": mock.MagicMock(DataLocation=lambda **kw: dict(kw)),
+            },
+        ):
+            loc = bfb.parse_weights_location("/tmp/eff.pt")
+        self.assertEqual(
+            loc,
+            {
+                "storage_type": "filesystem",
+                "key": "/tmp/eff.pt",
+            },
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_generate_report.py
+++ b/tests/pyspacer/test_generate_report.py
@@ -2,17 +2,19 @@
 
 Tests the pure transformation functions without requiring an MLflow server.
 """
+
 import base64
 import struct
+
+# Adjust sys.path so we can import from scripts/.
+import sys
 import tempfile
 import unittest
 import zlib
 from pathlib import Path
 from unittest.mock import MagicMock
 
-# Adjust sys.path so we can import from scripts/.
-import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'scripts'))
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
 
 from generate_report import (
     _artifact_key,
@@ -23,96 +25,95 @@ from generate_report import (
     load_csv_as_html_table,
     load_yaml_file,
     render_report,
-    EVALUATION_SECTIONS,
 )
 
 
 def _make_minimal_png(path: Path):
     """Write a minimal valid 1x1 white PNG to the given path."""
     # PNG signature
-    sig = b'\x89PNG\r\n\x1a\n'
+    sig = b"\x89PNG\r\n\x1a\n"
 
     def _chunk(chunk_type, data):
         c = chunk_type + data
-        return struct.pack('>I', len(data)) + c + struct.pack('>I', zlib.crc32(c) & 0xFFFFFFFF)
+        return struct.pack(">I", len(data)) + c + struct.pack(">I", zlib.crc32(c) & 0xFFFFFFFF)
 
     # IHDR: 1x1, 8-bit grayscale
-    ihdr_data = struct.pack('>IIBBBBB', 1, 1, 8, 0, 0, 0, 0)
-    ihdr = _chunk(b'IHDR', ihdr_data)
+    ihdr_data = struct.pack(">IIBBBBB", 1, 1, 8, 0, 0, 0, 0)
+    ihdr = _chunk(b"IHDR", ihdr_data)
     # IDAT: single white pixel, filter byte 0
-    raw = b'\x00\xff'
-    idat = _chunk(b'IDAT', zlib.compress(raw))
+    raw = b"\x00\xff"
+    idat = _chunk(b"IDAT", zlib.compress(raw))
     # IEND
-    iend = _chunk(b'IEND', b'')
+    iend = _chunk(b"IEND", b"")
 
     path.write_bytes(sig + ihdr + idat + iend)
 
 
 class TestArtifactKey(unittest.TestCase):
     def test_simple_filename(self):
-        self.assertEqual(_artifact_key('metrics_per_label.csv'), 'metrics_per_label_csv')
+        self.assertEqual(_artifact_key("metrics_per_label.csv"), "metrics_per_label_csv")
 
     def test_subdirectory_path(self):
-        self.assertEqual(_artifact_key('confusion_matrix/frequencies.png'), 'frequencies_png')
+        self.assertEqual(_artifact_key("confusion_matrix/frequencies.png"), "frequencies_png")
 
     def test_yaml_extension(self):
-        self.assertEqual(_artifact_key('system_specs.yaml'), 'system_specs_yaml')
+        self.assertEqual(_artifact_key("system_specs.yaml"), "system_specs_yaml")
 
 
 class TestEncodePngAsBase64(unittest.TestCase):
     def test_returns_data_uri(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            png_path = Path(tmpdir) / 'test.png'
+            png_path = Path(tmpdir) / "test.png"
             _make_minimal_png(png_path)
             result = encode_png_as_base64(png_path)
-            self.assertTrue(result.startswith('data:image/png;base64,'))
+            self.assertTrue(result.startswith("data:image/png;base64,"))
 
     def test_base64_is_valid(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            png_path = Path(tmpdir) / 'test.png'
+            png_path = Path(tmpdir) / "test.png"
             _make_minimal_png(png_path)
             result = encode_png_as_base64(png_path)
-            b64_part = result.split(',', 1)[1]
+            b64_part = result.split(",", 1)[1]
             decoded = base64.b64decode(b64_part)
             # Should start with PNG signature.
-            self.assertTrue(decoded.startswith(b'\x89PNG'))
+            self.assertTrue(decoded.startswith(b"\x89PNG"))
 
 
 class TestLoadCsvAsHtmlTable(unittest.TestCase):
     def test_basic_csv(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            csv_path = Path(tmpdir) / 'test.csv'
-            csv_path.write_text('name,value\nalpha,0.95\nbeta,0.87\n')
+            csv_path = Path(tmpdir) / "test.csv"
+            csv_path.write_text("name,value\nalpha,0.95\nbeta,0.87\n")
             result = load_csv_as_html_table(csv_path)
-            self.assertIn('<table', result)
-            self.assertIn('alpha', result)
-            self.assertIn('0.9500', result)
-            self.assertIn('dataframe', result)
+            self.assertIn("<table", result)
+            self.assertIn("alpha", result)
+            self.assertIn("0.9500", result)
+            self.assertIn("dataframe", result)
 
     def test_no_index_column(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            csv_path = Path(tmpdir) / 'test.csv'
-            csv_path.write_text('a,b\n1,2\n')
+            csv_path = Path(tmpdir) / "test.csv"
+            csv_path.write_text("a,b\n1,2\n")
             result = load_csv_as_html_table(csv_path)
             # Should not contain a default pandas index column.
-            self.assertNotIn('<th></th>', result)
+            self.assertNotIn("<th></th>", result)
 
 
 class TestLoadYamlFile(unittest.TestCase):
     def test_basic_yaml(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            yaml_path = Path(tmpdir) / 'test.yaml'
-            yaml_path.write_text('total_ram_gb: 16.0\nfree_storage_gb: 100.5\n')
+            yaml_path = Path(tmpdir) / "test.yaml"
+            yaml_path.write_text("total_ram_gb: 16.0\nfree_storage_gb: 100.5\n")
             result = load_yaml_file(yaml_path)
-            self.assertEqual(result['total_ram_gb'], 16.0)
-            self.assertEqual(result['free_storage_gb'], 100.5)
+            self.assertEqual(result["total_ram_gb"], 16.0)
+            self.assertEqual(result["free_storage_gb"], 100.5)
 
     def test_nested_yaml(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            yaml_path = Path(tmpdir) / 'test.yaml'
-            yaml_path.write_text('parent:\n  child: value\n')
+            yaml_path = Path(tmpdir) / "test.yaml"
+            yaml_path.write_text("parent:\n  child: value\n")
             result = load_yaml_file(yaml_path)
-            self.assertEqual(result['parent']['child'], 'value')
+            self.assertEqual(result["parent"]["child"], "value")
 
 
 class TestFetchScalarMetrics(unittest.TestCase):
@@ -123,54 +124,54 @@ class TestFetchScalarMetrics(unittest.TestCase):
 
     def test_full_metrics(self):
         metrics = {
-            'accuracy': 0.85,
-            'balanced_accuracy': 0.82,
-            'f1_macro': 0.80,
-            'precision_macro': 0.81,
-            'recall_macro': 0.79,
-            'mcc': 0.75,
-            'ece': 0.03,
-            'log_loss': 1.2,
-            'top_1_accuracy': 0.85,
-            'top_3_accuracy': 0.95,
-            'top_5_accuracy': 0.97,
-            'top_10_accuracy': 0.99,
-            'mrr': 0.90,
-            'cover_mean_abs_bias_pct': 2.1,
-            'cover_mean_rmse_pct': 3.5,
-            'cross_branch_error_rate': 0.15,
+            "accuracy": 0.85,
+            "balanced_accuracy": 0.82,
+            "f1_macro": 0.80,
+            "precision_macro": 0.81,
+            "recall_macro": 0.79,
+            "mcc": 0.75,
+            "ece": 0.03,
+            "log_loss": 1.2,
+            "top_1_accuracy": 0.85,
+            "top_3_accuracy": 0.95,
+            "top_5_accuracy": 0.97,
+            "top_10_accuracy": 0.99,
+            "mrr": 0.90,
+            "cover_mean_abs_bias_pct": 2.1,
+            "cover_mean_rmse_pct": 3.5,
+            "cross_branch_error_rate": 0.15,
         }
         run = self._make_mock_run(metrics)
         result = fetch_scalar_metrics(run)
 
-        self.assertIsNotNone(result['executive'])
-        self.assertEqual(len(result['executive']), 8)
-        self.assertIsNotNone(result['topk'])
-        self.assertEqual(len(result['topk']), 5)
-        self.assertIsNotNone(result['cover'])
-        self.assertEqual(len(result['cover']), 2)  # Only 2 of 4 cover metrics present.
-        self.assertIsNotNone(result['taxonomic'])
+        self.assertIsNotNone(result["executive"])
+        self.assertEqual(len(result["executive"]), 8)
+        self.assertIsNotNone(result["topk"])
+        self.assertEqual(len(result["topk"]), 5)
+        self.assertIsNotNone(result["cover"])
+        self.assertEqual(len(result["cover"]), 2)  # Only 2 of 4 cover metrics present.
+        self.assertIsNotNone(result["taxonomic"])
 
     def test_minimal_metrics(self):
         """Only executive metrics present, optional groups absent."""
         metrics = {
-            'accuracy': 0.85,
-            'f1_macro': 0.80,
+            "accuracy": 0.85,
+            "f1_macro": 0.80,
         }
         run = self._make_mock_run(metrics)
         result = fetch_scalar_metrics(run)
 
-        self.assertIsNotNone(result['executive'])
-        self.assertEqual(len(result['executive']), 2)
-        self.assertIsNone(result['topk'])
-        self.assertIsNone(result['cover'])
-        self.assertIsNone(result['taxonomic'])
+        self.assertIsNotNone(result["executive"])
+        self.assertEqual(len(result["executive"]), 2)
+        self.assertIsNone(result["topk"])
+        self.assertIsNone(result["cover"])
+        self.assertIsNone(result["taxonomic"])
 
     def test_empty_metrics(self):
         run = self._make_mock_run({})
         result = fetch_scalar_metrics(run)
-        self.assertIsNone(result['executive'])
-        self.assertIsNone(result['topk'])
+        self.assertIsNone(result["executive"])
+        self.assertIsNone(result["topk"])
 
 
 class TestLoadArtifactData(unittest.TestCase):
@@ -180,165 +181,174 @@ class TestLoadArtifactData(unittest.TestCase):
             artifact_dir = Path(tmpdir)
 
             # Create confusion_matrix artifacts.
-            cm_dir = artifact_dir / 'confusion_matrix'
+            cm_dir = artifact_dir / "confusion_matrix"
             cm_dir.mkdir()
-            _make_minimal_png(cm_dir / 'frequencies.png')
-            _make_minimal_png(cm_dir / 'percents.png')
+            _make_minimal_png(cm_dir / "frequencies.png")
+            _make_minimal_png(cm_dir / "percents.png")
 
             # Create calibration artifacts.
-            cal_dir = artifact_dir / 'calibration'
+            cal_dir = artifact_dir / "calibration"
             cal_dir.mkdir()
-            _make_minimal_png(cal_dir / 'reliability_diagram.png')
+            _make_minimal_png(cal_dir / "reliability_diagram.png")
 
             # Create taxonomic artifacts.
-            tax_dir = artifact_dir / 'taxonomic'
+            tax_dir = artifact_dir / "taxonomic"
             tax_dir.mkdir()
-            _make_minimal_png(tax_dir / 'error_attribution.png')
-            _make_minimal_png(tax_dir / 'top_level_confusion.png')
-            _make_minimal_png(tax_dir / 'gf_confusion.png')
+            _make_minimal_png(tax_dir / "error_attribution.png")
+            _make_minimal_png(tax_dir / "top_level_confusion.png")
+            _make_minimal_png(tax_dir / "gf_confusion.png")
 
             result = load_artifact_data(artifact_dir)
 
-            self.assertIn('confusion_matrix', result['sections'])
-            self.assertIn('calibration', result['sections'])
-            self.assertIn('taxonomic', result['sections'])
+            self.assertIn("confusion_matrix", result["sections"])
+            self.assertIn("calibration", result["sections"])
+            self.assertIn("taxonomic", result["sections"])
             # Optional sections should be absent.
-            self.assertNotIn('cover', result['sections'])
-            self.assertNotIn('probability', result['sections'])
-            self.assertNotIn('ranking', result['sections'])
+            self.assertNotIn("cover", result["sections"])
+            self.assertNotIn("probability", result["sections"])
+            self.assertNotIn("ranking", result["sections"])
 
     def test_optional_section_present(self):
         """Cover section appears when its artifacts exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             artifact_dir = Path(tmpdir)
-            cover_dir = artifact_dir / 'cover'
+            cover_dir = artifact_dir / "cover"
             cover_dir.mkdir()
-            _make_minimal_png(cover_dir / 'per_class_bias.png')
+            _make_minimal_png(cover_dir / "per_class_bias.png")
 
             result = load_artifact_data(artifact_dir)
-            self.assertIn('cover', result['sections'])
-            self.assertIsNotNone(
-                result['sections']['cover']['per_class_bias_png'])
+            self.assertIn("cover", result["sections"])
+            self.assertIsNotNone(result["sections"]["cover"]["per_class_bias_png"])
 
     def test_training_artifacts(self):
         """Training artifacts are loaded when present."""
         with tempfile.TemporaryDirectory() as tmpdir:
             artifact_dir = Path(tmpdir)
-            (artifact_dir / 'system_specs.yaml').write_text(
-                'total_ram_gb: 16\n')
-            (artifact_dir / 'train_summary.yaml').write_text(
-                'total_images: 5000\n')
+            (artifact_dir / "system_specs.yaml").write_text("total_ram_gb: 16\n")
+            (artifact_dir / "train_summary.yaml").write_text("total_images: 5000\n")
 
             result = load_artifact_data(artifact_dir)
-            self.assertTrue(result['has_training'])
-            self.assertIsNotNone(result['training']['system_specs_yaml'])
-            self.assertEqual(
-                result['training']['system_specs_yaml']['total_ram_gb'], 16)
+            self.assertTrue(result["has_training"])
+            self.assertIsNotNone(result["training"]["system_specs_yaml"])
+            self.assertEqual(result["training"]["system_specs_yaml"]["total_ram_gb"], 16)
 
 
 class TestBuildTemplateContext(unittest.TestCase):
     def test_basic_context(self):
         metadata = {
-            'run_id': 'abc123',
-            'run_name': 'test',
-            'experiment_name': 'exp1',
+            "run_id": "abc123",
+            "run_name": "test",
+            "experiment_name": "exp1",
         }
-        metrics = {'executive': [('Accuracy', 0.85)], 'topk': None,
-                   'cover': None, 'taxonomic': None}
+        metrics = {
+            "executive": [("Accuracy", 0.85)],
+            "topk": None,
+            "cover": None,
+            "taxonomic": None,
+        }
         artifacts = {
-            'sections': {},
-            'root_eval': {'metrics_per_label_csv': None,
-                          'metrics_overall_yaml': None},
-            'training': {},
-            'has_training': False,
+            "sections": {},
+            "root_eval": {"metrics_per_label_csv": None, "metrics_overall_yaml": None},
+            "training": {},
+            "has_training": False,
         }
 
         context = build_template_context(metadata, metrics, artifacts)
-        self.assertEqual(context['title'],
-                         'Classifier Report - exp1 - test')
-        self.assertIn('generated_at', context)
-        self.assertEqual(context['metadata'], metadata)
+        self.assertEqual(context["title"], "Classifier Report - exp1 - test")
+        self.assertIn("generated_at", context)
+        self.assertEqual(context["metadata"], metadata)
 
     def test_custom_title(self):
-        metadata = {'run_id': 'x', 'run_name': 'y',
-                    'experiment_name': 'z'}
-        metrics = {'executive': None, 'topk': None,
-                   'cover': None, 'taxonomic': None}
-        artifacts = {'sections': {}, 'root_eval': {}, 'training': {},
-                     'has_training': False}
+        metadata = {"run_id": "x", "run_name": "y", "experiment_name": "z"}
+        metrics = {"executive": None, "topk": None, "cover": None, "taxonomic": None}
+        artifacts = {"sections": {}, "root_eval": {}, "training": {}, "has_training": False}
 
-        context = build_template_context(
-            metadata, metrics, artifacts, title='Custom Title')
-        self.assertEqual(context['title'], 'Custom Title')
+        context = build_template_context(metadata, metrics, artifacts, title="Custom Title")
+        self.assertEqual(context["title"], "Custom Title")
 
 
 class TestRenderReport(unittest.TestCase):
     def test_renders_valid_html(self):
         """Render with a minimal context and verify output is HTML."""
         context = {
-            'title': 'Test Report',
-            'generated_at': '2025-01-01 00:00 UTC',
-            'metadata': {
-                'run_id': 'abc123def456',
-                'run_name': 'test-run',
-                'experiment_name': 'test-experiment',
-                'status': 'FINISHED',
-                'start_time': '2025-01-01 00:00 UTC',
-                'end_time': '2025-01-01 01:00 UTC',
-                'duration': '1h 0m 0s',
-                'params': {'epochs': '10'},
-                'tags': {},
+            "title": "Test Report",
+            "generated_at": "2025-01-01 00:00 UTC",
+            "metadata": {
+                "run_id": "abc123def456",
+                "run_name": "test-run",
+                "experiment_name": "test-experiment",
+                "status": "FINISHED",
+                "start_time": "2025-01-01 00:00 UTC",
+                "end_time": "2025-01-01 01:00 UTC",
+                "duration": "1h 0m 0s",
+                "params": {"epochs": "10"},
+                "tags": {},
             },
-            'metrics': {
-                'executive': [('Accuracy', 0.85), ('F1 (Macro)', 0.80)],
-                'topk': None,
-                'cover': None,
-                'taxonomic': None,
+            "metrics": {
+                "executive": [("Accuracy", 0.85), ("F1 (Macro)", 0.80)],
+                "topk": None,
+                "cover": None,
+                "taxonomic": None,
             },
-            'sections': {},
-            'root_eval': {
-                'metrics_per_label_csv': None,
-                'metrics_overall_yaml': None,
+            "sections": {},
+            "root_eval": {
+                "metrics_per_label_csv": None,
+                "metrics_overall_yaml": None,
             },
-            'training': {},
-            'has_training': False,
-            'section_order': ['confusion_matrix', 'calibration', 'cover',
-                              'probability', 'ranking', 'taxonomic'],
+            "training": {},
+            "has_training": False,
+            "section_order": [
+                "confusion_matrix",
+                "calibration",
+                "cover",
+                "probability",
+                "ranking",
+                "taxonomic",
+            ],
         }
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = Path(tmpdir) / 'report.html'
+            output_path = Path(tmpdir) / "report.html"
             render_report(context, output_path)
 
             self.assertTrue(output_path.exists())
             html = output_path.read_text()
-            self.assertIn('<!DOCTYPE html>', html)
-            self.assertIn('Test Report', html)
-            self.assertIn('80.0%', html)  # F1 (Macro) formatted as percentage
-            self.assertIn('abc123def456', html)
+            self.assertIn("<!DOCTYPE html>", html)
+            self.assertIn("Test Report", html)
+            self.assertIn("80.0%", html)  # F1 (Macro) formatted as percentage
+            self.assertIn("abc123def456", html)
 
     def test_conditional_sections_absent(self):
         """Sections with no data should not appear in output."""
         context = {
-            'title': 'Test',
-            'generated_at': '2025-01-01',
-            'metadata': {
-                'run_id': 'x', 'run_name': 'y',
-                'experiment_name': 'z', 'status': 'FINISHED',
-                'start_time': 'N/A', 'end_time': 'N/A',
-                'duration': 'N/A', 'params': {}, 'tags': {},
+            "title": "Test",
+            "generated_at": "2025-01-01",
+            "metadata": {
+                "run_id": "x",
+                "run_name": "y",
+                "experiment_name": "z",
+                "status": "FINISHED",
+                "start_time": "N/A",
+                "end_time": "N/A",
+                "duration": "N/A",
+                "params": {},
+                "tags": {},
             },
-            'metrics': {'executive': None, 'topk': None,
-                        'cover': None, 'taxonomic': None},
-            'sections': {},
-            'root_eval': {'metrics_per_label_csv': None,
-                          'metrics_overall_yaml': None},
-            'training': {},
-            'has_training': False,
-            'section_order': ['confusion_matrix', 'calibration', 'cover',
-                              'probability', 'ranking', 'taxonomic'],
+            "metrics": {"executive": None, "topk": None, "cover": None, "taxonomic": None},
+            "sections": {},
+            "root_eval": {"metrics_per_label_csv": None, "metrics_overall_yaml": None},
+            "training": {},
+            "has_training": False,
+            "section_order": [
+                "confusion_matrix",
+                "calibration",
+                "cover",
+                "probability",
+                "ranking",
+                "taxonomic",
+            ],
         }
         with tempfile.TemporaryDirectory() as tmpdir:
-            output_path = Path(tmpdir) / 'report.html'
+            output_path = Path(tmpdir) / "report.html"
             render_report(context, output_path)
             html = output_path.read_text()
 
@@ -352,5 +362,5 @@ class TestRenderReport(unittest.TestCase):
             self.assertNotIn('id="per-label-detail"', html)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_inference_decoupling.py
+++ b/tests/pyspacer/test_inference_decoupling.py
@@ -9,6 +9,7 @@ and used to run as a side effect of the subpackage ``__init__``).
 We assert this in a fresh subprocess so an already-imported settings module in
 the test session can't mask a regression.
 """
+
 import subprocess
 import sys
 import unittest
@@ -30,7 +31,8 @@ print("ok")
     def test_importing_pyspacer_subpackage_does_not_import_settings(self):
         result = subprocess.run(
             [sys.executable, "-c", self.CHILD],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("ok", result.stdout)

--- a/tests/pyspacer/test_metrics_calibration.py
+++ b/tests/pyspacer/test_metrics_calibration.py
@@ -10,7 +10,12 @@ from mermaid_classifier.pyspacer.metrics.calibration import (
     _adaptive_ece,
     compute_calibration,
 )
-from pyspacer.metrics_test_helpers import MockBALibrary, MockGFLibrary, make_val_results, format_metric
+from pyspacer.metrics_test_helpers import (
+    MockBALibrary,
+    MockGFLibrary,
+    format_metric,
+    make_val_results,
+)
 
 
 def _make_ctx(gt_indices, est_indices, classes, scores=None):
@@ -67,8 +72,7 @@ class AdaptiveECETest(unittest.TestCase):
         est = list(range(n))
         scores = [0.8] * n
         ece, bin_data = _adaptive_ece(scores, gt, est, n_bins=3)
-        expected_keys = {'avg_confidence', 'avg_accuracy', 'count',
-                         'conf_min', 'conf_max'}
+        expected_keys = {"avg_confidence", "avg_accuracy", "count", "conf_min", "conf_max"}
         for b in bin_data:
             self.assertEqual(set(b.keys()), expected_keys)
 
@@ -82,7 +86,7 @@ class ComputeCalibrationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 0, 1],
             est_indices=[0, 1, 1, 0],
-            classes=['A1::', 'B1::'],
+            classes=["A1::", "B1::"],
             scores=[0.9, 0.8, 0.7, 0.6],
         )
         result = compute_calibration(ctx)
@@ -90,14 +94,14 @@ class ComputeCalibrationTest(unittest.TestCase):
         self.assertIsInstance(result, MetricGroupResult)
 
         scalar_names = {s.name for s in result.scalars}
-        self.assertIn('ece', scalar_names)
+        self.assertIn("ece", scalar_names)
 
         df_paths = {df.artifact_path for df in result.dataframes}
-        self.assertIn('calibration/per_bin_details', df_paths)
-        self.assertIn('calibration/per_category_ece', df_paths)
+        self.assertIn("calibration/per_bin_details", df_paths)
+        self.assertIn("calibration/per_category_ece", df_paths)
 
         fig_paths = {f.artifact_path for f in result.figures}
-        self.assertIn('calibration/reliability_diagram.png', fig_paths)
+        self.assertIn("calibration/reliability_diagram.png", fig_paths)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -107,12 +111,12 @@ class ComputeCalibrationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[0, 1, 1, 0],
-            classes=['A1::', 'B1::'],
+            classes=["A1::", "B1::"],
             scores=[0.9, 0.6, 0.8, 0.55],
         )
         result = compute_calibration(ctx)
 
-        ece_scalar = next(s for s in result.scalars if s.name == 'ece')
+        ece_scalar = next(s for s in result.scalars if s.name == "ece")
         self.assertIsInstance(ece_scalar.value, float)
         self.assertGreaterEqual(ece_scalar.value, 0.0)
         self.assertLessEqual(ece_scalar.value, 1.0)
@@ -126,14 +130,13 @@ class ComputeCalibrationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[0, 1, 1, 0],
-            classes=['A1::', 'B1::'],
+            classes=["A1::", "B1::"],
             scores=[0.9, 0.6, 0.8, 0.55],
         )
         result = compute_calibration(ctx)
 
         per_cat_df_result = next(
-            df for df in result.dataframes
-            if df.artifact_path == 'calibration/per_category_ece'
+            df for df in result.dataframes if df.artifact_path == "calibration/per_category_ece"
         )
         self.assertEqual(len(per_cat_df_result.df), 0)
 
@@ -151,18 +154,16 @@ class ComputeCalibrationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=gt_indices,
             est_indices=est_indices,
-            classes=['A1::', 'B1::'],
+            classes=["A1::", "B1::"],
             scores=scores,
         )
         result = compute_calibration(ctx)
 
         per_cat_df_result = next(
-            df for df in result.dataframes
-            if df.artifact_path == 'calibration/per_category_ece'
+            df for df in result.dataframes if df.artifact_path == "calibration/per_category_ece"
         )
         self.assertGreater(len(per_cat_df_result.df), 0)
-        expected_columns = {'category', 'ece', 'accuracy', 'avg_confidence',
-                            'n_samples'}
+        expected_columns = {"category", "ece", "accuracy", "avg_confidence", "n_samples"}
         self.assertEqual(set(per_cat_df_result.df.columns), expected_columns)
 
         for fig_result in result.figures:
@@ -173,22 +174,28 @@ class ComputeCalibrationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 0, 1],
             est_indices=[0, 1, 0, 1],
-            classes=['A1::', 'B1::'],
+            classes=["A1::", "B1::"],
             scores=[0.9, 0.8, 0.7, 0.6],
         )
         result = compute_calibration(ctx)
 
         per_bin_df_result = next(
-            df for df in result.dataframes
-            if df.artifact_path == 'calibration/per_bin_details'
+            df for df in result.dataframes if df.artifact_path == "calibration/per_bin_details"
         )
-        expected_columns = {'bin', 'conf_min', 'conf_max', 'avg_confidence',
-                            'avg_accuracy', 'gap', 'count'}
+        expected_columns = {
+            "bin",
+            "conf_min",
+            "conf_max",
+            "avg_confidence",
+            "avg_accuracy",
+            "gap",
+            "count",
+        }
         self.assertEqual(set(per_bin_df_result.df.columns), expected_columns)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_classification.py
+++ b/tests/pyspacer/test_metrics_classification.py
@@ -21,11 +21,12 @@ class _MockBALibrary:
     """Minimal mock of BenthicAttributeLibrary for testing."""
 
     def bagf_id_to_name(self, bagf_id, gf_library):
-        return f'name_{bagf_id}'
+        return f"name_{bagf_id}"
 
 
 class _MockGFLibrary:
     """Minimal mock of GrowthFormLibrary for testing."""
+
     pass
 
 
@@ -62,7 +63,7 @@ class ComputeConfusionMatricesTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 0, 1],
             est_indices=[0, 1, 1, 0],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_confusion_matrices(ctx)
 
@@ -70,12 +71,8 @@ class ComputeConfusionMatricesTest(unittest.TestCase):
         # Two confusion matrices: frequencies and percents
         self.assertEqual(len(result.dataframes), 2)
         self.assertEqual(len(result.figures), 2)
-        self.assertEqual(
-            result.dataframes[0].artifact_path,
-            'confusion_matrix/frequencies')
-        self.assertEqual(
-            result.dataframes[1].artifact_path,
-            'confusion_matrix/percents')
+        self.assertEqual(result.dataframes[0].artifact_path, "confusion_matrix/frequencies")
+        self.assertEqual(result.dataframes[1].artifact_path, "confusion_matrix/percents")
 
         # Clean up figures
         for fig_result in result.figures:
@@ -86,7 +83,7 @@ class ComputeConfusionMatricesTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[0, 0, 1, 1],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_confusion_matrices(ctx)
 
@@ -102,7 +99,7 @@ class ComputeConfusionMatricesTest(unittest.TestCase):
 
     def test_dataframe_shape(self):
         """DataFrame should have N+1 columns and N rows."""
-        classes = ['a::', 'b::', 'c::']
+        classes = ["a::", "b::", "c::"]
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1, 2, 2],
             est_indices=[0, 1, 1, 1, 2, 0],
@@ -128,7 +125,7 @@ class ComputePrecisionRecallF1Test(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[0, 0, 1, 1],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_precision_recall_f1(ctx)
 
@@ -136,42 +133,38 @@ class ComputePrecisionRecallF1Test(unittest.TestCase):
         # Scalars: precision_macro, recall_macro, f1_macro
         self.assertEqual(len(result.scalars), 3)
         scalar_names = {s.name for s in result.scalars}
-        self.assertEqual(
-            scalar_names,
-            {'precision_macro', 'recall_macro', 'f1_macro'})
+        self.assertEqual(scalar_names, {"precision_macro", "recall_macro", "f1_macro"})
 
         # Per-label DataFrame
         self.assertEqual(len(result.dataframes), 1)
-        self.assertEqual(
-            result.dataframes[0].artifact_path, 'metrics_per_label')
+        self.assertEqual(result.dataframes[0].artifact_path, "metrics_per_label")
         df = result.dataframes[0].df
         self.assertEqual(len(df), 2)  # Two classes
 
         # Overall dict
         self.assertEqual(len(result.dicts), 1)
-        self.assertEqual(
-            result.dicts[0].artifact_path, 'metrics_overall.yaml')
-        self.assertIn('precision_macro', result.dicts[0].data)
+        self.assertEqual(result.dicts[0].artifact_path, "metrics_overall.yaml")
+        self.assertIn("precision_macro", result.dicts[0].data)
 
     def test_perfect_predictions(self):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[0, 0, 1, 1],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_precision_recall_f1(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars['precision_macro'], 1.0)
-        self.assertEqual(scalars['recall_macro'], 1.0)
-        self.assertEqual(scalars['f1_macro'], 1.0)
+        self.assertEqual(scalars["precision_macro"], 1.0)
+        self.assertEqual(scalars["recall_macro"], 1.0)
+        self.assertEqual(scalars["f1_macro"], 1.0)
 
         # Per-label should all be 1.0
         df = result.dataframes[0].df
         for _, row in df.iterrows():
-            self.assertEqual(row['precision'], 1.0)
-            self.assertEqual(row['recall'], 1.0)
-            self.assertEqual(row['f1_score'], 1.0)
+            self.assertEqual(row["precision"], 1.0)
+            self.assertEqual(row["recall"], 1.0)
+            self.assertEqual(row["f1_score"], 1.0)
 
     def test_all_wrong_predictions(self):
         """When all predictions are wrong, macro F1 should be 0.0,
@@ -179,34 +172,34 @@ class ComputePrecisionRecallF1Test(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[1, 1, 0, 0],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_precision_recall_f1(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars['precision_macro'], 0.0)
-        self.assertEqual(scalars['recall_macro'], 0.0)
-        self.assertEqual(scalars['f1_macro'], 0.0)
+        self.assertEqual(scalars["precision_macro"], 0.0)
+        self.assertEqual(scalars["recall_macro"], 0.0)
+        self.assertEqual(scalars["f1_macro"], 0.0)
 
         # Per-label should all be 0.0
         df = result.dataframes[0].df
         for _, row in df.iterrows():
-            self.assertEqual(row['precision'], 0.0)
-            self.assertEqual(row['recall'], 0.0)
-            self.assertEqual(row['f1_score'], 0.0)
+            self.assertEqual(row["precision"], 0.0)
+            self.assertEqual(row["recall"], 0.0)
+            self.assertEqual(row["f1_score"], 0.0)
 
     def test_per_label_has_bagf_fields(self):
         ctx = _make_ctx(
             gt_indices=[0],
             est_indices=[0],
-            classes=['a::'],
+            classes=["a::"],
         )
         result = compute_precision_recall_f1(ctx)
 
         df = result.dataframes[0].df
-        self.assertIn('bagf_name', df.columns)
-        self.assertIn('bagf_id', df.columns)
-        self.assertEqual(df.iloc[0]['bagf_id'], 'a::')
+        self.assertIn("bagf_name", df.columns)
+        self.assertIn("bagf_id", df.columns)
+        self.assertEqual(df.iloc[0]["bagf_id"], "a::")
 
 
 class ComputeBalancedAccuracyMccTest(unittest.TestCase):
@@ -216,7 +209,7 @@ class ComputeBalancedAccuracyMccTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1, 2, 2],
             est_indices=[0, 0, 1, 1, 2, 2],
-            classes=['a::', 'b::', 'c::'],
+            classes=["a::", "b::", "c::"],
         )
         result = compute_balanced_accuracy_mcc(ctx)
 
@@ -224,20 +217,20 @@ class ComputeBalancedAccuracyMccTest(unittest.TestCase):
         self.assertEqual(len(result.scalars), 2)
 
         scalars_by_name = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars_by_name['balanced_accuracy'], 1.0)
-        self.assertEqual(scalars_by_name['mcc'], 1.0)
+        self.assertEqual(scalars_by_name["balanced_accuracy"], 1.0)
+        self.assertEqual(scalars_by_name["mcc"], 1.0)
 
     def test_all_wrong_binary(self):
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1],
             est_indices=[1, 1, 0, 0],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_balanced_accuracy_mcc(ctx)
 
         scalars_by_name = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars_by_name['balanced_accuracy'], 0.0)
-        self.assertEqual(scalars_by_name['mcc'], -1.0)
+        self.assertEqual(scalars_by_name["balanced_accuracy"], 0.0)
+        self.assertEqual(scalars_by_name["mcc"], -1.0)
 
     def test_imbalanced_classes(self):
         # 8 samples of class 0, 2 samples of class 1.
@@ -246,20 +239,20 @@ class ComputeBalancedAccuracyMccTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 0, 0, 0, 0, 0, 0, 1, 1],
             est_indices=[0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_balanced_accuracy_mcc(ctx)
 
         scalars_by_name = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars_by_name['balanced_accuracy'], 0.5)
+        self.assertEqual(scalars_by_name["balanced_accuracy"], 0.5)
         # MCC is 0 when predicting a single class
-        self.assertEqual(scalars_by_name['mcc'], 0.0)
+        self.assertEqual(scalars_by_name["mcc"], 0.0)
 
     def test_no_figures_or_dataframes(self):
         ctx = _make_ctx(
             gt_indices=[0, 1],
             est_indices=[0, 1],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         result = compute_balanced_accuracy_mcc(ctx)
 
@@ -284,8 +277,7 @@ class MetricsContextValidationTest(unittest.TestCase):
         """Empty ground truth should fail validation."""
         # Build a valid ValResults, then clear gt/est to simulate
         # an edge case (ValResults.__init__ validates non-empty).
-        val_results = _make_val_results(
-            gt_indices=[0], est_indices=[0], classes=['a::'])
+        val_results = _make_val_results(gt_indices=[0], est_indices=[0], classes=["a::"])
         val_results.gt = []
         val_results.est = []
         ctx = self._make_ctx_with_val_results(val_results)
@@ -299,10 +291,8 @@ class MetricsContextValidationTest(unittest.TestCase):
             def bagf_id_to_name(self, bagf_id, gf_library):
                 raise KeyError(f"Unknown ID: {bagf_id}")
 
-        val_results = _make_val_results(
-            gt_indices=[0], est_indices=[0], classes=['unknown::'])
-        ctx = self._make_ctx_with_val_results(
-            val_results, ba_library=_BrokenBALibrary())
+        val_results = _make_val_results(gt_indices=[0], est_indices=[0], classes=["unknown::"])
+        ctx = self._make_ctx_with_val_results(val_results, ba_library=_BrokenBALibrary())
         with self.assertRaises(MetricsContextError):
             ctx.validate()
 
@@ -311,15 +301,14 @@ class MetricsContextValidationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1],
             est_indices=[0, 1],
-            classes=['a::', 'b::'],
+            classes=["a::", "b::"],
         )
         ctx.validate()  # Should not raise
 
     def test_out_of_range_class_index_raises(self):
         """Class indices beyond len(classes) should fail validation."""
         # Build valid ValResults, then inject an out-of-range index.
-        val_results = _make_val_results(
-            gt_indices=[0], est_indices=[0], classes=['a::'])
+        val_results = _make_val_results(gt_indices=[0], est_indices=[0], classes=["a::"])
         val_results.gt = [0, 5]
         val_results.est = [0, 0]
         val_results.scores = [1.0, 1.0]
@@ -328,5 +317,5 @@ class MetricsContextValidationTest(unittest.TestCase):
             ctx.validate()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_cover.py
+++ b/tests/pyspacer/test_metrics_cover.py
@@ -8,7 +8,12 @@ import matplotlib.pyplot as plt
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
 from mermaid_classifier.pyspacer.metrics._results import MetricGroupResult
 from mermaid_classifier.pyspacer.metrics.cover import compute_cover
-from pyspacer.metrics_test_helpers import MockBALibrary, MockGFLibrary, make_val_results, format_metric
+from pyspacer.metrics_test_helpers import (
+    MockBALibrary,
+    MockGFLibrary,
+    format_metric,
+    make_val_results,
+)
 
 
 class _MockValLabels:
@@ -18,8 +23,8 @@ class _MockValLabels:
         """image_sizes: list of ints, each is n_points for one image."""
         self._data = {}
         for i, n in enumerate(image_sizes):
-            key = f'img_{i}'
-            self._data[key] = [(0, 0, 'dummy')] * n
+            key = f"img_{i}"
+            self._data[key] = [(0, 0, "dummy")] * n
 
     def keys(self):
         return self._data.keys()
@@ -32,7 +37,7 @@ class _MockDataset:
     """Mock of TrainingDataset with only labels.val."""
 
     def __init__(self, val_labels):
-        self.labels = type('obj', (object,), {'val': val_labels})()
+        self.labels = type("obj", (object,), {"val": val_labels})()
 
 
 class ComputeCoverTest(unittest.TestCase):
@@ -55,7 +60,7 @@ class ComputeCoverTest(unittest.TestCase):
         # 3 images, 10 points each, 2 classes, all correct.
         # Each image: 5 points of class 0, 5 points of class 1 -> cover = 50/50
         # All images have the same cover vector, so std=0 -> R² is NaN.
-        classes = ['A1::', 'A::']
+        classes = ["A1::", "A::"]
         gt_per_image = [0] * 5 + [1] * 5
         est_per_image = [0] * 5 + [1] * 5
         gt_indices = gt_per_image * 3
@@ -65,13 +70,13 @@ class ComputeCoverTest(unittest.TestCase):
         result = compute_cover(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertAlmostEqual(scalars['cover_mean_abs_bias_pct'], 0.0, places=6)
-        self.assertAlmostEqual(scalars['cover_mean_rmse_pct'], 0.0, places=6)
-        self.assertAlmostEqual(scalars['cover_mean_mae_pct'], 0.0, places=6)
+        self.assertAlmostEqual(scalars["cover_mean_abs_bias_pct"], 0.0, places=6)
+        self.assertAlmostEqual(scalars["cover_mean_rmse_pct"], 0.0, places=6)
+        self.assertAlmostEqual(scalars["cover_mean_mae_pct"], 0.0, places=6)
 
         # R² is NaN when cover is identical across images (std=0); median of NaNs
         # falls back to the pandas default which is NaN.
-        r2 = scalars['cover_median_r_squared']
+        r2 = scalars["cover_median_r_squared"]
         self.assertTrue(math.isnan(r2))
 
         for fig_result in result.figures:
@@ -79,7 +84,7 @@ class ComputeCoverTest(unittest.TestCase):
 
     def test_returns_expected_artifacts(self):
         """Result contains the expected scalar names, DataFrame, and figure."""
-        classes = ['A1::', 'A::']
+        classes = ["A1::", "A::"]
         # Vary cover across images so the figure is generated.
         # Image 0: all class 0; Image 1: all class 1; Image 2: 50/50
         gt_indices = [0] * 4 + [1] * 4 + [0, 0, 1, 1]
@@ -91,28 +96,26 @@ class ComputeCoverTest(unittest.TestCase):
         self.assertIsInstance(result, MetricGroupResult)
 
         expected_scalar_names = {
-            'cover_mean_abs_bias_pct',
-            'cover_mean_rmse_pct',
-            'cover_mean_mae_pct',
-            'cover_median_r_squared',
+            "cover_mean_abs_bias_pct",
+            "cover_mean_rmse_pct",
+            "cover_mean_mae_pct",
+            "cover_median_r_squared",
         }
         actual_scalar_names = {s.name for s in result.scalars}
         self.assertEqual(actual_scalar_names, expected_scalar_names)
 
         self.assertEqual(len(result.dataframes), 1)
-        self.assertEqual(
-            result.dataframes[0].artifact_path, 'cover/per_class_cover_metrics')
+        self.assertEqual(result.dataframes[0].artifact_path, "cover/per_class_cover_metrics")
 
         self.assertEqual(len(result.figures), 1)
-        self.assertEqual(
-            result.figures[0].artifact_path, 'cover/per_class_bias.png')
+        self.assertEqual(result.figures[0].artifact_path, "cover/per_class_bias.png")
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_cover_vectors_sum_to_one(self):
         """Mean true cover values across all classes should sum to ~100%."""
-        classes = ['A1::', 'A::']
+        classes = ["A1::", "A::"]
         gt_indices = [0, 0, 1, 1, 0, 0, 1, 1]
         est_indices = [0, 0, 1, 1, 0, 0, 1, 1]
 
@@ -120,7 +123,7 @@ class ComputeCoverTest(unittest.TestCase):
         result = compute_cover(ctx)
 
         df = result.dataframes[0].df
-        total = df['mean_true_cover_pct'].sum()
+        total = df["mean_true_cover_pct"].sum()
         self.assertAlmostEqual(total, 100.0, places=6)
 
         for fig_result in result.figures:
@@ -128,7 +131,7 @@ class ComputeCoverTest(unittest.TestCase):
 
     def test_biased_predictions(self):
         """Systematic overprediction of class 0 produces positive bias for class 0."""
-        classes = ['A1::', 'A::']
+        classes = ["A1::", "A::"]
         # 5 images, 10 points each.
         # True: 5 class 0, 5 class 1 per image (50/50 cover).
         # Predicted: 7 class 0, 3 class 1 per image.
@@ -143,17 +146,17 @@ class ComputeCoverTest(unittest.TestCase):
         df = result.dataframes[0].df
         # all_classes is sorted(['A1::', 'A::']) = ['A1::', 'A::']
         # class index 0 = 'A1::' is what's being over-predicted
-        row_class0 = df[df['bagf_id'] == 'A1::'].iloc[0]
-        row_class1 = df[df['bagf_id'] == 'A::'].iloc[0]
+        row_class0 = df[df["bagf_id"] == "A1::"].iloc[0]
+        row_class1 = df[df["bagf_id"] == "A::"].iloc[0]
 
         # Over-predicted class should have positive bias
-        self.assertGreater(row_class0['bias_pct'], 0.0)
+        self.assertGreater(row_class0["bias_pct"], 0.0)
         # Under-predicted class should have negative bias
-        self.assertLess(row_class1['bias_pct'], 0.0)
+        self.assertLess(row_class1["bias_pct"], 0.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_per_source.py
+++ b/tests/pyspacer/test_metrics_per_source.py
@@ -9,6 +9,7 @@ from spacer.data_classes import DataLocation
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
 from mermaid_classifier.pyspacer.metrics._results import MetricGroupResult
 from mermaid_classifier.pyspacer.metrics.per_source import compute_per_source
+
 from .metrics_test_helpers import (
     MockBALibrary,
     MockGFLibrary,
@@ -18,7 +19,7 @@ from .metrics_test_helpers import (
 
 
 def _make_loc(key: str) -> DataLocation:
-    return DataLocation(storage_type='filesystem', key=key)
+    return DataLocation(storage_type="filesystem", key=key)
 
 
 class _MockValLabels:
@@ -28,7 +29,7 @@ class _MockValLabels:
         """image_specs: list of (DataLocation, n_points)."""
         self._data = OrderedDict()
         for loc, n in image_specs:
-            self._data[loc] = [(0, 0, 'dummy')] * n
+            self._data[loc] = [(0, 0, "dummy")] * n
 
     def keys(self):
         return self._data.keys()
@@ -42,7 +43,7 @@ class _MockDataset:
 
     def __init__(self, image_specs, source_map):
         val_labels = _MockValLabels(image_specs)
-        self.labels = type('obj', (object,), {'val': val_labels})()
+        self.labels = type("obj", (object,), {"val": val_labels})()
         self.feature_loc_to_source = source_map
 
 
@@ -66,35 +67,32 @@ class ComputePerSourceTest(unittest.TestCase):
         rows with distinct metrics."""
         # Image 1 (source A): 4 points, all correct.
         # Image 2 (source B): 4 points, half wrong (still within branch).
-        loc_a = _make_loc('img_a')
-        loc_b = _make_loc('img_b')
+        loc_a = _make_loc("img_a")
+        loc_b = _make_loc("img_b")
         image_specs = [(loc_a, 4), (loc_b, 4)]
         source_map = {
-            loc_a: ('coralnet', '109'),
-            loc_b: ('coralnet', '155'),
+            loc_a: ("coralnet", "109"),
+            loc_b: ("coralnet", "155"),
         }
         gt = [0, 0, 1, 1, 0, 0, 1, 1]
         est = [0, 0, 1, 1, 1, 1, 0, 0]  # source B all wrong
-        classes = ['A1::', 'A2::']  # both within branch A
+        classes = ["A1::", "A2::"]  # both within branch A
 
         ctx = _make_ctx(image_specs, source_map, gt, est, classes)
         result = compute_per_source(ctx)
 
-        df = next(
-            d.df for d in result.dataframes
-            if d.artifact_path == 'per_source/metrics'
-        )
+        df = next(d.df for d in result.dataframes if d.artifact_path == "per_source/metrics")
         self.assertEqual(len(df), 2)
 
-        row_a = df[df['source_key'] == 'coralnet:109'].iloc[0]
-        row_b = df[df['source_key'] == 'coralnet:155'].iloc[0]
+        row_a = df[df["source_key"] == "coralnet:109"].iloc[0]
+        row_b = df[df["source_key"] == "coralnet:155"].iloc[0]
 
-        self.assertEqual(row_a['num_val_images'], 1)
-        self.assertEqual(row_a['num_val_annotations'], 4)
-        self.assertAlmostEqual(row_a['accuracy'], 1.0)
-        self.assertAlmostEqual(row_b['accuracy'], 0.0)
+        self.assertEqual(row_a["num_val_images"], 1)
+        self.assertEqual(row_a["num_val_annotations"], 4)
+        self.assertAlmostEqual(row_a["accuracy"], 1.0)
+        self.assertAlmostEqual(row_b["accuracy"], 0.0)
         # Both errors stay within branch A -> cross_branch_error_rate = 0
-        self.assertAlmostEqual(row_b['cross_branch_error_rate'], 0.0)
+        self.assertAlmostEqual(row_b["cross_branch_error_rate"], 0.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -102,47 +100,44 @@ class ComputePerSourceTest(unittest.TestCase):
     def test_cross_branch_error_per_source(self):
         """A->B confusions on one source -> that source has positive
         cross_branch_error_rate."""
-        loc_a = _make_loc('img_a')
-        loc_b = _make_loc('img_b')
+        loc_a = _make_loc("img_a")
+        loc_b = _make_loc("img_b")
         image_specs = [(loc_a, 2), (loc_b, 2)]
         source_map = {
-            loc_a: ('coralnet', '109'),
-            loc_b: ('mermaid', 'all'),
+            loc_a: ("coralnet", "109"),
+            loc_b: ("mermaid", "all"),
         }
         # Source A: A1 -> A2 (within branch).
         # Source B: B1 -> A1 (cross branch).
         gt = [0, 0, 2, 2]
         est = [1, 1, 0, 0]
-        classes = ['A1::', 'A2::', 'B1::']
+        classes = ["A1::", "A2::", "B1::"]
 
         ctx = _make_ctx(image_specs, source_map, gt, est, classes)
         result = compute_per_source(ctx)
 
-        df = next(
-            d.df for d in result.dataframes
-            if d.artifact_path == 'per_source/metrics'
-        )
-        row_a = df[df['source_key'] == 'coralnet:109'].iloc[0]
-        row_b = df[df['source_key'] == 'mermaid:all'].iloc[0]
+        df = next(d.df for d in result.dataframes if d.artifact_path == "per_source/metrics")
+        row_a = df[df["source_key"] == "coralnet:109"].iloc[0]
+        row_b = df[df["source_key"] == "mermaid:all"].iloc[0]
 
-        self.assertAlmostEqual(row_a['cross_branch_error_rate'], 0.0)
-        self.assertAlmostEqual(row_b['cross_branch_error_rate'], 1.0)
+        self.assertAlmostEqual(row_a["cross_branch_error_rate"], 0.0)
+        self.assertAlmostEqual(row_b["cross_branch_error_rate"], 1.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_returns_expected_artifacts(self):
         """compute_per_source returns the dataframe, scalars, and figure."""
-        loc_a = _make_loc('img_a')
-        loc_b = _make_loc('img_b')
+        loc_a = _make_loc("img_a")
+        loc_b = _make_loc("img_b")
         image_specs = [(loc_a, 4), (loc_b, 4)]
         source_map = {
-            loc_a: ('coralnet', '109'),
-            loc_b: ('coralnet', '155'),
+            loc_a: ("coralnet", "109"),
+            loc_b: ("coralnet", "155"),
         }
         gt = [0, 0, 1, 1, 0, 0, 1, 1]
         est = [0, 1, 1, 0, 0, 0, 1, 1]
-        classes = ['A1::', 'A2::']
+        classes = ["A1::", "A2::"]
 
         ctx = _make_ctx(image_specs, source_map, gt, est, classes)
         result = compute_per_source(ctx)
@@ -150,53 +145,48 @@ class ComputePerSourceTest(unittest.TestCase):
         self.assertIsInstance(result, MetricGroupResult)
 
         df_paths = {d.artifact_path for d in result.dataframes}
-        self.assertIn('per_source/metrics', df_paths)
+        self.assertIn("per_source/metrics", df_paths)
 
         scalar_names = {s.name for s in result.scalars}
         self.assertEqual(
             scalar_names,
-            {'per_source/n_sources',
-             'per_source/min_accuracy',
-             'per_source/max_accuracy'},
+            {"per_source/n_sources", "per_source/min_accuracy", "per_source/max_accuracy"},
         )
 
         fig_paths = {f.artifact_path for f in result.figures}
-        self.assertIn('per_source/accuracy_by_source.png', fig_paths)
+        self.assertIn("per_source/accuracy_by_source.png", fig_paths)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_sorted_by_annotation_count_desc(self):
         """Source with more val annotations appears first."""
-        loc_big = _make_loc('img_big')
-        loc_small = _make_loc('img_small')
+        loc_big = _make_loc("img_big")
+        loc_small = _make_loc("img_small")
         image_specs = [(loc_small, 2), (loc_big, 6)]
         source_map = {
-            loc_small: ('coralnet', '155'),
-            loc_big: ('coralnet', '109'),
+            loc_small: ("coralnet", "155"),
+            loc_big: ("coralnet", "109"),
         }
         gt = [0, 1, 0, 0, 1, 1, 0, 1]
         est = [0, 1, 0, 0, 1, 1, 0, 1]
-        classes = ['A1::', 'A2::']
+        classes = ["A1::", "A2::"]
 
         ctx = _make_ctx(image_specs, source_map, gt, est, classes)
         result = compute_per_source(ctx)
 
-        df = next(
-            d.df for d in result.dataframes
-            if d.artifact_path == 'per_source/metrics'
-        )
-        self.assertEqual(df.iloc[0]['source_key'], 'coralnet:109')
-        self.assertEqual(df.iloc[0]['num_val_annotations'], 6)
-        self.assertEqual(df.iloc[1]['source_key'], 'coralnet:155')
-        self.assertEqual(df.iloc[1]['num_val_annotations'], 2)
+        df = next(d.df for d in result.dataframes if d.artifact_path == "per_source/metrics")
+        self.assertEqual(df.iloc[0]["source_key"], "coralnet:109")
+        self.assertEqual(df.iloc[0]["num_val_annotations"], 6)
+        self.assertEqual(df.iloc[1]["source_key"], "coralnet:155")
+        self.assertEqual(df.iloc[1]["num_val_annotations"], 2)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_no_dataset_returns_empty(self):
         """compute_per_source with no dataset is a no-op."""
-        val_results = make_val_results([0, 1], [0, 1], ['A1::', 'A2::'])
+        val_results = make_val_results([0, 1], [0, 1], ["A1::", "A2::"])
         ctx = MetricsContext(
             val_results=val_results,
             ba_library=MockBALibrary(),
@@ -214,18 +204,18 @@ class ComputePerSourceTest(unittest.TestCase):
     def test_index_count_mismatch_raises(self):
         """If val annotation count diverges from sum of per-image n_points,
         the function fails loudly rather than producing wrong metrics."""
-        loc_a = _make_loc('img_a')
+        loc_a = _make_loc("img_a")
         image_specs = [(loc_a, 4)]
-        source_map = {loc_a: ('coralnet', '109')}
+        source_map = {loc_a: ("coralnet", "109")}
         # gt has 5 entries but image has only 4 points -> mismatch.
         gt = [0, 0, 1, 1, 0]
         est = [0, 0, 1, 1, 0]
-        classes = ['A1::', 'A2::']
+        classes = ["A1::", "A2::"]
 
         ctx = _make_ctx(image_specs, source_map, gt, est, classes)
         with self.assertRaises(ValueError):
             compute_per_source(ctx)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_probability.py
+++ b/tests/pyspacer/test_metrics_probability.py
@@ -10,7 +10,7 @@ from spacer.data_classes import ValResults
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
 from mermaid_classifier.pyspacer.metrics._results import MetricGroupResult
 from mermaid_classifier.pyspacer.metrics.probability import compute_probability
-from pyspacer.metrics_test_helpers import MockBALibrary, MockGFLibrary, MockClf, format_metric
+from pyspacer.metrics_test_helpers import MockBALibrary, MockClf, MockGFLibrary, format_metric
 
 
 def _make_ctx(classes, gt_labels, proba):
@@ -42,42 +42,44 @@ class ComputeProbabilityTest(unittest.TestCase):
 
     def test_perfect_probability_matrix(self):
         """Perfect probability assignments yield log_loss near zero."""
-        classes = ['A1::', 'B1::']
-        gt_labels = ['A1::', 'A1::', 'B1::', 'B1::']
-        proba = np.array([
-            [1.0, 0.0],
-            [1.0, 0.0],
-            [0.0, 1.0],
-            [0.0, 1.0],
-        ])
+        classes = ["A1::", "B1::"]
+        gt_labels = ["A1::", "A1::", "B1::", "B1::"]
+        proba = np.array(
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.0, 1.0],
+            ]
+        )
         ctx = _make_ctx(classes, gt_labels, proba)
         result = compute_probability(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertAlmostEqual(scalars['log_loss'], 0.0, places=5)
+        self.assertAlmostEqual(scalars["log_loss"], 0.0, places=5)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_uniform_probability_matrix(self):
         """Uniform probabilities yield log_loss = log(n_classes)."""
-        classes = ['A1::', 'B1::']
-        gt_labels = ['A1::', 'A1::', 'B1::', 'B1::']
+        classes = ["A1::", "B1::"]
+        gt_labels = ["A1::", "A1::", "B1::", "B1::"]
         proba = np.full((4, 2), 0.5)
         ctx = _make_ctx(classes, gt_labels, proba)
         result = compute_probability(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
         expected = math.log(2)
-        self.assertAlmostEqual(scalars['log_loss'], expected, places=5)
+        self.assertAlmostEqual(scalars["log_loss"], expected, places=5)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_returns_expected_artifacts(self):
         """Result contains the log_loss scalar and per_category_log_loss DataFrame."""
-        classes = ['A1::', 'B1::']
-        gt_labels = ['A1::', 'A1::', 'B1::', 'B1::']
+        classes = ["A1::", "B1::"]
+        gt_labels = ["A1::", "A1::", "B1::", "B1::"]
         proba = np.full((4, 2), 0.5)
         ctx = _make_ctx(classes, gt_labels, proba)
         result = compute_probability(ctx)
@@ -85,39 +87,37 @@ class ComputeProbabilityTest(unittest.TestCase):
         self.assertIsInstance(result, MetricGroupResult)
 
         scalar_names = {s.name for s in result.scalars}
-        self.assertIn('log_loss', scalar_names)
+        self.assertIn("log_loss", scalar_names)
 
         df_paths = {d.artifact_path for d in result.dataframes}
-        self.assertIn('probability/per_category_log_loss', df_paths)
+        self.assertIn("probability/per_category_log_loss", df_paths)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_per_category_requires_min_samples(self):
         """Fewer than 30 samples per category yields an empty per_category DataFrame."""
-        classes = ['A1::', 'B1::']
+        classes = ["A1::", "B1::"]
         # 4 samples total — well below the 30-sample minimum per category.
-        gt_labels = ['A1::', 'A1::', 'B1::', 'B1::']
+        gt_labels = ["A1::", "A1::", "B1::", "B1::"]
         proba = np.full((4, 2), 0.5)
         ctx = _make_ctx(classes, gt_labels, proba)
         result = compute_probability(ctx)
 
         df_result = next(
-            d for d in result.dataframes
-            if d.artifact_path == 'probability/per_category_log_loss'
+            d for d in result.dataframes if d.artifact_path == "probability/per_category_log_loss"
         )
         self.assertEqual(len(df_result.df), 0)
-        self.assertListEqual(
-            list(df_result.df.columns), ['category', 'log_loss', 'n_samples'])
+        self.assertListEqual(list(df_result.df.columns), ["category", "log_loss", "n_samples"])
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_per_category_with_enough_samples(self):
         """35+ samples per category yields a populated per_category DataFrame."""
-        classes = ['A1::', 'B1::']
+        classes = ["A1::", "B1::"]
         n_per_class = 35
-        gt_labels = (['A1::'] * n_per_class) + (['B1::'] * n_per_class)
+        gt_labels = (["A1::"] * n_per_class) + (["B1::"] * n_per_class)
         n = len(gt_labels)
         # Uniform probabilities — simple and well-defined log loss.
         proba = np.full((n, 2), 0.5)
@@ -125,20 +125,19 @@ class ComputeProbabilityTest(unittest.TestCase):
         result = compute_probability(ctx)
 
         df_result = next(
-            d for d in result.dataframes
-            if d.artifact_path == 'probability/per_category_log_loss'
+            d for d in result.dataframes if d.artifact_path == "probability/per_category_log_loss"
         )
         df = df_result.df
         # Both top-level categories (TopA for A1, TopB for B1) should appear.
         self.assertGreater(len(df), 0)
-        self.assertIn('category', df.columns)
-        self.assertIn('log_loss', df.columns)
-        self.assertIn('n_samples', df.columns)
-        self.assertEqual(df['n_samples'].sum(), n)
+        self.assertIn("category", df.columns)
+        self.assertIn("log_loss", df.columns)
+        self.assertIn("n_samples", df.columns)
+        self.assertEqual(df["n_samples"].sum(), n)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_ranking.py
+++ b/tests/pyspacer/test_metrics_ranking.py
@@ -12,66 +12,73 @@ from mermaid_classifier.pyspacer.metrics.ranking import (
     _compute_topk_mrr,
     compute_ranking,
 )
-from pyspacer.metrics_test_helpers import MockBALibrary, MockGFLibrary, MockClf, format_metric
+from pyspacer.metrics_test_helpers import MockBALibrary, MockClf, MockGFLibrary, format_metric
 
 
 class ComputeTopKMRRTest(unittest.TestCase):
     """Tests for _compute_topk_mrr."""
 
     def setUp(self):
-        self.classes = ['A1::', 'A2::', 'B1::']
+        self.classes = ["A1::", "A2::", "B1::"]
 
     def test_perfect_predictions(self):
-        gt_labels = ['A1::', 'A2::', 'B1::']
-        proba = np.array([
-            [0.9, 0.05, 0.05],
-            [0.05, 0.9, 0.05],
-            [0.05, 0.05, 0.9],
-        ])
+        gt_labels = ["A1::", "A2::", "B1::"]
+        proba = np.array(
+            [
+                [0.9, 0.05, 0.05],
+                [0.05, 0.9, 0.05],
+                [0.05, 0.05, 0.9],
+            ]
+        )
         result = _compute_topk_mrr(proba, gt_labels, self.classes)
 
-        self.assertAlmostEqual(result['topk'][1], 1.0)
-        self.assertAlmostEqual(result['mrr'], 1.0)
+        self.assertAlmostEqual(result["topk"][1], 1.0)
+        self.assertAlmostEqual(result["mrr"], 1.0)
 
     def test_worst_predictions(self):
-        gt_labels = ['A1::', 'A2::', 'B1::']
-        proba = np.array([
-            [0.05, 0.45, 0.5],
-            [0.5, 0.05, 0.45],
-            [0.45, 0.5, 0.05],
-        ])
+        gt_labels = ["A1::", "A2::", "B1::"]
+        proba = np.array(
+            [
+                [0.05, 0.45, 0.5],
+                [0.5, 0.05, 0.45],
+                [0.45, 0.5, 0.05],
+            ]
+        )
         result = _compute_topk_mrr(proba, gt_labels, self.classes)
 
-        self.assertAlmostEqual(result['topk'][1], 0.0)
+        self.assertAlmostEqual(result["topk"][1], 0.0)
 
     def test_topk_monotonically_increasing(self):
-        gt_labels = ['A1::', 'A2::', 'B1::']
-        proba = np.array([
-            [0.6, 0.3, 0.1],
-            [0.1, 0.5, 0.4],
-            [0.2, 0.3, 0.5],
-        ])
+        gt_labels = ["A1::", "A2::", "B1::"]
+        proba = np.array(
+            [
+                [0.6, 0.3, 0.1],
+                [0.1, 0.5, 0.4],
+                [0.2, 0.3, 0.5],
+            ]
+        )
         result = _compute_topk_mrr(proba, gt_labels, self.classes)
 
-        ks = sorted(result['topk'].keys())
+        ks = sorted(result["topk"].keys())
         for i in range(len(ks) - 1):
-            self.assertLessEqual(
-                result['topk'][ks[i]], result['topk'][ks[i + 1]])
+            self.assertLessEqual(result["topk"][ks[i]], result["topk"][ks[i + 1]])
 
 
 class ComputeRankingTest(unittest.TestCase):
     """Tests for compute_ranking."""
 
     def setUp(self):
-        classes = ['A1::', 'A2::', 'B1::']
+        classes = ["A1::", "A2::", "B1::"]
         n = 4
-        gt_labels = ['A1::', 'A2::', 'B1::', 'A1::']
-        proba = np.array([
-            [0.8, 0.1, 0.1],
-            [0.1, 0.8, 0.1],
-            [0.1, 0.1, 0.8],
-            [0.8, 0.1, 0.1],
-        ])
+        gt_labels = ["A1::", "A2::", "B1::", "A1::"]
+        proba = np.array(
+            [
+                [0.8, 0.1, 0.1],
+                [0.1, 0.8, 0.1],
+                [0.1, 0.1, 0.8],
+                [0.8, 0.1, 0.1],
+            ]
+        )
         val_results = ValResults(
             scores=[0.8] * n,
             gt=[0, 1, 2, 0],
@@ -89,7 +96,7 @@ class ComputeRankingTest(unittest.TestCase):
         )
 
     def tearDown(self):
-        plt.close('all')
+        plt.close("all")
 
     def test_returns_expected_scalars(self):
         result = compute_ranking(self.ctx)
@@ -97,12 +104,12 @@ class ComputeRankingTest(unittest.TestCase):
         self.assertIsInstance(result, MetricGroupResult)
         scalar_names = {s.name for s in result.scalars}
         expected = {
-            'top_1_accuracy',
-            'top_3_accuracy',
-            'top_5_accuracy',
-            'top_10_accuracy',
-            'mrr',
-            'hierarchical_top_5_mean_similarity',
+            "top_1_accuracy",
+            "top_3_accuracy",
+            "top_5_accuracy",
+            "top_10_accuracy",
+            "mrr",
+            "hierarchical_top_5_mean_similarity",
         }
         self.assertEqual(scalar_names, expected)
 
@@ -113,24 +120,26 @@ class ComputeRankingTest(unittest.TestCase):
         result = compute_ranking(self.ctx)
 
         artifact_paths = {df.artifact_path for df in result.dataframes}
-        self.assertIn('ranking/per_category_topk', artifact_paths)
-        self.assertIn('ranking/hierarchical_topk', artifact_paths)
+        self.assertIn("ranking/per_category_topk", artifact_paths)
+        self.assertIn("ranking/hierarchical_topk", artifact_paths)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
     def test_hierarchical_topk_partial_credit(self):
         """Sibling predictions (A1 vs A2) yield hierarchical similarity > 0."""
-        classes = ['A1::', 'A2::', 'B1::']
+        classes = ["A1::", "A2::", "B1::"]
         # All samples are A1:: but predicted as A2:: (siblings)
         n = 4
-        gt_labels = ['A1::'] * n
-        proba = np.array([
-            [0.1, 0.8, 0.1],
-            [0.1, 0.8, 0.1],
-            [0.1, 0.8, 0.1],
-            [0.1, 0.8, 0.1],
-        ])
+        gt_labels = ["A1::"] * n
+        proba = np.array(
+            [
+                [0.1, 0.8, 0.1],
+                [0.1, 0.8, 0.1],
+                [0.1, 0.8, 0.1],
+                [0.1, 0.8, 0.1],
+            ]
+        )
         val_results = ValResults(
             scores=[0.8] * n,
             gt=[0] * n,
@@ -151,11 +160,11 @@ class ComputeRankingTest(unittest.TestCase):
         scalars = {s.name: s.value for s in result.scalars}
         # Top prediction is A2:: (sibling of A1::), so hierarchical
         # similarity at top-1 is > 0 (siblings share parent A).
-        self.assertGreater(scalars['hierarchical_top_5_mean_similarity'], 0.0)
+        self.assertGreater(scalars["hierarchical_top_5_mean_similarity"], 0.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_taxonomic.py
+++ b/tests/pyspacer/test_metrics_taxonomic.py
@@ -7,7 +7,12 @@ import matplotlib.pyplot as plt
 from mermaid_classifier.pyspacer.metrics._context import MetricsContext
 from mermaid_classifier.pyspacer.metrics._results import MetricGroupResult
 from mermaid_classifier.pyspacer.metrics.taxonomic import compute_taxonomic
-from pyspacer.metrics_test_helpers import MockBALibrary, MockGFLibrary, make_val_results, format_metric
+from pyspacer.metrics_test_helpers import (
+    MockBALibrary,
+    MockGFLibrary,
+    format_metric,
+    make_val_results,
+)
 
 
 def _make_ctx(gt_indices, est_indices, classes, gf_library=None):
@@ -29,17 +34,16 @@ class ErrorAttributionTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 2, 3],
             est_indices=[0, 1, 2, 3],
-            classes=['A1::', 'A2::', 'B1::', 'B2::'],
+            classes=["A1::", "A2::", "B1::", "B2::"],
         )
         result = compute_taxonomic(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars['cross_branch_error_rate'], 0.0)
-        self.assertEqual(scalars['within_branch_error_rate'], 0.0)
+        self.assertEqual(scalars["cross_branch_error_rate"], 0.0)
+        self.assertEqual(scalars["within_branch_error_rate"], 0.0)
 
         attribution_dfs = [
-            dr for dr in result.dataframes
-            if dr.artifact_path == 'taxonomic/error_attribution'
+            dr for dr in result.dataframes if dr.artifact_path == "taxonomic/error_attribution"
         ]
         self.assertEqual(len(attribution_dfs), 1)
         self.assertEqual(len(attribution_dfs[0].df), 0)
@@ -52,12 +56,12 @@ class ErrorAttributionTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 0, 0],
             est_indices=[2, 2, 2, 2],
-            classes=['A1::', 'A2::', 'B1::', 'B2::'],
+            classes=["A1::", "A2::", "B1::", "B2::"],
         )
         result = compute_taxonomic(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertGreater(scalars['cross_branch_error_rate'], 0.0)
+        self.assertGreater(scalars["cross_branch_error_rate"], 0.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -67,12 +71,12 @@ class ErrorAttributionTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 0, 0],
             est_indices=[1, 1, 1, 1],
-            classes=['A1::', 'A2::', 'B1::', 'B2::'],
+            classes=["A1::", "A2::", "B1::", "B2::"],
         )
         result = compute_taxonomic(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertGreater(scalars['within_branch_error_rate'], 0.0)
+        self.assertGreater(scalars["within_branch_error_rate"], 0.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -86,15 +90,15 @@ class TopLevelConfusionTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 2, 3],
             est_indices=[0, 1, 2, 3],
-            classes=['A1::', 'A2::', 'B1::', 'B2::'],
+            classes=["A1::", "A2::", "B1::", "B2::"],
         )
         result = compute_taxonomic(ctx)
 
         df_paths = {dr.artifact_path for dr in result.dataframes}
         fig_paths = {fr.artifact_path for fr in result.figures}
 
-        self.assertIn('taxonomic/top_level_confusions', df_paths)
-        self.assertIn('taxonomic/top_level_confusion.png', fig_paths)
+        self.assertIn("taxonomic/top_level_confusions", df_paths)
+        self.assertIn("taxonomic/top_level_confusion.png", fig_paths)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -105,13 +109,12 @@ class TopLevelConfusionTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 0, 0, 0],
             est_indices=[1, 1, 1, 1],
-            classes=['A1::', 'A2::', 'B1::', 'B2::'],
+            classes=["A1::", "A2::", "B1::", "B2::"],
         )
         result = compute_taxonomic(ctx)
 
         top_level_dfs = [
-            dr for dr in result.dataframes
-            if dr.artifact_path == 'taxonomic/top_level_confusions'
+            dr for dr in result.dataframes if dr.artifact_path == "taxonomic/top_level_confusions"
         ]
         self.assertEqual(len(top_level_dfs), 1)
         df = top_level_dfs[0].df
@@ -121,8 +124,9 @@ class TopLevelConfusionTest(unittest.TestCase):
         if len(df) > 0:
             for _, row in df.iterrows():
                 self.assertEqual(
-                    row['true_top_level'], row['pred_top_level'],
-                    msg='Expected no cross-branch top-level confusions',
+                    row["true_top_level"],
+                    row["pred_top_level"],
+                    msg="Expected no cross-branch top-level confusions",
                 )
 
         for fig_result in result.figures:
@@ -138,13 +142,13 @@ class GrowthFormDifferentiationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 0, 1],
             est_indices=[0, 1, 1, 0],
-            classes=['A1::gf1', 'A1::gf2'],
+            classes=["A1::gf1", "A1::gf2"],
         )
         result = compute_taxonomic(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertIn('gf_accuracy_gf_relevant', scalars)
-        self.assertIn('within_ba_gf_accuracy', scalars)
+        self.assertIn("gf_accuracy_gf_relevant", scalars)
+        self.assertIn("within_ba_gf_accuracy", scalars)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -154,12 +158,12 @@ class GrowthFormDifferentiationTest(unittest.TestCase):
         ctx = _make_ctx(
             gt_indices=[0, 1, 2, 3],
             est_indices=[0, 1, 2, 3],
-            classes=['A1::', 'A2::', 'B1::', 'B2::'],
+            classes=["A1::", "A2::", "B1::", "B2::"],
         )
         result = compute_taxonomic(ctx)
 
         scalars = {s.name: s.value for s in result.scalars}
-        self.assertEqual(scalars['gf_accuracy_gf_relevant'], 0.0)
+        self.assertEqual(scalars["gf_accuracy_gf_relevant"], 0.0)
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
@@ -169,25 +173,25 @@ class ComputeTaxonomicIntegrationTest(unittest.TestCase):
     """Integration tests verifying compute_taxonomic returns all expected
     artifacts."""
 
-    _CLASSES = ['A1::', 'A2::', 'B1::', 'B2::']
+    _CLASSES = ["A1::", "A2::", "B1::", "B2::"]
 
     _EXPECTED_SCALARS = {
-        'cross_branch_error_rate',
-        'within_branch_error_rate',
-        'gf_accuracy_gf_relevant',
-        'within_ba_gf_accuracy',
+        "cross_branch_error_rate",
+        "within_branch_error_rate",
+        "gf_accuracy_gf_relevant",
+        "within_ba_gf_accuracy",
     }
 
     _EXPECTED_DATAFRAMES = {
-        'taxonomic/error_attribution',
-        'taxonomic/top_level_confusions',
-        'taxonomic/gf_precision_recall_f1',
+        "taxonomic/error_attribution",
+        "taxonomic/top_level_confusions",
+        "taxonomic/gf_precision_recall_f1",
     }
 
     _EXPECTED_FIGURES = {
-        'taxonomic/error_attribution.png',
-        'taxonomic/top_level_confusion.png',
-        'taxonomic/gf_confusion.png',
+        "taxonomic/error_attribution.png",
+        "taxonomic/top_level_confusion.png",
+        "taxonomic/gf_confusion.png",
     }
 
     def test_returns_all_expected_artifacts(self):
@@ -195,7 +199,7 @@ class ComputeTaxonomicIntegrationTest(unittest.TestCase):
         and figures."""
         # Use classes with growth forms and imperfect predictions so that
         # error attribution and GF differentiation figures are generated.
-        classes = ['A1::gf1', 'A2::gf2', 'B1::', 'B2::']
+        classes = ["A1::gf1", "A2::gf2", "B1::", "B2::"]
         ctx = _make_ctx(
             gt_indices=[0, 0, 1, 1, 2, 2, 3, 3],
             est_indices=[0, 1, 1, 0, 2, 3, 3, 2],
@@ -208,19 +212,19 @@ class ComputeTaxonomicIntegrationTest(unittest.TestCase):
 
         scalar_names = {s.name for s in result.scalars}
         for expected in self._EXPECTED_SCALARS:
-            self.assertIn(expected, scalar_names, msg=f'Missing scalar: {expected}')
+            self.assertIn(expected, scalar_names, msg=f"Missing scalar: {expected}")
 
         df_paths = {dr.artifact_path for dr in result.dataframes}
         for expected in self._EXPECTED_DATAFRAMES:
-            self.assertIn(expected, df_paths, msg=f'Missing dataframe: {expected}')
+            self.assertIn(expected, df_paths, msg=f"Missing dataframe: {expected}")
 
         fig_paths = {fr.artifact_path for fr in result.figures}
         for expected in self._EXPECTED_FIGURES:
-            self.assertIn(expected, fig_paths, msg=f'Missing figure: {expected}')
+            self.assertIn(expected, fig_paths, msg=f"Missing figure: {expected}")
 
         for fig_result in result.figures:
             plt.close(fig_result.fig)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_metrics_taxonomy_helpers.py
+++ b/tests/pyspacer/test_metrics_taxonomy_helpers.py
@@ -2,8 +2,6 @@
 
 import unittest
 
-from pyspacer.metrics_test_helpers import MockBALibrary
-
 from mermaid_classifier.pyspacer.metrics._taxonomy_helpers import (
     build_ba_paths,
     build_ba_to_top,
@@ -12,6 +10,7 @@ from mermaid_classifier.pyspacer.metrics._taxonomy_helpers import (
     taxonomic_similarity,
     top_level_ancestor,
 )
+from pyspacer.metrics_test_helpers import MockBALibrary
 
 
 class TopLevelAncestorTest(unittest.TestCase):
@@ -21,16 +20,16 @@ class TopLevelAncestorTest(unittest.TestCase):
         self.lib = MockBALibrary()
 
     def test_leaf_node_returns_root(self):
-        self.assertEqual(top_level_ancestor('A1', self.lib), 'A')
+        self.assertEqual(top_level_ancestor("A1", self.lib), "A")
 
     def test_other_leaf_node_returns_root(self):
-        self.assertEqual(top_level_ancestor('B2', self.lib), 'B')
+        self.assertEqual(top_level_ancestor("B2", self.lib), "B")
 
     def test_root_node_returns_itself(self):
-        self.assertEqual(top_level_ancestor('A', self.lib), 'A')
+        self.assertEqual(top_level_ancestor("A", self.lib), "A")
 
     def test_other_root_node_returns_itself(self):
-        self.assertEqual(top_level_ancestor('B', self.lib), 'B')
+        self.assertEqual(top_level_ancestor("B", self.lib), "B")
 
 
 class BuildBaToTopTest(unittest.TestCase):
@@ -40,33 +39,33 @@ class BuildBaToTopTest(unittest.TestCase):
         self.lib = MockBALibrary()
 
     def test_maps_leaf_classes_to_roots(self):
-        classes = ['A1::', 'A2::', 'B1::']
+        classes = ["A1::", "A2::", "B1::"]
         result = build_ba_to_top(classes, self.lib)
-        self.assertEqual(result['A1'], 'A')
-        self.assertEqual(result['A2'], 'A')
-        self.assertEqual(result['B1'], 'B')
+        self.assertEqual(result["A1"], "A")
+        self.assertEqual(result["A2"], "A")
+        self.assertEqual(result["B1"], "B")
 
     def test_maps_root_classes_to_themselves(self):
-        classes = ['A::', 'B::']
+        classes = ["A::", "B::"]
         result = build_ba_to_top(classes, self.lib)
-        self.assertEqual(result['A'], 'A')
-        self.assertEqual(result['B'], 'B')
+        self.assertEqual(result["A"], "A")
+        self.assertEqual(result["B"], "B")
 
     def test_deduplicates_ba_ids(self):
-        classes = ['A1::', 'A1::gf1', 'A1::gf2']
+        classes = ["A1::", "A1::gf1", "A1::gf2"]
         result = build_ba_to_top(classes, self.lib)
-        self.assertEqual(list(result.keys()), ['A1'])
+        self.assertEqual(list(result.keys()), ["A1"])
 
     def test_classes_with_growth_forms(self):
-        classes = ['B1::gf1', 'B2::gf2']
+        classes = ["B1::gf1", "B2::gf2"]
         result = build_ba_to_top(classes, self.lib)
-        self.assertEqual(result['B1'], 'B')
-        self.assertEqual(result['B2'], 'B')
+        self.assertEqual(result["B1"], "B")
+        self.assertEqual(result["B2"], "B")
 
     def test_all_classes_present(self):
-        classes = ['A1::', 'A2::', 'B1::', 'B2::']
+        classes = ["A1::", "A2::", "B1::", "B2::"]
         result = build_ba_to_top(classes, self.lib)
-        self.assertEqual(set(result.keys()), {'A1', 'A2', 'B1', 'B2'})
+        self.assertEqual(set(result.keys()), {"A1", "A2", "B1", "B2"})
 
 
 class BuildBaPathsTest(unittest.TestCase):
@@ -76,30 +75,30 @@ class BuildBaPathsTest(unittest.TestCase):
         self.lib = MockBALibrary()
 
     def test_leaf_path_is_root_to_leaf(self):
-        classes = ['A1::']
+        classes = ["A1::"]
         result = build_ba_paths(classes, self.lib)
-        self.assertEqual(result['A1'], ['A', 'A1'])
+        self.assertEqual(result["A1"], ["A", "A1"])
 
     def test_root_path_is_just_root(self):
-        classes = ['A::']
+        classes = ["A::"]
         result = build_ba_paths(classes, self.lib)
-        self.assertEqual(result['A'], ['A'])
+        self.assertEqual(result["A"], ["A"])
 
     def test_multiple_classes_different_trees(self):
-        classes = ['A1::', 'B2::']
+        classes = ["A1::", "B2::"]
         result = build_ba_paths(classes, self.lib)
-        self.assertEqual(result['A1'], ['A', 'A1'])
-        self.assertEqual(result['B2'], ['B', 'B2'])
+        self.assertEqual(result["A1"], ["A", "A1"])
+        self.assertEqual(result["B2"], ["B", "B2"])
 
     def test_deduplicates_ba_ids(self):
-        classes = ['A1::', 'A1::gf1']
+        classes = ["A1::", "A1::gf1"]
         result = build_ba_paths(classes, self.lib)
-        self.assertEqual(list(result.keys()), ['A1'])
+        self.assertEqual(list(result.keys()), ["A1"])
 
     def test_all_leaves_present(self):
-        classes = ['A1::', 'A2::', 'B1::', 'B2::']
+        classes = ["A1::", "A2::", "B1::", "B2::"]
         result = build_ba_paths(classes, self.lib)
-        self.assertEqual(set(result.keys()), {'A1', 'A2', 'B1', 'B2'})
+        self.assertEqual(set(result.keys()), {"A1", "A2", "B1", "B2"})
 
 
 class FindLcaTest(unittest.TestCase):
@@ -108,32 +107,32 @@ class FindLcaTest(unittest.TestCase):
     def setUp(self):
         self.lib = MockBALibrary()
         self.ba_paths = {
-            'A': ['A'],
-            'A1': ['A', 'A1'],
-            'A2': ['A', 'A2'],
-            'B': ['B'],
-            'B1': ['B', 'B1'],
-            'B2': ['B', 'B2'],
+            "A": ["A"],
+            "A1": ["A", "A1"],
+            "A2": ["A", "A2"],
+            "B": ["B"],
+            "B1": ["B", "B1"],
+            "B2": ["B", "B2"],
         }
 
     def test_siblings_return_parent(self):
-        lca = find_lca('A1', 'A2', self.ba_paths)
-        self.assertEqual(lca, 'A')
+        lca = find_lca("A1", "A2", self.ba_paths)
+        self.assertEqual(lca, "A")
 
     def test_same_node_returns_itself(self):
-        lca = find_lca('A1', 'A1', self.ba_paths)
-        self.assertEqual(lca, 'A1')
+        lca = find_lca("A1", "A1", self.ba_paths)
+        self.assertEqual(lca, "A1")
 
     def test_root_and_leaf_same_branch_returns_root(self):
-        lca = find_lca('A', 'A1', self.ba_paths)
-        self.assertEqual(lca, 'A')
+        lca = find_lca("A", "A1", self.ba_paths)
+        self.assertEqual(lca, "A")
 
     def test_different_branches_returns_none(self):
-        lca = find_lca('A1', 'B1', self.ba_paths)
+        lca = find_lca("A1", "B1", self.ba_paths)
         self.assertIsNone(lca)
 
     def test_different_roots_returns_none(self):
-        lca = find_lca('A', 'B', self.ba_paths)
+        lca = find_lca("A", "B", self.ba_paths)
         self.assertIsNone(lca)
 
 
@@ -143,43 +142,43 @@ class TaxonomicSimilarityTest(unittest.TestCase):
     def setUp(self):
         self.lib = MockBALibrary()
         self.ba_paths = {
-            'A': ['A'],
-            'A1': ['A', 'A1'],
-            'A2': ['A', 'A2'],
-            'B': ['B'],
-            'B1': ['B', 'B1'],
-            'B2': ['B', 'B2'],
+            "A": ["A"],
+            "A1": ["A", "A1"],
+            "A2": ["A", "A2"],
+            "B": ["B"],
+            "B1": ["B", "B1"],
+            "B2": ["B", "B2"],
         }
 
     def test_same_node_returns_one(self):
-        sim = taxonomic_similarity('A1', 'A1', self.ba_paths, self.lib)
+        sim = taxonomic_similarity("A1", "A1", self.ba_paths, self.lib)
         self.assertEqual(sim, 1.0)
 
     def test_siblings_return_expected_fraction(self):
         # shared_depth = len(ancestors of 'A') + 1 = 0 + 1 = 1
         # max_depth = max(len(['A', 'A1']), len(['A', 'A2'])) = 2
         # expected = 1 / 2 = 0.5
-        sim = taxonomic_similarity('A1', 'A2', self.ba_paths, self.lib)
+        sim = taxonomic_similarity("A1", "A2", self.ba_paths, self.lib)
         self.assertAlmostEqual(sim, 0.5)
 
     def test_different_branches_return_zero(self):
-        sim = taxonomic_similarity('A1', 'B1', self.ba_paths, self.lib)
+        sim = taxonomic_similarity("A1", "B1", self.ba_paths, self.lib)
         self.assertEqual(sim, 0.0)
 
     def test_different_roots_return_zero(self):
-        sim = taxonomic_similarity('A', 'B', self.ba_paths, self.lib)
+        sim = taxonomic_similarity("A", "B", self.ba_paths, self.lib)
         self.assertEqual(sim, 0.0)
 
     def test_symmetry(self):
-        sim_ab = taxonomic_similarity('A1', 'A2', self.ba_paths, self.lib)
-        sim_ba = taxonomic_similarity('A2', 'A1', self.ba_paths, self.lib)
+        sim_ab = taxonomic_similarity("A1", "A2", self.ba_paths, self.lib)
+        sim_ba = taxonomic_similarity("A2", "A1", self.ba_paths, self.lib)
         self.assertAlmostEqual(sim_ab, sim_ba)
 
     def test_root_siblings_return_expected_fraction(self):
         # shared_depth = len(ancestors of 'B') + 1 = 0 + 1 = 1
         # max_depth = max(len(['B', 'B1']), len(['B', 'B2'])) = 2
         # expected = 1 / 2 = 0.5
-        sim = taxonomic_similarity('B1', 'B2', self.ba_paths, self.lib)
+        sim = taxonomic_similarity("B1", "B2", self.ba_paths, self.lib)
         self.assertAlmostEqual(sim, 0.5)
 
 
@@ -189,72 +188,95 @@ class GroupByTopLevelTest(unittest.TestCase):
     def setUp(self):
         self.lib = MockBALibrary()
         # classes: 0=A1::, 1=A2::, 2=B1::, 3=B2::
-        self.classes = ['A1::', 'A2::', 'B1::', 'B2::']
-        self.ba_to_top = {'A1': 'A', 'A2': 'A', 'B1': 'B', 'B2': 'B'}
+        self.classes = ["A1::", "A2::", "B1::", "B2::"]
+        self.ba_to_top = {"A1": "A", "A2": "A", "B1": "B", "B2": "B"}
 
     def test_groups_by_top_level_ba(self):
         # gt: samples 0,1 -> A1 (top=A); samples 2,3 -> B1 (top=B)
         gt_indices = [0, 0, 2, 2]
         sample_indices = list(range(4))
         groups = group_by_top_level(
-            sample_indices, gt_indices, self.classes,
-            self.ba_to_top, self.lib, min_samples=1,
+            sample_indices,
+            gt_indices,
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=1,
         )
-        top_ba_ids = {g['top_ba_id'] for g in groups}
-        self.assertEqual(top_ba_ids, {'A', 'B'})
+        top_ba_ids = {g["top_ba_id"] for g in groups}
+        self.assertEqual(top_ba_ids, {"A", "B"})
 
     def test_group_has_correct_fields(self):
         gt_indices = [0, 0, 2, 2]
         sample_indices = list(range(4))
         groups = group_by_top_level(
-            sample_indices, gt_indices, self.classes,
-            self.ba_to_top, self.lib, min_samples=1,
+            sample_indices,
+            gt_indices,
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=1,
         )
         for group in groups:
-            self.assertIn('top_ba_id', group)
-            self.assertIn('name', group)
-            self.assertIn('indices', group)
-            self.assertIn('n_samples', group)
+            self.assertIn("top_ba_id", group)
+            self.assertIn("name", group)
+            self.assertIn("indices", group)
+            self.assertIn("n_samples", group)
 
     def test_group_name_from_library(self):
         gt_indices = [0, 0]
         sample_indices = [0, 1]
         groups = group_by_top_level(
-            sample_indices, gt_indices, self.classes,
-            self.ba_to_top, self.lib, min_samples=1,
+            sample_indices,
+            gt_indices,
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=1,
         )
         self.assertEqual(len(groups), 1)
-        self.assertEqual(groups[0]['name'], 'TopA')
+        self.assertEqual(groups[0]["name"], "TopA")
 
     def test_min_samples_filters_small_groups(self):
         # Only 2 samples for A, 1 sample for B
         gt_indices = [0, 0, 2]
         sample_indices = [0, 1, 2]
         groups = group_by_top_level(
-            sample_indices, gt_indices, self.classes,
-            self.ba_to_top, self.lib, min_samples=2,
+            sample_indices,
+            gt_indices,
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=2,
         )
-        top_ba_ids = {g['top_ba_id'] for g in groups}
-        self.assertIn('A', top_ba_ids)
-        self.assertNotIn('B', top_ba_ids)
+        top_ba_ids = {g["top_ba_id"] for g in groups}
+        self.assertIn("A", top_ba_ids)
+        self.assertNotIn("B", top_ba_ids)
 
     def test_n_samples_matches_indices_length(self):
         gt_indices = [0, 0, 0, 2, 2]
         sample_indices = list(range(5))
         groups = group_by_top_level(
-            sample_indices, gt_indices, self.classes,
-            self.ba_to_top, self.lib, min_samples=1,
+            sample_indices,
+            gt_indices,
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=1,
         )
-        groups_by_id = {g['top_ba_id']: g for g in groups}
-        self.assertEqual(groups_by_id['A']['n_samples'], 3)
-        self.assertEqual(groups_by_id['A']['n_samples'],
-                         len(groups_by_id['A']['indices']))
-        self.assertEqual(groups_by_id['B']['n_samples'], 2)
+        groups_by_id = {g["top_ba_id"]: g for g in groups}
+        self.assertEqual(groups_by_id["A"]["n_samples"], 3)
+        self.assertEqual(groups_by_id["A"]["n_samples"], len(groups_by_id["A"]["indices"]))
+        self.assertEqual(groups_by_id["B"]["n_samples"], 2)
 
     def test_empty_sample_indices_returns_no_groups(self):
         groups = group_by_top_level(
-            [], [], self.classes,
-            self.ba_to_top, self.lib, min_samples=1,
+            [],
+            [],
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=1,
         )
         self.assertEqual(groups, [])
 
@@ -262,11 +284,15 @@ class GroupByTopLevelTest(unittest.TestCase):
         gt_indices = [0, 2]
         sample_indices = [0, 1]
         groups = group_by_top_level(
-            sample_indices, gt_indices, self.classes,
-            self.ba_to_top, self.lib, min_samples=30,
+            sample_indices,
+            gt_indices,
+            self.classes,
+            self.ba_to_top,
+            self.lib,
+            min_samples=30,
         )
         self.assertEqual(groups, [])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/pyspacer/test_mlflow_model.py
+++ b/tests/pyspacer/test_mlflow_model.py
@@ -1,5 +1,6 @@
 """Tests for the MLflow pyfunc shim that stores the portable artifact
 (model.pt + model.json) and serves it through load_predictor."""
+
 import tempfile
 import unittest
 from pathlib import Path
@@ -34,13 +35,13 @@ class ArtifactPredictorModelTest(unittest.TestCase):
             got = pyfunc_model.predict(_Ctx(), X)
 
         self.assertEqual(got.shape, model.predict_proba(X).shape)
-        self.assertLess(
-            float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
+        self.assertLess(float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
 
 
 class LogArtifactModelTest(unittest.TestCase):
     def test_logs_pt_and_json_and_no_pickle_and_reloads(self):
         import mlflow
+
         from mermaid_classifier.pyspacer.inference import export_artifact
         from mermaid_classifier.pyspacer.mlflow_model import log_artifact_model
 
@@ -57,17 +58,14 @@ class LogArtifactModelTest(unittest.TestCase):
             artifacts_root = d / "artifacts"
             mlflow.set_tracking_uri(f"sqlite:///{d / 'mlflow.db'}")
             exp_id = mlflow.create_experiment(
-                "test-artifact-store",
-                artifact_location=artifacts_root.as_uri())
+                "test-artifact-store", artifact_location=artifacts_root.as_uri()
+            )
             with mlflow.start_run(experiment_id=exp_id):
-                info = log_artifact_model(
-                    model_pt, model_json,
-                    registered_model_name=None)
+                info = log_artifact_model(model_pt, model_json, registered_model_name=None)
                 loaded = mlflow.pyfunc.load_model(info.model_uri)
 
             # Stored the deployable files, and NO classifier pickle.
-            artifact_files = [p.name for p in artifacts_root.rglob("*")
-                              if p.is_file()]
+            artifact_files = [p.name for p in artifacts_root.rglob("*") if p.is_file()]
             self.assertIn("model.pt", artifact_files)
             self.assertIn("model.json", artifact_files)
             # The spec prohibits the *classifier* pickle (model.pkl), not
@@ -75,9 +73,7 @@ class LogArtifactModelTest(unittest.TestCase):
             self.assertNotIn("model.pkl", artifact_files)
 
             got = loaded.predict(X)
-        self.assertLess(
-            float(np.max(np.abs(np.asarray(got) - model.predict_proba(X)))),
-            1e-6)
+        self.assertLess(float(np.max(np.abs(np.asarray(got) - model.predict_proba(X)))), 1e-6)
 
 
 if __name__ == "__main__":

--- a/tests/pyspacer/test_mlp_benchmark.py
+++ b/tests/pyspacer/test_mlp_benchmark.py
@@ -9,6 +9,7 @@ on identical data.
 
 All data is synthetic and small so the full suite runs in seconds.
 """
+
 from __future__ import annotations
 
 import pickle
@@ -19,7 +20,6 @@ import numpy as np
 from sklearn.neural_network import MLPClassifier
 
 from mermaid_classifier.pyspacer.torch_classifier import TorchMLPClassifier
-
 
 # Seed convention: distinct offsets give independent-but-deterministic RNG
 # streams so the data-generation order never correlates with the training
@@ -89,8 +89,7 @@ def train_via_partial_fit(
         X_shuf, y_shuf = X[order], y[order]
         for start in range(0, n, chunk_size):
             end = min(start + chunk_size, n)
-            clf.partial_fit(X_shuf[start:end], y_shuf[start:end],
-                            classes=classes)
+            clf.partial_fit(X_shuf[start:end], y_shuf[start:end], classes=classes)
 
 
 class MLPBenchmarkBase:
@@ -114,18 +113,23 @@ class MLPBenchmarkBase:
     @classmethod
     def setUpClass(cls):  # type: ignore[override]
         X_all, y_all = make_gaussian_clusters(
-            n_per_class=(N_TRAIN + N_VAL) // N_CLASSES, seed=SEED,
+            n_per_class=(N_TRAIN + N_VAL) // N_CLASSES,
+            seed=SEED,
         )
-        cls.X_train, cls.y_train, cls.X_val, cls.y_val = train_val_split(
-            X_all, y_all, n_val=N_VAL)
+        cls.X_train, cls.y_train, cls.X_val, cls.y_val = train_val_split(X_all, y_all, n_val=N_VAL)
         cls.classes_list = sorted(np.unique(y_all).tolist())
 
     def _train(self, clf):
         rng = np.random.RandomState(SEED + 1)  # training-shuffle stream
         t0 = time.time()
         train_via_partial_fit(
-            clf, self.X_train, self.y_train, self.classes_list,
-            epochs=EPOCHS, chunk_size=PARTIAL_FIT_BATCH, rng=rng,
+            clf,
+            self.X_train,
+            self.y_train,
+            self.classes_list,
+            epochs=EPOCHS,
+            chunk_size=PARTIAL_FIT_BATCH,
+            rng=rng,
         )
         return time.time() - t0
 
@@ -138,9 +142,7 @@ class MLPBenchmarkBase:
         preds = clf.predict(self.X_train)
         acc = float(np.mean(preds == self.y_train))
         self.assertGreater(
-            acc, 0.85,
-            f"Training accuracy {acc:.3f} below threshold 0.85"
-            f" for {type(clf).__name__}"
+            acc, 0.85, f"Training accuracy {acc:.3f} below threshold 0.85 for {type(clf).__name__}"
         )
 
     def test_generalises_to_validation(self):
@@ -150,9 +152,9 @@ class MLPBenchmarkBase:
         preds = clf.predict(self.X_val)
         acc = float(np.mean(preds == self.y_val))
         self.assertGreater(
-            acc, 0.80,
-            f"Validation accuracy {acc:.3f} below threshold 0.80"
-            f" for {type(clf).__name__}"
+            acc,
+            0.80,
+            f"Validation accuracy {acc:.3f} below threshold 0.80 for {type(clf).__name__}",
         )
 
     def test_predict_proba_shape_and_normalisation(self):
@@ -160,8 +162,7 @@ class MLPBenchmarkBase:
         self._train(clf)
         probs = clf.predict_proba(self.X_val)
         self.assertEqual(probs.shape, (N_VAL, N_CLASSES))
-        np.testing.assert_allclose(
-            probs.sum(axis=1), np.ones(N_VAL), rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(probs.sum(axis=1), np.ones(N_VAL), rtol=1e-5, atol=1e-5)
         self.assertTrue((probs >= 0).all())
         self.assertTrue((probs <= 1).all())
 
@@ -177,10 +178,7 @@ class MLPBenchmarkBase:
     def test_loss_curve_available_and_finite(self):
         clf = self._make_classifier()
         self._train(clf)
-        self.assertTrue(
-            hasattr(clf, "loss_curve_"),
-            f"{type(clf).__name__} missing loss_curve_"
-        )
+        self.assertTrue(hasattr(clf, "loss_curve_"), f"{type(clf).__name__} missing loss_curve_")
         self.assertGreater(len(clf.loss_curve_), 0)
         self.assertTrue(all(np.isfinite(clf.loss_curve_)))
         # Loss should trend downward — the first recorded loss should be
@@ -207,8 +205,7 @@ class MLPBenchmarkBase:
         probs_after = clf2.predict_proba(self.X_val)
 
         np.testing.assert_array_equal(preds_before, preds_after)
-        np.testing.assert_allclose(probs_before, probs_after,
-                                   rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(probs_before, probs_after, rtol=1e-5, atol=1e-6)
 
     def test_partial_fit_accumulates_across_calls(self):
         """Multiple small partial_fit calls should still converge."""
@@ -216,14 +213,19 @@ class MLPBenchmarkBase:
         rng = np.random.RandomState(SEED + 2)  # tiny-chunk shuffle stream
         # Deliberately tiny chunks: tests the incremental-fit contract.
         train_via_partial_fit(
-            clf, self.X_train, self.y_train, self.classes_list,
-            epochs=EPOCHS, chunk_size=50, rng=rng,
+            clf,
+            self.X_train,
+            self.y_train,
+            self.classes_list,
+            epochs=EPOCHS,
+            chunk_size=50,
+            rng=rng,
         )
         acc = float(np.mean(clf.predict(self.X_val) == self.y_val))
         self.assertGreater(
-            acc, 0.75,
-            f"Incremental partial_fit accuracy {acc:.3f} below 0.75"
-            f" for {type(clf).__name__}"
+            acc,
+            0.75,
+            f"Incremental partial_fit accuracy {acc:.3f} below 0.75 for {type(clf).__name__}",
         )
 
     def test_decision_function_or_predict_proba_usable_for_calibration(self):
@@ -287,10 +289,10 @@ class MLPParityTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):  # type: ignore[override]
         X_all, y_all = make_gaussian_clusters(
-            n_per_class=(N_TRAIN + N_VAL) // N_CLASSES, seed=SEED,
+            n_per_class=(N_TRAIN + N_VAL) // N_CLASSES,
+            seed=SEED,
         )
-        cls.X_train, cls.y_train, cls.X_val, cls.y_val = train_val_split(
-            X_all, y_all, n_val=N_VAL)
+        cls.X_train, cls.y_train, cls.X_val, cls.y_val = train_val_split(X_all, y_all, n_val=N_VAL)
         cls.classes_list = sorted(np.unique(y_all).tolist())
 
     def _train_both(self):
@@ -307,8 +309,13 @@ class MLPParityTest(unittest.TestCase):
         for clf in (sk, tr):
             rng = np.random.RandomState(SEED + 1)  # training-shuffle stream
             train_via_partial_fit(
-                clf, self.X_train, self.y_train, self.classes_list,
-                epochs=EPOCHS, chunk_size=PARTIAL_FIT_BATCH, rng=rng,
+                clf,
+                self.X_train,
+                self.y_train,
+                self.classes_list,
+                epochs=EPOCHS,
+                chunk_size=PARTIAL_FIT_BATCH,
+                rng=rng,
             )
         return sk, tr
 
@@ -318,9 +325,9 @@ class MLPParityTest(unittest.TestCase):
         sk_acc = float(np.mean(sk.predict(self.X_val) == self.y_val))
         tr_acc = float(np.mean(tr.predict(self.X_val) == self.y_val))
         self.assertGreaterEqual(
-            tr_acc, sk_acc - 0.05,
-            f"Torch {tr_acc:.3f} vs sklearn {sk_acc:.3f} —"
-            f" torch must be within 5% of sklearn."
+            tr_acc,
+            sk_acc - 0.05,
+            f"Torch {tr_acc:.3f} vs sklearn {sk_acc:.3f} — torch must be within 5% of sklearn.",
         )
 
     def test_torch_training_accuracy_within_tolerance(self):
@@ -328,8 +335,7 @@ class MLPParityTest(unittest.TestCase):
         sk_acc = float(np.mean(sk.predict(self.X_train) == self.y_train))
         tr_acc = float(np.mean(tr.predict(self.X_train) == self.y_train))
         self.assertGreaterEqual(
-            tr_acc, sk_acc - 0.05,
-            f"Torch train {tr_acc:.3f} vs sklearn {sk_acc:.3f}"
+            tr_acc, sk_acc - 0.05, f"Torch train {tr_acc:.3f} vs sklearn {sk_acc:.3f}"
         )
 
     def test_torch_predict_proba_distribution_close(self):
@@ -340,9 +346,9 @@ class MLPParityTest(unittest.TestCase):
         tr_argmax = np.argmax(tr.predict_proba(self.X_val), axis=1)
         agreement = float(np.mean(sk_argmax == tr_argmax))
         self.assertGreater(
-            agreement, 0.85,
-            f"Torch and sklearn argmax agree on only {agreement:.3f} of"
-            f" validation samples."
+            agreement,
+            0.85,
+            f"Torch and sklearn argmax agree on only {agreement:.3f} of validation samples.",
         )
 
     def test_predict_proba_values_close_to_sklearn(self):
@@ -361,9 +367,10 @@ class MLPParityTest(unittest.TestCase):
         # BLAS/framework numerical drift across environments.
         mean_abs_diff = float(np.mean(np.abs(sk_probs - tr_probs)))
         self.assertLess(
-            mean_abs_diff, 1e-2,
+            mean_abs_diff,
+            1e-2,
             f"Mean abs difference between torch and sklearn predict_proba"
-            f" is {mean_abs_diff:.4f} (> 1e-2)."
+            f" is {mean_abs_diff:.4f} (> 1e-2).",
         )
 
     def test_calibrated_predict_proba_close_to_sklearn(self):
@@ -392,9 +399,10 @@ class MLPParityTest(unittest.TestCase):
         self.assertEqual(sk_probs.shape, tr_probs.shape)
         mean_abs_diff = float(np.mean(np.abs(sk_probs - tr_probs)))
         self.assertLess(
-            mean_abs_diff, 1e-2,
+            mean_abs_diff,
+            1e-2,
             f"Mean abs difference between torch and sklearn calibrated"
-            f" predict_proba is {mean_abs_diff:.4f} (> 1e-2)."
+            f" predict_proba is {mean_abs_diff:.4f} (> 1e-2).",
         )
 
 
@@ -411,18 +419,17 @@ class BatchingEquivalenceTest(unittest.TestCase):
     def setUpClass(cls):
         rng = np.random.RandomState(SEED)
         cls.X = rng.randn(500, 16).astype(np.float32)
-        cls.y = np.array(
-            ["a", "b", "c"] * 166 + ["a", "b"], dtype=object)
+        cls.y = np.array(["a", "b", "c"] * 166 + ["a", "b"], dtype=object)
         cls.classes = ["a", "b", "c"]
 
     def _make_pair(self):
         """Same hyperparameters on both sides."""
-        kw = dict(
-            hidden_layer_sizes=(16,),
-            learning_rate_init=1e-3,
-            batch_size="auto",
-            random_state=SEED,
-        )
+        kw = {
+            "hidden_layer_sizes": (16,),
+            "learning_rate_init": 1e-3,
+            "batch_size": "auto",
+            "random_state": SEED,
+        }
         return MLPClassifier(**kw), TorchMLPClassifier(**kw)
 
     def test_one_partial_fit_call_appends_one_loss_entry(self):
@@ -432,15 +439,15 @@ class BatchingEquivalenceTest(unittest.TestCase):
         for clf in (sk, tr):
             clf.partial_fit(self.X, self.y, classes=self.classes)
             self.assertEqual(
-                len(clf.loss_curve_), 1,
-                f"{type(clf).__name__}: expected 1 entry, got"
-                f" {len(clf.loss_curve_)}"
+                len(clf.loss_curve_),
+                1,
+                f"{type(clf).__name__}: expected 1 entry, got {len(clf.loss_curve_)}",
             )
             clf.partial_fit(self.X, self.y)
             self.assertEqual(
-                len(clf.loss_curve_), 2,
-                f"{type(clf).__name__}: expected 2 entries, got"
-                f" {len(clf.loss_curve_)}"
+                len(clf.loss_curve_),
+                2,
+                f"{type(clf).__name__}: expected 2 entries, got {len(clf.loss_curve_)}",
             )
 
     def test_n_iter_increments_by_one_per_partial_fit(self):
@@ -474,11 +481,11 @@ class BatchingEquivalenceTest(unittest.TestCase):
 
     def test_explicit_batch_size_is_clipped_to_n_samples(self):
         """batch_size=128 on 50-sample input clips to 50 in both."""
-        kw = dict(
-            hidden_layer_sizes=(8,),
-            batch_size=128,
-            random_state=SEED,
-        )
+        kw = {
+            "hidden_layer_sizes": (8,),
+            "batch_size": 128,
+            "random_state": SEED,
+        }
         sk = MLPClassifier(**kw)
         tr = TorchMLPClassifier(**kw)
         sk.partial_fit(self.X[:50], self.y[:50], classes=self.classes)
@@ -505,19 +512,15 @@ class BatchingEquivalenceTest(unittest.TestCase):
         step_count = tr._optimizer.state[first_param]["step"]
         # PyTorch stores step as either a tensor or a python int depending
         # on version; normalise.
-        step_int = int(step_count.item()) if hasattr(step_count, "item") \
-            else int(step_count)
+        step_int = int(step_count.item()) if hasattr(step_count, "item") else int(step_count)
         self.assertEqual(
-            step_int, 5,
-            f"Expected 5 Adam steps for 500 samples at batch_size=100,"
-            f" got {step_int}"
+            step_int, 5, f"Expected 5 Adam steps for 500 samples at batch_size=100, got {step_int}"
         )
 
         # Second partial_fit call → 5 more steps (cumulative 10).
         tr.partial_fit(self.X[:500], self.y[:500])
         step_count = tr._optimizer.state[first_param]["step"]
-        step_int = int(step_count.item()) if hasattr(step_count, "item") \
-            else int(step_count)
+        step_int = int(step_count.item()) if hasattr(step_count, "item") else int(step_count)
         self.assertEqual(step_int, 10)
 
     def test_partial_fit_on_smaller_than_batch_size_is_one_step(self):
@@ -530,8 +533,7 @@ class BatchingEquivalenceTest(unittest.TestCase):
         tr.partial_fit(self.X[:50], self.y[:50], classes=self.classes)
         first_param = next(iter(tr._module.parameters()))
         step_count = tr._optimizer.state[first_param]["step"]
-        step_int = int(step_count.item()) if hasattr(step_count, "item") \
-            else int(step_count)
+        step_int = int(step_count.item()) if hasattr(step_count, "item") else int(step_count)
         self.assertEqual(step_int, 1)
 
     def test_loss_curve_records_regularised_loss_trend(self):
@@ -550,17 +552,21 @@ class BatchingEquivalenceTest(unittest.TestCase):
         sklearn contract — and our torch version honours it by re-seeding
         from random_state inside each partial_fit call."""
         tr1 = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), random_state=SEED,
+            hidden_layer_sizes=(8,),
+            random_state=SEED,
         )
         tr2 = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), random_state=SEED,
+            hidden_layer_sizes=(8,),
+            random_state=SEED,
         )
         for _ in range(5):
             tr1.partial_fit(self.X, self.y, classes=self.classes)
             tr2.partial_fit(self.X, self.y, classes=self.classes)
         np.testing.assert_allclose(
-            tr1.loss_curve_, tr2.loss_curve_, rtol=1e-6,
-            err_msg="Same random_state must yield identical loss curves"
+            tr1.loss_curve_,
+            tr2.loss_curve_,
+            rtol=1e-6,
+            err_msg="Same random_state must yield identical loss curves",
         )
 
 
@@ -578,10 +584,10 @@ class TorchMLPIntegratesWithCalibratedClassifierCVTest(unittest.TestCase):
         from mermaid_classifier.pyspacer.trainer import MermaidTrainer
 
         X_all, y_all = make_gaussian_clusters(
-            n_per_class=(N_TRAIN + N_VAL) // N_CLASSES, seed=SEED,
+            n_per_class=(N_TRAIN + N_VAL) // N_CLASSES,
+            seed=SEED,
         )
-        X_train, y_train, X_val, y_val = train_val_split(
-            X_all, y_all, n_val=N_VAL)
+        X_train, y_train, X_val, y_val = train_val_split(X_all, y_all, n_val=N_VAL)
         classes_list = sorted(np.unique(y_all).tolist())
 
         clf = TorchMLPClassifier(
@@ -591,11 +597,17 @@ class TorchMLPIntegratesWithCalibratedClassifierCVTest(unittest.TestCase):
         )
         rng = np.random.RandomState(SEED + 1)  # training-shuffle stream
         train_via_partial_fit(
-            clf, X_train, y_train, classes_list,
-            epochs=EPOCHS, chunk_size=PARTIAL_FIT_BATCH, rng=rng,
+            clf,
+            X_train,
+            y_train,
+            classes_list,
+            epochs=EPOCHS,
+            chunk_size=PARTIAL_FIT_BATCH,
+            rng=rng,
         )
 
         mock_labels = mock.Mock()
+
         def batch_generator(batch_size=100):
             for i in range(0, len(X_train), batch_size):
                 end = min(i + batch_size, len(X_train))
@@ -603,6 +615,7 @@ class TorchMLPIntegratesWithCalibratedClassifierCVTest(unittest.TestCase):
                     [X_train[j] for j in range(i, end)],
                     [y_train[j] for j in range(i, end)],
                 )
+
         mock_labels.load_data_in_batches = batch_generator
 
         trainer = MermaidTrainer(batch_size=100)
@@ -616,19 +629,14 @@ class TorchMLPIntegratesWithCalibratedClassifierCVTest(unittest.TestCase):
         probs = calibrated.predict_proba(X_val)
         preds = calibrated.predict(X_val)
         self.assertEqual(probs.shape, (N_VAL, N_CLASSES))
-        np.testing.assert_allclose(
-            probs.sum(axis=1), np.ones(N_VAL), rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(probs.sum(axis=1), np.ones(N_VAL), rtol=1e-5, atol=1e-5)
         acc = float(np.mean(preds == y_val))
-        self.assertGreater(
-            acc, 0.80,
-            f"Calibrated TorchMLP val accuracy {acc:.3f} below 0.80"
-        )
+        self.assertGreater(acc, 0.80, f"Calibrated TorchMLP val accuracy {acc:.3f} below 0.80")
 
         # Full pickle round-trip of the calibrated artifact — this is
         # exactly what spacer.storage.store_classifier serialises.
         restored = pickle.loads(pickle.dumps(calibrated))
-        np.testing.assert_allclose(
-            restored.predict_proba(X_val), probs, rtol=1e-5, atol=1e-6)
+        np.testing.assert_allclose(restored.predict_proba(X_val), probs, rtol=1e-5, atol=1e-6)
         np.testing.assert_array_equal(restored.predict(X_val), preds)
 
 

--- a/tests/pyspacer/test_pickle_free_training.py
+++ b/tests/pyspacer/test_pickle_free_training.py
@@ -6,6 +6,7 @@ back in. This covers the whole codebase: the train/eval/store path and the
 CLI scripts. (The last pickle consumer, ``scripts/evaluate_model.py``, was
 removed in #61.)
 """
+
 import ast
 import unittest
 from pathlib import Path
@@ -17,8 +18,7 @@ SCANNED_DIRS = (REPO_ROOT / "mermaid_classifier", REPO_ROOT / "scripts")
 # Pickle-glue symbols that must never reach the train/eval/store path,
 # whether imported by name (``from spacer.storage import load_classifier``)
 # or reached as an attribute (``import spacer.storage as s; s.load_classifier``).
-FORBIDDEN = {"load_classifier", "train_classifier", "store_classifier",
-             "TrainClassifierMsg"}
+FORBIDDEN = {"load_classifier", "train_classifier", "store_classifier", "TrainClassifierMsg"}
 
 # Whole modules whose only purpose on this path is the pickle glue. Importing
 # them at all is a re-entry signal, even before any use.
@@ -44,11 +44,10 @@ def _glue_references(source: str) -> set[str]:
             for alias in node.names:
                 if alias.name in FORBIDDEN or alias.name in FORBIDDEN_MODULES:
                     offenders.add(alias.name)
-        elif isinstance(node, ast.Attribute):
+        elif isinstance(node, ast.Attribute) and node.attr in FORBIDDEN:
             # e.g. ``storage.load_classifier`` or
             # ``spacer.storage.store_classifier``.
-            if node.attr in FORBIDDEN:
-                offenders.add(node.attr)
+            offenders.add(node.attr)
     return offenders
 
 
@@ -58,9 +57,11 @@ class PickleFreeTrainingTest(unittest.TestCase):
             for path in base.rglob("*.py"):
                 offenders = _glue_references(path.read_text())
                 self.assertEqual(
-                    offenders, set(),
+                    offenders,
+                    set(),
                     msg=f"{path.relative_to(REPO_ROOT)} must not reference "
-                        f"{offenders} (pickle path)")
+                    f"{offenders} (pickle path)",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/pyspacer/test_portable_artifact.py
+++ b/tests/pyspacer/test_portable_artifact.py
@@ -1,4 +1,5 @@
 """Tests for the portable classifier artifact (model.pt + model.json)."""
+
 import json
 import os
 import subprocess
@@ -41,7 +42,9 @@ class ScaffoldTest(unittest.TestCase):
             "raise SystemExit(1 if mod in sys.modules else 0)\n"
         )
         result = subprocess.run(
-            [sys.executable, "-c", child], capture_output=True, text=True,
+            [sys.executable, "-c", child],
+            capture_output=True,
+            text=True,
         )
         self.assertEqual(result.returncode, 0, msg=result.stderr)
 
@@ -85,6 +88,7 @@ class ExportTest(unittest.TestCase):
             # trained_with must record pyspacer so the serving runtime can verify
             # feature-extraction compatibility.
             from importlib.metadata import version
+
             self.assertEqual(manifest["trained_with"]["pyspacer"], version("pyspacer"))
 
             on_disk = json.loads((Path(d) / "model.json").read_text())
@@ -103,28 +107,28 @@ class ExportTest(unittest.TestCase):
     def test_parity_gate_raises_when_graph_diverges(self):
         model, X = make_calibrated_model()
         # Force the gate to fire with an impossible tolerance: any non-negative max diff > -1.0 always raises.
-        with tempfile.TemporaryDirectory() as d:
-            with self.assertRaises(ParityError):
-                export_artifact(model, d, X, tol=-1.0)
+        with tempfile.TemporaryDirectory() as d, self.assertRaises(ParityError):
+            export_artifact(model, d, X, tol=-1.0)
 
     def test_export_raises_when_sklearn_unpinned(self):
         model, X = make_calibrated_model()
-        with tempfile.TemporaryDirectory() as d:
+        with (
+            tempfile.TemporaryDirectory() as d,
+            mock.patch(
+                "mermaid_classifier.pyspacer.inference.export.PARITY_PROVEN_SKLEARN",
+                "0.0.0-never",
+            ),
+            self.assertRaises(SklearnPinError),
+        ):
             # Patch the proven version to something the runner can't have, so
             # the installed sklearn is guaranteed to differ.
-            with mock.patch(
-                "mermaid_classifier.pyspacer.inference.export"
-                ".PARITY_PROVEN_SKLEARN", "0.0.0-never",
-            ):
-                with self.assertRaises(SklearnPinError):
-                    export_artifact(model, d, X)
+            export_artifact(model, d, X)
 
     def test_export_manifest_records_proven_sklearn(self):
         model, X = make_calibrated_model()
         with tempfile.TemporaryDirectory() as d:
             _, manifest, _ = export_artifact(model, d, X)
-        self.assertEqual(manifest["trained_with"]["sklearn"],
-                         PARITY_PROVEN_SKLEARN)
+        self.assertEqual(manifest["trained_with"]["sklearn"], PARITY_PROVEN_SKLEARN)
 
 
 class LoadValidationTest(unittest.TestCase):
@@ -140,8 +144,7 @@ class LoadValidationTest(unittest.TestCase):
             self.assertEqual(predictor.classes, model.classes_.tolist())
             self.assertEqual(predictor.input_dim, X.shape[1])
             got = predictor.predict_proba(X)
-            self.assertLess(
-                float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
+            self.assertLess(float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
 
     def test_schema_version_mismatch_raises(self):
         with tempfile.TemporaryDirectory() as d:
@@ -172,6 +175,7 @@ class LoadValidationTest(unittest.TestCase):
 
     def test_predictor_exposes_classes_alias_for_metrics(self):
         from mermaid_classifier.pyspacer.inference import load_predictor
+
         with tempfile.TemporaryDirectory() as d:
             model_pt, model_json, model, _X = self._export(d)
             predictor = load_predictor(model_pt, model_json)
@@ -186,16 +190,16 @@ class LiveModelParityTest(unittest.TestCase):
     def _load_live_model(self):
         # spacer.storage pulls heavy S3 machinery only this env-gated test
         # needs, so it stays a function-local import (deferred on purpose).
-        from spacer.storage import storage_factory
-        from spacer.data_classes import DataLocation
-        from urllib.parse import urlparse
         import pickle
+        from urllib.parse import urlparse
+
+        from spacer.data_classes import DataLocation
+        from spacer.storage import storage_factory
 
         loc = os.environ["PORTABLE_ARTIFACT_LIVE_MODEL"]
         uri = urlparse(loc)
         if uri.scheme == "s3":
-            data_loc = DataLocation(
-                "s3", bucket_name=uri.netloc, key=uri.path.strip("/"))
+            data_loc = DataLocation("s3", bucket_name=uri.netloc, key=uri.path.strip("/"))
         else:
             data_loc = DataLocation("filesystem", key=loc)
         storage = storage_factory(data_loc.storage_type, data_loc.bucket_name)
@@ -228,8 +232,7 @@ class LiveModelParityTest(unittest.TestCase):
         X = np.load(feats_path).astype(np.float32)
         if X.ndim != 2 or X.shape[1] != input_dim:
             self.fail(
-                f"real features must be (N, {input_dim}) to match the live"
-                f" model; got {X.shape}."
+                f"real features must be (N, {input_dim}) to match the live model; got {X.shape}."
             )
 
         with tempfile.TemporaryDirectory() as d:
@@ -239,8 +242,7 @@ class LiveModelParityTest(unittest.TestCase):
             self.assertEqual(manifest["classes"], model.classes_.tolist())
             predictor = load_predictor(model_pt, Path(d) / "model.json")
             got = predictor.predict_proba(X)
-        self.assertLess(
-            float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
+        self.assertLess(float(np.max(np.abs(got - model.predict_proba(X)))), 1e-6)
 
 
 if __name__ == "__main__":

--- a/tests/pyspacer/test_sklearn_pin.py
+++ b/tests/pyspacer/test_sklearn_pin.py
@@ -2,6 +2,7 @@
 artifact's parity gate was proven against. A silent sklearn bump can change
 CalibratedClassifierCV / _SigmoidCalibration semantics, so this test fails the
 build until parity is re-proven and the pin + constant are updated together."""
+
 import unittest
 from importlib.metadata import version
 

--- a/tests/pyspacer/test_torch_classifier_normalization.py
+++ b/tests/pyspacer/test_torch_classifier_normalization.py
@@ -9,6 +9,7 @@ and emits its own RuntimeWarning if the pre-renorm drift is larger than
 expected float32 accumulation error, which would indicate a real
 numerical issue (NaN/Inf logits, bypassed softmax) rather than rounding.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -51,13 +52,15 @@ class RowSumRenormalizationTest(unittest.TestCase):
                 max_iter=2,
                 random_state=0,
             ),
-            X, y,
+            X,
+            y,
         )
         probs = clf.predict_proba(X)
         np.testing.assert_allclose(
             probs.sum(axis=1),
             np.ones(len(probs), dtype=np.float64),
-            rtol=0, atol=1e-12,
+            rtol=0,
+            atol=1e-12,
         )
 
 
@@ -75,20 +78,21 @@ class NoSpuriousDriftWarningTest(unittest.TestCase):
                 max_iter=2,
                 random_state=0,
             ),
-            X, y,
+            X,
+            y,
         )
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             clf.predict_proba(X)
         drift_warnings = [
-            w for w in caught
-            if issubclass(w.category, RuntimeWarning)
-            and "row sums deviate" in str(w.message)
+            w
+            for w in caught
+            if issubclass(w.category, RuntimeWarning) and "row sums deviate" in str(w.message)
         ]
         self.assertEqual(
-            drift_warnings, [],
-            f"Unexpected drift warning(s): "
-            f"{[str(w.message) for w in drift_warnings]}",
+            drift_warnings,
+            [],
+            f"Unexpected drift warning(s): {[str(w.message) for w in drift_warnings]}",
         )
 
 
@@ -106,7 +110,8 @@ class AnomalousDriftTriggersWarningTest(unittest.TestCase):
                 max_iter=2,
                 random_state=0,
             ),
-            X, y,
+            X,
+            y,
         )
 
     def test_drifted_rows_trigger_warning_and_still_renormalize(self):
@@ -122,21 +127,22 @@ class AnomalousDriftTriggersWarningTest(unittest.TestCase):
             out = real_softmax(logits, dim=dim)
             return out * 1.5
 
-        target = (
-            "mermaid_classifier.pyspacer.torch_classifier.F.softmax"
-        )
-        with mock.patch(target, side_effect=_broken_softmax):
-            with warnings.catch_warnings(record=True) as caught:
-                warnings.simplefilter("always")
-                probs = clf.predict_proba(X_eval)
+        target = "mermaid_classifier.pyspacer.torch_classifier.F.softmax"
+        with (
+            mock.patch(target, side_effect=_broken_softmax),
+            warnings.catch_warnings(record=True) as caught,
+        ):
+            warnings.simplefilter("always")
+            probs = clf.predict_proba(X_eval)
 
         drift_warnings = [
-            w for w in caught
-            if issubclass(w.category, RuntimeWarning)
-            and "row sums deviate" in str(w.message)
+            w
+            for w in caught
+            if issubclass(w.category, RuntimeWarning) and "row sums deviate" in str(w.message)
         ]
         self.assertEqual(
-            len(drift_warnings), 1,
+            len(drift_warnings),
+            1,
             f"Expected exactly one drift warning, got {len(drift_warnings)}. "
             f"All warnings: {[str(w.message) for w in caught]}",
         )
@@ -146,7 +152,8 @@ class AnomalousDriftTriggersWarningTest(unittest.TestCase):
         np.testing.assert_allclose(
             probs.sum(axis=1),
             np.ones(len(probs), dtype=np.float64),
-            rtol=0, atol=1e-12,
+            rtol=0,
+            atol=1e-12,
         )
 
 

--- a/tests/pyspacer/test_train.py
+++ b/tests/pyspacer/test_train.py
@@ -1,10 +1,10 @@
-from contextlib import contextmanager
 import importlib
-from io import StringIO
 import sys
 import tempfile
-from types import SimpleNamespace
 import unittest
+from contextlib import contextmanager
+from io import StringIO
+from types import SimpleNamespace
 from unittest import mock
 
 import pandas as pd
@@ -12,8 +12,7 @@ from spacer.data_classes import DataLocation, ImageLabels
 
 from mermaid_classifier.common.benthic_attributes import CoralNetMermaidMapping
 from mermaid_classifier.pyspacer.settings import settings
-from mermaid_classifier.pyspacer.train import (
-    Artifacts, CNSourceFilter, Sites, TrainingDataset)
+from mermaid_classifier.pyspacer.train import Artifacts, CNSourceFilter, Sites, TrainingDataset
 
 
 class SettingsOverride:
@@ -30,6 +29,7 @@ class SettingsOverride:
     Some parts are from
     https://rednafi.com/python/patch-pydantic-settings-in-pytest/
     """
+
     def __init__(self, **kwargs):
         self.options = kwargs
         super().__init__()
@@ -68,17 +68,17 @@ class NoInitDataset(TrainingDataset):
     just want access to the other methods of the class.
     So here we make init barebones.
     """
+
     def __init__(self):
         self._duck_conn = None
         self.artifacts = Artifacts()
         self._feature_temp_dir = None
-        self._feature_dir = '/tmp/mermaid_features_test'
+        self._feature_dir = "/tmp/mermaid_features_test"
 
 
 class BaseTrainTest(unittest.TestCase):
-
     def setUp(self):
-        self.override = SettingsOverride(aws_anonymous='True')
+        self.override = SettingsOverride(aws_anonymous="True")
         self.override.enable()
         super().setUp()
 
@@ -92,13 +92,15 @@ def same_char_uuid(char: str):
     If you pass in '0', you get '00000000-0000-0000-0000-000000000000'.
     Passing in 0-9 or a-f should result in a valid uuid4 string.
     """
-    return '-'.join([
-        ''.join([char]*8),
-        ''.join([char]*4),
-        ''.join([char]*4),
-        ''.join([char]*4),
-        ''.join([char]*12),
-    ])
+    return "-".join(
+        [
+            "".join([char] * 8),
+            "".join([char] * 4),
+            "".join([char] * 4),
+            "".join([char] * 4),
+            "".join([char] * 12),
+        ]
+    )
 
 
 class ReadCoralNetDataTest(BaseTrainTest):
@@ -121,47 +123,43 @@ class ReadCoralNetDataTest(BaseTrainTest):
         dataset = NoInitDataset()
 
         source_id = 23
-        dataset.cn_source_filter = CNSourceFilter(StringIO(
-            'id\n'
-            f'{source_id}\n'
-        ))
+        dataset.cn_source_filter = CNSourceFilter(StringIO(f"id\n{source_id}\n"))
 
         # CoralNet annotations are read in as CSV.
         cn_annotations_csv_content = (
-            'Image ID,Row,Column,Label ID\n'
-            '12345,2000,1200,123\n'
-            '67890,1500,2800,456\n'
+            "Image ID,Row,Column,Label ID\n12345,2000,1200,123\n67890,1500,2800,456\n"
         )
 
         # Mock CN-MM mapping to use.
         mapping = [
-            dict(
-                benthic_attribute_id=same_char_uuid('0'),
-                growth_form_id=same_char_uuid('1'),
-                benthic_attribute_name='BA1',
-                growth_form_name='GF1',
-                provider_id='123',
-                provider_label='Label123',
-            ),
-            dict(
-                benthic_attribute_id=same_char_uuid('2'),
+            {
+                "benthic_attribute_id": same_char_uuid("0"),
+                "growth_form_id": same_char_uuid("1"),
+                "benthic_attribute_name": "BA1",
+                "growth_form_name": "GF1",
+                "provider_id": "123",
+                "provider_label": "Label123",
+            },
+            {
+                "benthic_attribute_id": same_char_uuid("2"),
                 # We expect the API's mapping to have null/None
                 # for blank growth forms.
-                growth_form_id=None,
-                benthic_attribute_name='BA2',
-                growth_form_name=None,
-                provider_id='456',
-                provider_label='Label456',
-            ),
+                "growth_form_id": None,
+                "benthic_attribute_name": "BA2",
+                "growth_form_name": None,
+                "provider_id": "456",
+                "provider_label": "Label456",
+            },
         ]
 
-        prefix_pattern = 's{source_id}_'
+        prefix_pattern = "s{source_id}_"
         prefix = prefix_pattern.format(source_id=source_id)
 
         with tempfile.NamedTemporaryFile(
-            prefix=prefix, mode='w', delete_on_close=False,
+            prefix=prefix,
+            mode="w",
+            delete_on_close=False,
         ) as csv_f:
-
             csv_f.write(cn_annotations_csv_content)
             csv_f.close()
 
@@ -170,14 +168,15 @@ class ReadCoralNetDataTest(BaseTrainTest):
                     coralnet_annotations_csv_pattern=csv_f.name,
                 ),
                 mock.patch.object(
-                    CoralNetMermaidMapping, '_download_mapping',
+                    CoralNetMermaidMapping,
+                    "_download_mapping",
                 ) as mock_download_mapping,
                 # read_coralnet_data uses S3FileSystem.exists to skip
                 # sources whose annotations.csv isn't in S3. The test
                 # serves its CSV from a local tempfile, so short-circuit
                 # that check.
                 mock.patch(
-                    'mermaid_classifier.pyspacer.train.S3FileSystem',
+                    "mermaid_classifier.pyspacer.train.S3FileSystem",
                 ) as mock_s3fs_cls,
             ):
                 mock_download_mapping.return_value = mapping
@@ -186,20 +185,18 @@ class ReadCoralNetDataTest(BaseTrainTest):
                 dataset.read_coralnet_data()
 
         result_tuples = dataset.duck_conn.execute(
-            "SELECT image_id, row, col, benthic_attribute_id, growth_form_id"
-            " FROM annotations").fetchall()
+            "SELECT image_id, row, col, benthic_attribute_id, growth_form_id FROM annotations"
+        ).fetchall()
         result_tuples.sort()
 
         self.assertListEqual(
             list(result_tuples[0]),
-            ['12345', 2000, 1200,
-             same_char_uuid('0'), same_char_uuid('1')],
+            ["12345", 2000, 1200, same_char_uuid("0"), same_char_uuid("1")],
         )
         # Empty GF should show as ''.
         self.assertListEqual(
             list(result_tuples[1]),
-            ['67890', 1500, 2800,
-             same_char_uuid('2'), ''],
+            ["67890", 1500, 2800, same_char_uuid("2"), ""],
         )
 
 
@@ -222,47 +219,44 @@ class ReadMermaidDataTest(BaseTrainTest):
         # Write a couple of coralnet annotations to DuckDB.
         # One with growth form, one without (this is represented as the
         # empty string '').
-        cn_annotations_df = pd.DataFrame(dict(
-            site=['coralnet']*2,
-            bucket=['cn-data']*2,
-            project_id=['12', '34'],
-            image_id=['12345', '67890'],
-            feature_vector=['s12/i12345.fv', 's34/i67890.fv'],
-            row=[2000, 1500],
-            col=[1200, 2800],
-            label_id=['123', '456'],
-            benthic_attribute_id=[same_char_uuid('0'), same_char_uuid('1')],
-            growth_form_id=[same_char_uuid('2'), ''],
-        ))
-
-        dataset.duck_conn.execute(
-            f"CREATE TABLE annotations AS SELECT * FROM cn_annotations_df"
+        cn_annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": ["coralnet"] * 2,
+                "bucket": ["cn-data"] * 2,
+                "project_id": ["12", "34"],
+                "image_id": ["12345", "67890"],
+                "feature_vector": ["s12/i12345.fv", "s34/i67890.fv"],
+                "row": [2000, 1500],
+                "col": [1200, 2800],
+                "label_id": ["123", "456"],
+                "benthic_attribute_id": [same_char_uuid("0"), same_char_uuid("1")],
+                "growth_form_id": [same_char_uuid("2"), ""],
+            }
         )
 
-        with tempfile.NamedTemporaryFile(delete_on_close=False) as parquet_f:
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM cn_annotations_df")
 
+        with tempfile.NamedTemporaryFile(delete_on_close=False) as parquet_f:
             # Write a couple of mermaid annotations to a parquet file.
             # One with growth form, one without (this is represented in
             # mermaid parquet as string 'None').
-            mermaid_parquet_df = pd.DataFrame(dict(
-                image_id=[same_char_uuid('3'), same_char_uuid('4')],
-                row=[3000, 500],
-                col=[2200, 1800],
-                benthic_attribute_id=[
-                    same_char_uuid('5'), same_char_uuid('6')],
-                growth_form_id=[same_char_uuid('7'), 'None'],
-            ))
+            mermaid_parquet_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+                {
+                    "image_id": [same_char_uuid("3"), same_char_uuid("4")],
+                    "row": [3000, 500],
+                    "col": [2200, 1800],
+                    "benthic_attribute_id": [same_char_uuid("5"), same_char_uuid("6")],
+                    "growth_form_id": [same_char_uuid("7"), "None"],
+                }
+            )
             dataset.duck_conn.execute(
-                f"CREATE TABLE mermaid_parquet_input AS"
-                f" SELECT * FROM mermaid_parquet_df"
+                "CREATE TABLE mermaid_parquet_input AS SELECT * FROM mermaid_parquet_df"
             )
 
             # DuckDB will reopen the file, so close it first.
             parquet_f.close()
             dataset.duck_conn.execute(
-                f"COPY (SELECT * FROM mermaid_parquet_input)"
-                f" TO '{parquet_f.name}'"
-                f" (FORMAT parquet)"
+                f"COPY (SELECT * FROM mermaid_parquet_input) TO '{parquet_f.name}' (FORMAT parquet)"
             )
 
             with override_settings(
@@ -271,98 +265,93 @@ class ReadMermaidDataTest(BaseTrainTest):
                 dataset.read_mermaid_data()
 
         result_tuples = dataset.duck_conn.execute(
-            "SELECT image_id, row, col, benthic_attribute_id, growth_form_id"
-            " FROM annotations").fetchall()
+            "SELECT image_id, row, col, benthic_attribute_id, growth_form_id FROM annotations"
+        ).fetchall()
         # We don't really care about the result order. So we'll alphabetize
         # the results to make it easier to assert on them.
         result_tuples.sort()
 
         self.assertListEqual(
             list(result_tuples[0]),
-            ['12345', 2000, 1200,
-             same_char_uuid('0'), same_char_uuid('2')],
+            ["12345", 2000, 1200, same_char_uuid("0"), same_char_uuid("2")],
         )
         self.assertListEqual(
             list(result_tuples[1]),
-            [same_char_uuid('3'), 3000, 2200,
-             same_char_uuid('5'), same_char_uuid('7')],
+            [same_char_uuid("3"), 3000, 2200, same_char_uuid("5"), same_char_uuid("7")],
         )
         # mermaid 'None' growth form should have become ''.
         self.assertListEqual(
             list(result_tuples[2]),
-            [same_char_uuid('4'), 500, 1800,
-             same_char_uuid('6'), ''],
+            [same_char_uuid("4"), 500, 1800, same_char_uuid("6"), ""],
         )
         # coralnet row with '' growth form should not be accidentally
         # dropped.
         self.assertListEqual(
             list(result_tuples[3]),
-            ['67890', 1500, 2800,
-             same_char_uuid('1'), ''],
+            ["67890", 1500, 2800, same_char_uuid("1"), ""],
         )
 
 
 class HandleMissingFeatureVectorsTest(BaseTrainTest):
-
     @staticmethod
     def annotations_fvs(dataset):
         result_tuples = dataset.duck_conn.execute(
-            "SELECT feature_vector FROM annotations").fetchall()
-        feature_vector_files = [
-            tup[0] for tup in result_tuples]
+            "SELECT feature_vector FROM annotations"
+        ).fetchall()
+        feature_vector_files = [tup[0] for tup in result_tuples]
         return sorted(feature_vector_files)
 
     def test_none_missing(self):
-        annotations_df = pd.DataFrame({
-            'site': [Sites.MERMAID.value]*4,
-            'bucket': ['my-bucket']*4,
-            'feature_vector': ['01.fv', '01.fv', '02.fv', '02.fv'],
-        })
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": [Sites.MERMAID.value] * 4,
+                "bucket": ["my-bucket"] * 4,
+                "feature_vector": ["01.fv", "01.fv", "02.fv", "02.fv"],
+            }
+        )
         s3_paths = {
-            'my-bucket/01.fv',
-            'my-bucket/02.fv',
+            "my-bucket/01.fv",
+            "my-bucket/02.fv",
         }
 
         dataset = NoInitDataset()
-        dataset.duck_conn.execute(
-            "CREATE TABLE annotations AS SELECT * FROM annotations_df"
-        )
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
         # Since there shouldn't be any missing feature vectors, it
         # shouldn't log any warnings.
-        with self.assertNoLogs(logger='train', level='WARN'):
+        with self.assertNoLogs(logger="train", level="WARN"):
             dataset.handle_missing_feature_vectors(s3_paths)
 
         self.assertListEqual(
             self.annotations_fvs(dataset),
-            ['01.fv', '01.fv', '02.fv', '02.fv'],
+            ["01.fv", "01.fv", "02.fv", "02.fv"],
             msg="No annotations should have been filtered out",
         )
 
     def test_one_missing(self):
-        annotations_df = pd.DataFrame({
-            'site': [Sites.MERMAID.value]*4,
-            'bucket': ['my-bucket']*4,
-            'feature_vector': ['01.fv', '01.fv', '02.fv', '02.fv'],
-        })
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": [Sites.MERMAID.value] * 4,
+                "bucket": ["my-bucket"] * 4,
+                "feature_vector": ["01.fv", "01.fv", "02.fv", "02.fv"],
+            }
+        )
         # S3 doesn't have 02.
         s3_paths = {
-            'my-bucket/01.fv',
-            'my-bucket/05.fv',
+            "my-bucket/01.fv",
+            "my-bucket/05.fv",
         }
 
         dataset = NoInitDataset()
-        dataset.duck_conn.execute(
-            "CREATE TABLE annotations AS SELECT * FROM annotations_df"
-        )
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
         with (
-            self.assertLogs(logger='train', level='WARN') as warn_cm,
+            self.assertLogs(logger="train", level="WARN") as warn_cm,
             override_settings(training_inputs_percent_missing_allowed=50),
         ):
             dataset.handle_missing_feature_vectors(s3_paths)
 
         self.assertListEqual(
             self.annotations_fvs(dataset),
-            ['01.fv', '01.fv'],
+            ["01.fv", "01.fv"],
             msg="02.fv should have been filtered out",
         )
 
@@ -370,34 +359,34 @@ class HandleMissingFeatureVectorsTest(BaseTrainTest):
             warn_cm.output[0],
             "WARNING:train:Skipping 1 feature vector(s) because the files"
             " aren't in S3. Example(s):"
-            "\nmy-bucket/02.fv"
+            "\nmy-bucket/02.fv",
         )
 
     def test_over_three_missing(self):
-        annotations_df = pd.DataFrame({
-            'site': [Sites.MERMAID.value]*5,
-            'bucket': ['my-bucket']*5,
-            'feature_vector': ['01.fv', '02.fv', '03.fv', '04.fv', '05.fv'],
-        })
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": [Sites.MERMAID.value] * 5,
+                "bucket": ["my-bucket"] * 5,
+                "feature_vector": ["01.fv", "02.fv", "03.fv", "04.fv", "05.fv"],
+            }
+        )
         # S3 doesn't have 01, 02, 04, 05.
         s3_paths = {
-            'my-bucket/03.fv',
-            'my-bucket/07.fv',
+            "my-bucket/03.fv",
+            "my-bucket/07.fv",
         }
 
         dataset = NoInitDataset()
-        dataset.duck_conn.execute(
-            "CREATE TABLE annotations AS SELECT * FROM annotations_df"
-        )
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
         with (
-            self.assertLogs(logger='train', level='WARN') as warn_cm,
+            self.assertLogs(logger="train", level="WARN") as warn_cm,
             override_settings(training_inputs_percent_missing_allowed=90),
         ):
             dataset.handle_missing_feature_vectors(s3_paths)
 
         self.assertListEqual(
             self.annotations_fvs(dataset),
-            ['03.fv'],
+            ["03.fv"],
             msg="All but 03.fv should have been filtered out",
         )
 
@@ -408,39 +397,41 @@ class HandleMissingFeatureVectorsTest(BaseTrainTest):
             " aren't in S3. Example(s):",
             message,
         )
-        example_count = sum([
-            1 if feature_path in message else 0
-            for feature_path in [
-                'my-bucket/01.fv',
-                'my-bucket/02.fv',
-                'my-bucket/04.fv',
-                'my-bucket/05.fv',
+        example_count = sum(
+            [
+                1 if feature_path in message else 0
+                for feature_path in [
+                    "my-bucket/01.fv",
+                    "my-bucket/02.fv",
+                    "my-bucket/04.fv",
+                    "my-bucket/05.fv",
+                ]
             ]
-        ])
+        )
         self.assertEqual(example_count, 3)
 
     def test_over_threshold_missing(self):
-        annotations_df = pd.DataFrame({
-            'site': [Sites.MERMAID.value]*5,
-            'bucket': ['my-bucket']*5,
-            'feature_vector': ['01.fv', '02.fv', '03.fv', '04.fv', '05.fv'],
-        })
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": [Sites.MERMAID.value] * 5,
+                "bucket": ["my-bucket"] * 5,
+                "feature_vector": ["01.fv", "02.fv", "03.fv", "04.fv", "05.fv"],
+            }
+        )
         # S3 doesn't have 01, 05 (40% missing).
         # We'll add more extras here to demonstrate that the threshold is
         # out of features in annotations, not features in S3.
         s3_paths = {
-            'my-bucket/02.fv',
-            'my-bucket/03.fv',
-            'my-bucket/04.fv',
-            'my-bucket/12.fv',
-            'my-bucket/13.fv',
-            'my-bucket/14.fv',
+            "my-bucket/02.fv",
+            "my-bucket/03.fv",
+            "my-bucket/04.fv",
+            "my-bucket/12.fv",
+            "my-bucket/13.fv",
+            "my-bucket/14.fv",
         }
 
         dataset = NoInitDataset()
-        dataset.duck_conn.execute(
-            "CREATE TABLE annotations AS SELECT * FROM annotations_df"
-        )
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
         with (
             self.assertRaises(RuntimeError) as error_cm,
             override_settings(training_inputs_percent_missing_allowed=39),
@@ -448,13 +439,10 @@ class HandleMissingFeatureVectorsTest(BaseTrainTest):
             dataset.handle_missing_feature_vectors(s3_paths)
 
         message = str(error_cm.exception)
-        self.assertIn(
-            "Too many feature vectors are missing (2), such as:", message)
-        self.assertIn('my-bucket/01.fv', message)
-        self.assertIn('my-bucket/05.fv', message)
-        self.assertIn(
-            "You can configure the tolerance for missing feature vectors",
-            message)
+        self.assertIn("Too many feature vectors are missing (2), such as:", message)
+        self.assertIn("my-bucket/01.fv", message)
+        self.assertIn("my-bucket/05.fv", message)
+        self.assertIn("You can configure the tolerance for missing feature vectors", message)
 
 
 class LazyLibraryTest(BaseTrainTest):
@@ -465,15 +453,14 @@ class LazyLibraryTest(BaseTrainTest):
     """
 
     def test_importing_train_does_not_call_the_mermaid_api(self):
-        module_name = 'mermaid_classifier.pyspacer.train'
+        module_name = "mermaid_classifier.pyspacer.train"
 
         def fail(*args, **kwargs):
-            raise AssertionError(
-                "Importing train made a network call to the MERMAID API")
+            raise AssertionError("Importing train made a network call to the MERMAID API")
 
         original_module = sys.modules.get(module_name)
         try:
-            with mock.patch('urllib.request.urlopen', side_effect=fail):
+            with mock.patch("urllib.request.urlopen", side_effect=fail):
                 # Force a fresh import so the module body re-executes.
                 sys.modules.pop(module_name, None)
                 importlib.import_module(module_name)
@@ -501,41 +488,47 @@ class AddTrainingSetNamesTest(BaseTrainTest):
         Otherwise the join matches nothing, every annotation gets a NULL
         training_set, and the stats artifacts wrongly report 100% dropped.
         """
-        annotations_df = pd.DataFrame({
-            'bucket': ['bucketA', 'bucketA', 'bucketB'],
-            'feature_vector': [
-                'cn/img1.featurevector',
-                'cn/img1.featurevector',
-                'mermaid/img2.featurevector',
-            ],
-            'row': [10, 30, 50],
-            'col': [20, 40, 60],
-        })
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "bucket": ["bucketA", "bucketA", "bucketB"],
+                "feature_vector": [
+                    "cn/img1.featurevector",
+                    "cn/img1.featurevector",
+                    "mermaid/img2.featurevector",
+                ],
+                "row": [10, 30, 50],
+                "col": [20, 40, 60],
+            }
+        )
 
         dataset = NoInitDataset()
-        dataset.duck_conn.execute(
-            "CREATE TABLE annotations AS SELECT * FROM annotations_df"
-        )
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
 
         # The labels carry filesystem DataLocations keyed by local download
         # paths, alongside a mapping back to the original (bucket, key).
-        loc1_path = '/tmp/feat/bucketA/cn/img1.featurevector'
-        loc2_path = '/tmp/feat/bucketB/mermaid/img2.featurevector'
+        loc1_path = "/tmp/feat/bucketA/cn/img1.featurevector"
+        loc2_path = "/tmp/feat/bucketB/mermaid/img2.featurevector"
         dataset._feature_path_to_s3_location = {
-            loc1_path: ('bucketA', 'cn/img1.featurevector'),
-            loc2_path: ('bucketB', 'mermaid/img2.featurevector'),
+            loc1_path: ("bucketA", "cn/img1.featurevector"),
+            loc2_path: ("bucketB", "mermaid/img2.featurevector"),
         }
 
         dataset.labels = SimpleNamespace(
-            train=ImageLabels({
-                DataLocation('filesystem', loc1_path): [(10, 20, 'BA1')],
-            }),
-            ref=ImageLabels({
-                DataLocation('filesystem', loc1_path): [(30, 40, 'BA1')],
-            }),
-            val=ImageLabels({
-                DataLocation('filesystem', loc2_path): [(50, 60, 'BA2')],
-            }),
+            train=ImageLabels(
+                {
+                    DataLocation("filesystem", loc1_path): [(10, 20, "BA1")],
+                }
+            ),
+            ref=ImageLabels(
+                {
+                    DataLocation("filesystem", loc1_path): [(30, 40, "BA1")],
+                }
+            ),
+            val=ImageLabels(
+                {
+                    DataLocation("filesystem", loc2_path): [(50, 60, "BA2")],
+                }
+            ),
         )
 
         dataset.add_training_set_names()
@@ -548,9 +541,9 @@ class AddTrainingSetNamesTest(BaseTrainTest):
         self.assertListEqual(
             result,
             [
-                ('bucketA', 'cn/img1.featurevector', 10, 20, 'train'),
-                ('bucketA', 'cn/img1.featurevector', 30, 40, 'ref'),
-                ('bucketB', 'mermaid/img2.featurevector', 50, 60, 'val'),
+                ("bucketA", "cn/img1.featurevector", 10, 20, "train"),
+                ("bucketA", "cn/img1.featurevector", 30, 40, "ref"),
+                ("bucketB", "mermaid/img2.featurevector", 50, 60, "val"),
             ],
             msg="Each annotation should be matched to its train/ref/val set",
         )
@@ -558,5 +551,4 @@ class AddTrainingSetNamesTest(BaseTrainTest):
         dropped = dataset.duck_conn.execute(
             "SELECT count(*) FROM annotations WHERE training_set IS NULL"
         ).fetchone()[0]
-        self.assertEqual(
-            dropped, 0, msg="No annotation should be reported as dropped")
+        self.assertEqual(dropped, 0, msg="No annotation should be reported as dropped")

--- a/tests/pyspacer/test_trainer.py
+++ b/tests/pyspacer/test_trainer.py
@@ -62,13 +62,15 @@ class CalibrateInBatchesTest(unittest.TestCase):
         n_samples = 500
         n_features = 50
         n_per_class = n_samples // n_classes
-        classes = [f'class_{i}' for i in range(n_classes)]
+        classes = [f"class_{i}" for i in range(n_classes)]
 
         centroids = rng.randn(n_classes, n_features).astype(np.float32) * 3.0
-        X = np.vstack([
-            centroids[i] + rng.randn(n_per_class, n_features).astype(np.float32)
-            for i in range(n_classes)
-        ])
+        X = np.vstack(
+            [
+                centroids[i] + rng.randn(n_per_class, n_features).astype(np.float32)
+                for i in range(n_classes)
+            ]
+        )
         y = np.array([cls for cls in classes for _ in range(n_per_class)])
 
         # Shuffle so train/ref split isn't class-stratified by half.
@@ -85,9 +87,7 @@ class CalibrateInBatchesTest(unittest.TestCase):
         # so the trained weights — and the cross-BLAS FP drift they produce —
         # vary every run, making the calibration-equivalence comparison flaky
         # on Linux CI.
-        clf = MLPClassifier(
-            hidden_layer_sizes=(20,), learning_rate_init=1e-3,
-            random_state=0)
+        clf = MLPClassifier(hidden_layer_sizes=(20,), learning_rate_init=1e-3, random_state=0)
         clf.partial_fit(X_train, y_train, classes=classes)
 
         # Standard calibration (current approach)
@@ -127,16 +127,23 @@ class CalibrateInBatchesTest(unittest.TestCase):
         for cc_std, cc_batch in zip(
             clf_std.calibrated_classifiers_,
             clf_batched.calibrated_classifiers_,
+            strict=False,
         ):
-            for cal_std, cal_batch in zip(
-                cc_std.calibrators, cc_batch.calibrators
-            ):
+            for cal_std, cal_batch in zip(cc_std.calibrators, cc_batch.calibrators, strict=False):
                 np.testing.assert_allclose(
-                    cal_std.a_, cal_batch.a_, rtol=1e-3, atol=5e-3,
-                    err_msg="Sigmoid parameter 'a' differs")
+                    cal_std.a_,
+                    cal_batch.a_,
+                    rtol=1e-3,
+                    atol=5e-3,
+                    err_msg="Sigmoid parameter 'a' differs",
+                )
                 np.testing.assert_allclose(
-                    cal_std.b_, cal_batch.b_, rtol=1e-3, atol=5e-3,
-                    err_msg="Sigmoid parameter 'b' differs")
+                    cal_std.b_,
+                    cal_batch.b_,
+                    rtol=1e-3,
+                    atol=5e-3,
+                    err_msg="Sigmoid parameter 'b' differs",
+                )
 
         # Compare predict_proba outputs — the actual API surface.
         # Even if sigmoid params differ at the solver-tolerance level,
@@ -152,15 +159,15 @@ class CalibrateInBatchesTest(unittest.TestCase):
         proba_std = clf_std.predict_proba(X_test)
         proba_batch = clf_batched.predict_proba(X_test)
         np.testing.assert_allclose(
-            proba_std, proba_batch, rtol=3e-3, atol=2e-4,
-            err_msg="predict_proba outputs differ")
+            proba_std, proba_batch, rtol=3e-3, atol=2e-4, err_msg="predict_proba outputs differ"
+        )
 
         # Verify PySpacer compatibility attributes
         self.assertIsInstance(clf_batched, CalibratedClassifierCV)
-        self.assertEqual(clf_batched.cv, 'prefit')
-        self.assertTrue(hasattr(clf_batched, 'calibrated_classifiers_'))
-        self.assertTrue(hasattr(clf_batched, 'classes_'))
-        self.assertTrue(hasattr(clf_batched, 'estimator'))
+        self.assertEqual(clf_batched.cv, "prefit")
+        self.assertTrue(hasattr(clf_batched, "calibrated_classifiers_"))
+        self.assertTrue(hasattr(clf_batched, "classes_"))
+        self.assertTrue(hasattr(clf_batched, "estimator"))
 
 
 class EarlyStoppingConstructorTest(unittest.TestCase):
@@ -207,7 +214,7 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
         """
         rng = np.random.RandomState(seed)
         n_features = 16
-        classes = ['c0', 'c1', 'c2']
+        classes = ["c0", "c1", "c2"]
 
         def _make_split(n):
             X = rng.randn(n, n_features).astype(np.float32)
@@ -231,6 +238,7 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
                     x_batch = [X[j] for j in range(i, end)]
                     y_batch = list(y[i:end])
                     yield x_batch, y_batch
+
             obj.load_data_in_batches = gen
             return obj
 
@@ -259,12 +267,11 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
                 super().__init__(*a, **kw)
                 self_._scripted_remaining = list(schedule)
 
-            def _calc_acc_and_log_loss_batched(
-                self_, clf, labels, classes_list):
+            def _calc_acc_and_log_loss_batched(self_, clf, labels, classes_list):
                 if not self_._scripted_remaining:
                     raise AssertionError(
-                        "val_loss schedule exhausted; trainer ran for"
-                        " more epochs than expected")
+                        "val_loss schedule exhausted; trainer ran for more epochs than expected"
+                    )
                 loss = self_._scripted_remaining.pop(0)
                 return 0.5, float(loss)
 
@@ -288,12 +295,12 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
         trainer, captured = self._run(schedule, patience=None, n_epochs=5)
         self.assertEqual(len(captured), 5)
         info = trainer._early_stop_info
-        self.assertFalse(info['enabled'])
-        self.assertEqual(info['stop_reason'], 'budget_exhausted')
-        self.assertEqual(info['final_epoch'], 5)
+        self.assertFalse(info["enabled"])
+        self.assertEqual(info["stop_reason"], "budget_exhausted")
+        self.assertEqual(info["final_epoch"], 5)
         # When ES is off, no snapshot is kept.
-        self.assertIsNone(info['best_val_epoch'])
-        self.assertIsNone(info['best_val_loss'])
+        self.assertIsNone(info["best_val_epoch"])
+        self.assertIsNone(info["best_val_loss"])
 
     def test_monotone_down_no_stop(self):
         """patience=2 + always-improving val_loss: no early stop."""
@@ -301,12 +308,12 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
         trainer, captured = self._run(schedule, patience=2, n_epochs=5)
         self.assertEqual(len(captured), 5)
         info = trainer._early_stop_info
-        self.assertTrue(info['enabled'])
-        self.assertEqual(info['stop_reason'], 'budget_exhausted')
-        self.assertEqual(info['final_epoch'], 5)
+        self.assertTrue(info["enabled"])
+        self.assertEqual(info["stop_reason"], "budget_exhausted")
+        self.assertEqual(info["final_epoch"], 5)
         # Best is the last epoch (5).
-        self.assertEqual(info['best_val_epoch'], 5)
-        self.assertAlmostEqual(info['best_val_loss'], 0.6)
+        self.assertEqual(info["best_val_epoch"], 5)
+        self.assertAlmostEqual(info["best_val_loss"], 0.6)
 
     def test_v_shape_triggers_after_patience(self):
         """val_loss minimum at epoch 3, then rises for patience+ epochs.
@@ -316,27 +323,27 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
         schedule = [1.0, 0.9, 0.8, 0.85, 0.9, 1.0, 1.1]  # extras unused
         trainer, captured = self._run(schedule, patience=2, n_epochs=10)
         info = trainer._early_stop_info
-        self.assertTrue(info['enabled'])
-        self.assertEqual(info['stop_reason'], 'early_stopping')
+        self.assertTrue(info["enabled"])
+        self.assertEqual(info["stop_reason"], "early_stopping")
         # Trained 5 epochs total: 3 to best + 2 patience = stop @ epoch 5.
-        self.assertEqual(info['final_epoch'], 5)
-        self.assertEqual(info['best_val_epoch'], 3)
-        self.assertAlmostEqual(info['best_val_loss'], 0.8)
+        self.assertEqual(info["final_epoch"], 5)
+        self.assertEqual(info["best_val_epoch"], 3)
+        self.assertAlmostEqual(info["best_val_loss"], 0.8)
         # Five callback events fired (one per epoch run).
         self.assertEqual(len(captured), 5)
         # Final-epoch callback carries the summary fields.
-        self.assertTrue(captured[-1]['early_stopped'])
-        self.assertEqual(captured[-1]['final_epoch'], 5)
-        self.assertEqual(captured[-1]['best_val_epoch'], 3)
+        self.assertTrue(captured[-1]["early_stopped"])
+        self.assertEqual(captured[-1]["final_epoch"], 5)
+        self.assertEqual(captured[-1]["best_val_epoch"], 3)
 
     def test_patience_one_immediate_stop_on_first_regression(self):
         """patience=1: stops the very first epoch val_loss doesn't improve."""
         schedule = [1.0, 0.5, 0.6]  # best=ep2, regress at ep3 -> stop
         trainer, captured = self._run(schedule, patience=1, n_epochs=10)
         info = trainer._early_stop_info
-        self.assertEqual(info['stop_reason'], 'early_stopping')
-        self.assertEqual(info['final_epoch'], 3)
-        self.assertEqual(info['best_val_epoch'], 2)
+        self.assertEqual(info["stop_reason"], "early_stopping")
+        self.assertEqual(info["final_epoch"], 3)
+        self.assertEqual(info["best_val_epoch"], 2)
 
     def test_summary_only_on_final_epoch(self):
         """early_stopped/best_val_epoch fields only on the last epoch."""
@@ -344,13 +351,13 @@ class EarlyStoppingBehaviorTest(unittest.TestCase):
         trainer, captured = self._run(schedule, patience=2, n_epochs=10)
         # Non-final epochs MUST NOT have the summary fields.
         for cb in captured[:-1]:
-            self.assertNotIn('early_stopped', cb)
-            self.assertNotIn('final_epoch', cb)
+            self.assertNotIn("early_stopped", cb)
+            self.assertNotIn("final_epoch", cb)
         # Final epoch DOES have them.
-        self.assertIn('early_stopped', captured[-1])
-        self.assertIn('final_epoch', captured[-1])
-        self.assertIn('best_val_epoch', captured[-1])
-        self.assertIn('best_val_loss', captured[-1])
+        self.assertIn("early_stopped", captured[-1])
+        self.assertIn("final_epoch", captured[-1])
+        self.assertIn("best_val_epoch", captured[-1])
+        self.assertIn("best_val_loss", captured[-1])
 
 
 class TrainerCleanupGuardTest(unittest.TestCase):
@@ -361,10 +368,8 @@ class TrainerCleanupGuardTest(unittest.TestCase):
         self.source = Path(trainer_module.__file__).read_text()
 
     def test_no_sgd_or_clf_type_references(self):
-        for token in ('SGDClassifier', 'clf_type'):
-            self.assertNotIn(
-                token, self.source,
-                f"{token} should not reappear in trainer.py")
+        for token in ("SGDClassifier", "clf_type"):
+            self.assertNotIn(token, self.source, f"{token} should not reappear in trainer.py")
 
     def test_no_dead_pyspacer_imports(self):
         # Walk the actual import nodes (not substrings) so equivalent
@@ -375,25 +380,24 @@ class TrainerCleanupGuardTest(unittest.TestCase):
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     # `import spacer.config[.x]` in any aliased form
-                    if (alias.name == 'spacer.config'
-                            or alias.name.startswith('spacer.config.')):
+                    if alias.name == "spacer.config" or alias.name.startswith("spacer.config."):
                         offenders.append(f"import {alias.name}")
             elif isinstance(node, ast.ImportFrom):
-                module = node.module or ''
+                module = node.module or ""
                 names = {alias.name for alias in node.names}
                 # `from spacer import config`
-                if module == 'spacer' and 'config' in names:
+                if module == "spacer" and "config" in names:
                     offenders.append("from spacer import config")
                 # `from spacer.config[.x] import ...`
-                if (module == 'spacer.config'
-                        or module.startswith('spacer.config.')):
+                if module == "spacer.config" or module.startswith("spacer.config."):
                     offenders.append(f"from {module} import ...")
                 # `from spacer.train_utils import calc_acc`
-                if module == 'spacer.train_utils' and 'calc_acc' in names:
-                    offenders.append(
-                        "from spacer.train_utils import calc_acc")
+                if module == "spacer.train_utils" and "calc_acc" in names:
+                    offenders.append("from spacer.train_utils import calc_acc")
         self.assertEqual(
-            offenders, [],
+            offenders,
+            [],
             "trainer.py should not re-import spacer.config or the dead"
             f" calc_acc helper (use sklearn.metrics.accuracy_score); found:"
-            f" {offenders}")
+            f" {offenders}",
+        )

--- a/tests/sagemaker_launcher/test_config.py
+++ b/tests/sagemaker_launcher/test_config.py
@@ -6,6 +6,7 @@ exercise both happy paths (loading a complete YAML) and edge cases
 NOT import from mermaid_classifier.pyspacer.* to keep the test fast
 and to verify the schema is decoupled from the heavy pyspacer imports.
 """
+
 from __future__ import annotations
 
 import textwrap
@@ -16,7 +17,6 @@ from tempfile import TemporaryDirectory
 from pydantic import ValidationError
 
 from mermaid_classifier.sagemaker.config import TrainingRunConfig
-
 
 MINIMAL_YAML = textwrap.dedent("""
     dataset:
@@ -50,7 +50,6 @@ def _write(tmp: Path, text: str) -> Path:
 
 
 class LoadHappyPathTest(unittest.TestCase):
-
     def test_minimal_yaml_loads(self):
         with TemporaryDirectory() as td:
             path = _write(Path(td), MINIMAL_YAML)
@@ -59,8 +58,7 @@ class LoadHappyPathTest(unittest.TestCase):
         self.assertEqual(config.training.epochs, 5)
         self.assertEqual(config.training.early_stopping_patience, 3)
         self.assertEqual(config.mlflow.experiment_name, "test-experiment")
-        self.assertEqual(
-            config.env["MLFLOW_TRACKING_SERVER"], "file:./mlruns")
+        self.assertEqual(config.env["MLFLOW_TRACKING_SERVER"], "file:./mlruns")
 
     def test_csv_paths_resolve_against_yaml_dir(self):
         with TemporaryDirectory() as td:
@@ -73,9 +71,9 @@ class LoadHappyPathTest(unittest.TestCase):
 
 
 class SubsampleStrategiesTest(unittest.TestCase):
-
     def _load(self, subsample_yaml: str) -> TrainingRunConfig:
         import yaml as _yaml
+
         base = _yaml.safe_load(MINIMAL_YAML)
         patch = _yaml.safe_load(subsample_yaml)
         base["dataset"]["subsample"] = patch.get("subsample")
@@ -84,21 +82,25 @@ class SubsampleStrategiesTest(unittest.TestCase):
             return TrainingRunConfig.from_yaml_path(path)
 
     def test_stratified_with_total_annotations_loads(self):
-        config = self._load(textwrap.dedent("""\
+        config = self._load(
+            textwrap.dedent("""\
               subsample:
                 strategy: stratified
                 total_annotations: 5000
-        """))
+        """)
+        )
         self.assertEqual(config.dataset.subsample.strategy, "stratified")
         self.assertEqual(config.dataset.subsample.total_annotations, 5000)
 
     def test_balanced_with_total_annotations_loads(self):
-        config = self._load(textwrap.dedent("""\
+        config = self._load(
+            textwrap.dedent("""\
               subsample:
                 strategy: balanced
                 total_annotations: 5000
                 min_per_class: 50
-        """))
+        """)
+        )
         self.assertEqual(config.dataset.subsample.strategy, "balanced")
         self.assertEqual(config.dataset.subsample.min_per_class, 50)
 
@@ -107,23 +109,26 @@ class SubsampleStrategiesTest(unittest.TestCase):
         # experiments settled on 'balanced'); extra="forbid" rejects
         # both the strategy and its old companion fields.
         with self.assertRaises(ValidationError):
-            self._load(textwrap.dedent("""\
+            self._load(
+                textwrap.dedent("""\
                   subsample:
                     strategy: soft_balanced
                     total_annotations: 5000
-            """))
+            """)
+            )
 
     def test_unknown_strategy_rejected(self):
         with self.assertRaises(ValidationError):
-            self._load(textwrap.dedent("""\
+            self._load(
+                textwrap.dedent("""\
                   subsample:
                     strategy: not_a_strategy
                     total_annotations: 1000
-            """))
+            """)
+            )
 
 
 class WeightingTest(unittest.TestCase):
-
     def test_weighting_yaml_overrides_default(self):
         with TemporaryDirectory() as td:
             path = _write(Path(td), MINIMAL_YAML)
@@ -138,22 +143,21 @@ class WeightingTest(unittest.TestCase):
         exposed here are `enabled` and `weight_ratio_cap`.
         """
         from mermaid_classifier.sagemaker.config import WeightingConfig
+
         w = WeightingConfig()
         self.assertTrue(w.enabled)
         self.assertIsNone(w.weight_ratio_cap)
 
     def test_removed_weighting_field_rejected(self):
         # `strategy`/`alpha` were removed; extra="forbid" rejects them.
-        bad_yaml = MINIMAL_YAML.replace(
-            "weight_ratio_cap: 5000.0", "alpha: 0.5")
+        bad_yaml = MINIMAL_YAML.replace("weight_ratio_cap: 5000.0", "alpha: 0.5")
         with TemporaryDirectory() as td:
             path = _write(Path(td), bad_yaml)
             with self.assertRaises(ValidationError):
                 TrainingRunConfig.from_yaml_path(path)
 
     def test_invalid_weight_ratio_cap_rejected(self):
-        bad_yaml = MINIMAL_YAML.replace(
-            "weight_ratio_cap: 5000.0", "weight_ratio_cap: 0.5")
+        bad_yaml = MINIMAL_YAML.replace("weight_ratio_cap: 5000.0", "weight_ratio_cap: 0.5")
         with TemporaryDirectory() as td:
             path = _write(Path(td), bad_yaml)
             with self.assertRaises(ValidationError):
@@ -161,10 +165,10 @@ class WeightingTest(unittest.TestCase):
 
 
 class ApplyEnvTest(unittest.TestCase):
-
     def test_apply_env_writes_to_os_environ(self):
         import os
         from unittest import mock
+
         with TemporaryDirectory() as td:
             path = _write(Path(td), MINIMAL_YAML)
             config = TrainingRunConfig.from_yaml_path(path)
@@ -174,15 +178,13 @@ class ApplyEnvTest(unittest.TestCase):
                 os.environ.pop("MLFLOW_TRACKING_SERVER", None)
                 os.environ.pop("WEIGHTS_LOCATION", None)
                 config.apply_env()
-                self.assertEqual(
-                    os.environ["MLFLOW_TRACKING_SERVER"], "file:./mlruns")
-                self.assertEqual(
-                    os.environ["WEIGHTS_LOCATION"],
-                    "s3://bucket/weights.pt")
+                self.assertEqual(os.environ["MLFLOW_TRACKING_SERVER"], "file:./mlruns")
+                self.assertEqual(os.environ["WEIGHTS_LOCATION"], "s3://bucket/weights.pt")
 
     def test_apply_env_with_empty_block_is_noop(self):
         import os
         from unittest import mock
+
         yaml_no_env = MINIMAL_YAML.replace(
             "env:\n  MLFLOW_TRACKING_SERVER: file:./mlruns\n"
             "  WEIGHTS_LOCATION: s3://bucket/weights.pt\n",
@@ -198,7 +200,6 @@ class ApplyEnvTest(unittest.TestCase):
 
 
 class RequiredFieldsTest(unittest.TestCase):
-
     def test_missing_dataset_block_rejected(self):
         bad = "training:\n  epochs: 1\nmlflow:\n  experiment_name: x\n"
         with TemporaryDirectory() as td:
@@ -217,25 +218,24 @@ class BuildOptionsTest(unittest.TestCase):
     def test_build_options_produces_three_dataclasses(self):
         try:
             from mermaid_classifier.pyspacer.train import (
-                DatasetOptions, MLflowOptions, TrainingOptions,
+                DatasetOptions,
+                MLflowOptions,
+                TrainingOptions,
             )
         except Exception:
             self.skipTest("pyspacer extras not installed")
         with TemporaryDirectory() as td:
             tmp = Path(td)
             (tmp / "sources.csv").write_text("id\n123\n")
-            (tmp / "rollups.csv").write_text(
-                "from_ba_id,from_gf_id,to_ba_id,to_gf_id\n")
+            (tmp / "rollups.csv").write_text("from_ba_id,from_gf_id,to_ba_id,to_gf_id\n")
             (tmp / "included_labels.csv").write_text("ba_id,gf_id\n")
             path = _write(tmp, MINIMAL_YAML)
             config = TrainingRunConfig.from_yaml_path(path)
-            dataset, training, mlflow = config.build_options(
-                config_dir=tmp)
+            dataset, training, mlflow = config.build_options(config_dir=tmp)
         self.assertIsInstance(dataset, DatasetOptions)
         self.assertIsInstance(training, TrainingOptions)
         self.assertIsInstance(mlflow, MLflowOptions)
-        self.assertEqual(
-            dataset.coralnet_sources_csv, str(tmp / "sources.csv"))
+        self.assertEqual(dataset.coralnet_sources_csv, str(tmp / "sources.csv"))
         self.assertEqual(training.epochs, 5)
         self.assertEqual(training.early_stopping_patience, 3)
 
@@ -247,8 +247,7 @@ class MLflowModelNameTest(unittest.TestCase):
     """
 
     def _load_with_model_name(self, name: str) -> TrainingRunConfig:
-        yaml_text = MINIMAL_YAML.replace(
-            "model_name: TestModel", f"model_name: {name}")
+        yaml_text = MINIMAL_YAML.replace("model_name: TestModel", f"model_name: {name}")
         with TemporaryDirectory() as td:
             path = _write(Path(td), yaml_text)
             return TrainingRunConfig.from_yaml_path(path)
@@ -285,6 +284,7 @@ class MLflowModelNameTest(unittest.TestCase):
         # Omitting model_name lets MermaidTrainer auto-generate a safe one
         # via _get_model_name(); the validator must not reject None.
         import yaml as _yaml
+
         base = _yaml.safe_load(MINIMAL_YAML)
         base["mlflow"].pop("model_name")
         with TemporaryDirectory() as td:
@@ -294,21 +294,18 @@ class MLflowModelNameTest(unittest.TestCase):
 
 
 class ExampleYamlTest(unittest.TestCase):
-
     def test_committed_example_loads(self):
         # Resolve relative to the repo root (the tests/ dir is one
         # level deep so the example is at ../sagemaker/configs/example).
         here = Path(__file__).resolve().parent.parent.parent
-        example = here / "sagemaker" / "configs" / "example" \
-            / "training_config.yaml"
+        example = here / "sagemaker" / "configs" / "example" / "training_config.yaml"
         self.assertTrue(
             example.is_file(),
             f"Example YAML not found at {example}",
         )
         config = TrainingRunConfig.from_yaml_path(example)
         self.assertIsNotNone(config.dataset.subsample)
-        self.assertEqual(
-            config.dataset.subsample.strategy, "balanced")
+        self.assertEqual(config.dataset.subsample.strategy, "balanced")
 
 
 if __name__ == "__main__":

--- a/tests/sagemaker_launcher/test_entrypoint.py
+++ b/tests/sagemaker_launcher/test_entrypoint.py
@@ -12,28 +12,26 @@ imports or hit AWS. Tests verify:
   * an exception in runner.run propagates to sys.exit(1) with the
     traceback in log output
 """
+
 from __future__ import annotations
 
 import importlib.util
 import io
 import logging
 import os
-import sys
 import textwrap
 import unittest
-from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
-
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 ENTRYPOINT_PATH = REPO_ROOT / "scripts" / "sagemaker_train_entrypoint.py"
 
 
 def _load_entrypoint():
-    spec = importlib.util.spec_from_file_location(
-        "sagemaker_train_entrypoint", ENTRYPOINT_PATH)
+    spec = importlib.util.spec_from_file_location("sagemaker_train_entrypoint", ENTRYPOINT_PATH)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
@@ -65,33 +63,35 @@ def _config_dir():
         tmp = Path(td)
         (tmp / "training_config.yaml").write_text(MINIMAL_YAML)
         (tmp / "sources.csv").write_text("id\n123\n")
-        (tmp / "rollups.csv").write_text(
-            "from_ba_id,from_gf_id,to_ba_id,to_gf_id\n")
+        (tmp / "rollups.csv").write_text("from_ba_id,from_gf_id,to_ba_id,to_gf_id\n")
         (tmp / "included_labels.csv").write_text("ba_id,gf_id\n")
         yield tmp
 
 
 class EntrypointHappyPathTest(unittest.TestCase):
-
     def setUp(self):
         # Wipe env vars the entrypoint will set so we can detect them.
         for key in (
-            "MLFLOW_TRACKING_SERVER", "WEIGHTS_LOCATION",
+            "MLFLOW_TRACKING_SERVER",
+            "WEIGHTS_LOCATION",
         ):
             os.environ.pop(key, None)
         self.module = _load_entrypoint()
 
     def test_main_runs_runner_once_with_built_options(self):
-        with _config_dir() as cfg_dir:
-            with patch.object(
-                self.module, "_resolve_runner_factory"
-            ) as get_factory:
-                fake_runner = MagicMock()
-                factory = MagicMock(return_value=fake_runner)
-                get_factory.return_value = factory
-                self.module.main([
-                    "--config-dir", str(cfg_dir),
-                ])
+        with (
+            _config_dir() as cfg_dir,
+            patch.object(self.module, "_resolve_runner_factory") as get_factory,
+        ):
+            fake_runner = MagicMock()
+            factory = MagicMock(return_value=fake_runner)
+            get_factory.return_value = factory
+            self.module.main(
+                [
+                    "--config-dir",
+                    str(cfg_dir),
+                ]
+            )
         factory.assert_called_once()
         fake_runner.run.assert_called_once_with()
 
@@ -100,13 +100,13 @@ class EntrypointHappyPathTest(unittest.TestCase):
             observed = {}
 
             def factory(*args, **kwargs):
-                observed["mlflow"] = os.environ.get(
-                    "MLFLOW_TRACKING_SERVER")
+                observed["mlflow"] = os.environ.get("MLFLOW_TRACKING_SERVER")
                 observed["weights"] = os.environ.get("WEIGHTS_LOCATION")
                 return MagicMock()
 
             with patch.object(
-                self.module, "_resolve_runner_factory",
+                self.module,
+                "_resolve_runner_factory",
                 return_value=factory,
             ):
                 self.module.main(["--config-dir", str(cfg_dir)])
@@ -121,12 +121,15 @@ class EntrypointHappyPathTest(unittest.TestCase):
         root.addHandler(handler)
         root.setLevel(logging.INFO)
         try:
-            with _config_dir() as cfg_dir:
-                with patch.object(
-                    self.module, "_resolve_runner_factory",
+            with (
+                _config_dir() as cfg_dir,
+                patch.object(
+                    self.module,
+                    "_resolve_runner_factory",
                     return_value=lambda *a, **kw: MagicMock(),
-                ):
-                    self.module.main(["--config-dir", str(cfg_dir)])
+                ),
+            ):
+                self.module.main(["--config-dir", str(cfg_dir)])
         finally:
             root.removeHandler(handler)
         log_text = buf.getvalue()
@@ -141,31 +144,32 @@ class EntrypointHappyPathTest(unittest.TestCase):
                     indices.append(i)
                     break
             else:
-                self.fail(
-                    f"Missing ENTER marker for stage '{stage}' in log:\n"
-                    f"{log_text}")
+                self.fail(f"Missing ENTER marker for stage '{stage}' in log:\n{log_text}")
         self.assertEqual(
-            indices, sorted(indices),
-            "Stage ENTER markers appeared out of order. The env-before-"
-            "pyspacer-import contract relies on apply_env preceding "
-            "build_options preceding runner_run. Got indices: %s for "
-            "stages %s" % (indices, stage_names),
+            indices,
+            sorted(indices),
+            f"Stage ENTER markers appeared out of order. The env-before-"
+            f"pyspacer-import contract relies on apply_env preceding "
+            f"build_options preceding runner_run. Got indices: {indices} for "
+            f"stages {stage_names}",
         )
 
 
 class EntrypointFailureTest(unittest.TestCase):
-
     def test_runner_exception_exits_nonzero(self):
         module = _load_entrypoint()
         with _config_dir() as cfg_dir:
             fake_runner = MagicMock()
             fake_runner.run.side_effect = RuntimeError("boom")
-            with patch.object(
-                module, "_resolve_runner_factory",
-                return_value=lambda *a, **kw: fake_runner,
+            with (
+                patch.object(
+                    module,
+                    "_resolve_runner_factory",
+                    return_value=lambda *a, **kw: fake_runner,
+                ),
+                self.assertRaises(SystemExit) as cm,
             ):
-                with self.assertRaises(SystemExit) as cm:
-                    module.main(["--config-dir", str(cfg_dir)])
+                module.main(["--config-dir", str(cfg_dir)])
         self.assertEqual(cm.exception.code, 1)
 
 

--- a/tests/sagemaker_launcher/test_launch_processing.py
+++ b/tests/sagemaker_launcher/test_launch_processing.py
@@ -1,4 +1,5 @@
 """Tests for scripts.launch_processing (mermaid-classifier)."""
+
 from __future__ import annotations
 
 import csv
@@ -63,6 +64,7 @@ class BuildProcessingRequestTest(unittest.TestCase):
     def test_request_shape_no_shard(self, mock_dt):
         mock_dt.now.return_value.strftime.return_value = "20260525T120000Z"
         from mermaid_classifier.sagemaker.launcher_config import parse_run_config
+
         cfg = parse_run_config(
             """
 job:
@@ -77,23 +79,29 @@ processing:
     - --target-bucket=2605-coralnet-public-sources
     - --skip-existing
 """,
-            kind="processing", strict=True)
+            kind="processing",
+            strict=True,
+        )
         req = lp.build_processing_request(
-            cfg=cfg, run_id="mermaid-features-20260525T120000Z",
-            worker_idx=0, worker_items=None)
+            cfg=cfg, run_id="mermaid-features-20260525T120000Z", worker_idx=0, worker_items=None
+        )
         self.assertEqual(req["ProcessingJobName"], "mermaid-features-20260525T120000Z-0")
         self.assertEqual(req["RoleArn"], "arn:aws:iam::554812291621:role/dev-sm-execution-role")
         self.assertEqual(
             req["AppSpecification"]["ImageUri"],
-            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs:features-latest")
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs:features-latest",
+        )
         self.assertIn("--skip-existing", req["AppSpecification"]["ContainerArguments"])
-        self.assertEqual(req["ProcessingResources"]["ClusterConfig"]["InstanceType"], "ml.g5.xlarge")
+        self.assertEqual(
+            req["ProcessingResources"]["ClusterConfig"]["InstanceType"], "ml.g5.xlarge"
+        )
         self.assertEqual(req["StoppingCondition"]["MaxRuntimeInSeconds"], 12 * 3600)
 
     @patch("launch_processing.datetime")
     def test_request_shape_with_shard(self, mock_dt):
         mock_dt.now.return_value.strftime.return_value = "20260525T120000Z"
         from mermaid_classifier.sagemaker.launcher_config import parse_run_config
+
         cfg = parse_run_config(
             """
 job:
@@ -111,10 +119,15 @@ processing:
     workers: 4
     per_worker_arg: --source-ids
 """,
-            kind="processing", strict=True)
+            kind="processing",
+            strict=True,
+        )
         req = lp.build_processing_request(
-            cfg=cfg, run_id="mermaid-features-20260525T120000Z",
-            worker_idx=2, worker_items=["1", "5", "9"])
+            cfg=cfg,
+            run_id="mermaid-features-20260525T120000Z",
+            worker_idx=2,
+            worker_items=["1", "5", "9"],
+        )
         args = req["AppSpecification"]["ContainerArguments"]
         self.assertIn("--source-ids", args)
         idx = args.index("--source-ids")

--- a/tests/sagemaker_launcher/test_launch_training.py
+++ b/tests/sagemaker_launcher/test_launch_training.py
@@ -1,4 +1,5 @@
 """Tests for scripts.launch_training (mermaid-classifier)."""
+
 from __future__ import annotations
 
 import importlib.util
@@ -47,8 +48,7 @@ class ExpandImageTest(unittest.TestCase):
         result = lt.expand_image_uri("mermaid-classifier-jobs:training-latest")
         self.assertEqual(
             result,
-            "554812291621.dkr.ecr.us-east-1.amazonaws.com"
-            "/mermaid-classifier-jobs:training-latest",
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs:training-latest",
         )
 
     def test_full_uri_passes_through(self):
@@ -76,6 +76,7 @@ class BuildEstimatorKwargsTest(unittest.TestCase):
         mock_dt.now.return_value.strftime.return_value = "20260525T120000Z"
 
         from mermaid_classifier.sagemaker.launcher_config import parse_run_config
+
         cfg = parse_run_config(_minimal_yaml(), kind="training", strict=False)
         kwargs = lt.build_estimator_kwargs(
             cfg=cfg,
@@ -98,11 +99,12 @@ class BuildEstimatorKwargsTest(unittest.TestCase):
         )
         self.assertEqual(
             kwargs["image_uri"],
-            "554812291621.dkr.ecr.us-east-1.amazonaws.com"
-            "/mermaid-classifier-jobs:training-smoke",
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs:training-smoke",
         )
         # MLflow URI is injected as env, NOT YAML-overridable.
-        self.assertEqual(kwargs["environment"]["MLFLOW_TRACKING_SERVER"],
-            "arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-2OMU4VP53ZS2")
+        self.assertEqual(
+            kwargs["environment"]["MLFLOW_TRACKING_SERVER"],
+            "arn:aws:sagemaker:us-east-1:554812291621:mlflow-app/app-2OMU4VP53ZS2",
+        )
         # YAML env preserved:
         self.assertEqual(kwargs["environment"]["MY_VAR"], "1")

--- a/tests/sagemaker_launcher/test_launcher_config.py
+++ b/tests/sagemaker_launcher/test_launcher_config.py
@@ -1,4 +1,5 @@
 """Tests for mermaid_classifier.sagemaker.launcher_config."""
+
 from __future__ import annotations
 
 import unittest
@@ -7,7 +8,8 @@ import yaml
 from pydantic import ValidationError
 
 from mermaid_classifier.sagemaker.launcher_config import (
-    JobConfig, ProcessingConfig, ShardConfig, TrainingConfig,
+    JobConfig,
+    ShardConfig,
     parse_run_config,
 )
 
@@ -22,10 +24,10 @@ class JobConfigTest(unittest.TestCase):
             volume_gb=200,
             max_runtime_hours=24,
         )
-        self.assertEqual(cfg.instance_count, 1)        # default
-        self.assertFalse(cfg.use_spot)                  # default
-        self.assertEqual(cfg.env, {})                   # default
-        self.assertEqual(cfg.tags, {})                  # default
+        self.assertEqual(cfg.instance_count, 1)  # default
+        self.assertFalse(cfg.use_spot)  # default
+        self.assertEqual(cfg.env, {})  # default
+        self.assertEqual(cfg.tags, {})  # default
 
     def test_missing_required_field_raises(self):
         with self.assertRaises(ValidationError) as ctx:
@@ -41,17 +43,27 @@ class JobConfigTest(unittest.TestCase):
 
     def test_image_short_form_accepted(self):
         cfg = JobConfig(
-            name_prefix="x", image="mermaid-classifier-jobs:training-latest",
-            entrypoint="x", instance_type="x",
-            volume_gb=1, max_runtime_hours=1)
+            name_prefix="x",
+            image="mermaid-classifier-jobs:training-latest",
+            entrypoint="x",
+            instance_type="x",
+            volume_gb=1,
+            max_runtime_hours=1,
+        )
         self.assertEqual(cfg.image, "mermaid-classifier-jobs:training-latest")
 
     def test_image_full_uri_accepted(self):
-        full = "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs:training-latest"
+        full = (
+            "554812291621.dkr.ecr.us-east-1.amazonaws.com/mermaid-classifier-jobs:training-latest"
+        )
         cfg = JobConfig(
-            name_prefix="x", image=full,
-            entrypoint="x", instance_type="x",
-            volume_gb=1, max_runtime_hours=1)
+            name_prefix="x",
+            image=full,
+            entrypoint="x",
+            instance_type="x",
+            volume_gb=1,
+            max_runtime_hours=1,
+        )
         self.assertEqual(cfg.image, full)
 
 
@@ -65,55 +77,65 @@ class ShardConfigTest(unittest.TestCase):
 
 class ParseRunConfigTest(unittest.TestCase):
     def test_training_only(self):
-        y = yaml.safe_dump({
-            "job": {
-                "name_prefix": "x",
-                "image": "y",
-                "entrypoint": "z",
-                "instance_type": "ml.m5.4xlarge",
-                "volume_gb": 200,
-                "max_runtime_hours": 24,
-            },
-            "training": {
-                "hyperparameters": {"k": "v"},
-            },
-        })
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "ml.m5.4xlarge",
+                    "volume_gb": 200,
+                    "max_runtime_hours": 24,
+                },
+                "training": {
+                    "hyperparameters": {"k": "v"},
+                },
+            }
+        )
         cfg = parse_run_config(y, kind="training")
         self.assertIsNotNone(cfg.training)
         self.assertIsNone(cfg.processing)
         self.assertEqual(cfg.training.hyperparameters, {"k": "v"})
 
     def test_processing_only(self):
-        y = yaml.safe_dump({
-            "job": {
-                "name_prefix": "x",
-                "image": "y",
-                "entrypoint": "z",
-                "instance_type": "ml.g5.xlarge",
-                "volume_gb": 100,
-                "max_runtime_hours": 12,
-            },
-            "processing": {
-                "container_args": ["--a=1"],
-                "shard": {
-                    "items_from": "ids.csv",
-                    "workers": 4,
-                    "per_worker_arg": "--source-ids",
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "ml.g5.xlarge",
+                    "volume_gb": 100,
+                    "max_runtime_hours": 12,
                 },
-            },
-        })
+                "processing": {
+                    "container_args": ["--a=1"],
+                    "shard": {
+                        "items_from": "ids.csv",
+                        "workers": 4,
+                        "per_worker_arg": "--source-ids",
+                    },
+                },
+            }
+        )
         cfg = parse_run_config(y, kind="processing")
         self.assertIsNotNone(cfg.processing)
         self.assertEqual(cfg.processing.shard.workers, 4)
 
     def test_unknown_top_level_key_raises(self):
-        y = yaml.safe_dump({
-            "job": {
-                "name_prefix": "x", "image": "y", "entrypoint": "z",
-                "instance_type": "a", "volume_gb": 1, "max_runtime_hours": 1,
-            },
-            "garbage": {"foo": "bar"},
-        })
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "a",
+                    "volume_gb": 1,
+                    "max_runtime_hours": 1,
+                },
+                "garbage": {"foo": "bar"},
+            }
+        )
         with self.assertRaises(ValidationError):
             parse_run_config(y, kind="training")
 
@@ -121,14 +143,20 @@ class ParseRunConfigTest(unittest.TestCase):
         # The launcher schema must coexist with the existing
         # TrainingRunConfig keys (dataset, training-classifier-specific,
         # mlflow). The launcher ignores those.
-        y = yaml.safe_dump({
-            "job": {
-                "name_prefix": "x", "image": "y", "entrypoint": "z",
-                "instance_type": "a", "volume_gb": 1, "max_runtime_hours": 1,
-            },
-            "dataset": {"include_mermaid": False},
-            "mlflow": {"experiment_name": "foo"},
-        })
+        y = yaml.safe_dump(
+            {
+                "job": {
+                    "name_prefix": "x",
+                    "image": "y",
+                    "entrypoint": "z",
+                    "instance_type": "a",
+                    "volume_gb": 1,
+                    "max_runtime_hours": 1,
+                },
+                "dataset": {"include_mermaid": False},
+                "mlflow": {"experiment_name": "foo"},
+            }
+        )
         # No ValidationError; dataset/mlflow are allowed-but-ignored.
         cfg = parse_run_config(y, kind="training", strict=False)
         self.assertIsNone(cfg.training)

--- a/tests/test_generate_training_config.py
+++ b/tests/test_generate_training_config.py
@@ -5,6 +5,7 @@ The script's only network-touching seams are `_load_ba_library`,
 with hand-built fakes that exercise specific corners of the hierarchy
 walk, the Porites GF-bucket logic, and the EXCLUDED_NAMES filter.
 """
+
 from __future__ import annotations
 
 import csv
@@ -20,7 +21,7 @@ from unittest import mock
 
 # Allow importing scripts/generate_training_config.py.
 REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import generate_training_config as gtc  # noqa: E402
 
@@ -35,62 +36,62 @@ from mermaid_classifier.common.benthic_attributes import (  # noqa: E402
 def _canned_urlopen(*args, **kwargs):
     """Tiny but valid responses so module-level imports of
     `mermaid_classifier.pyspacer.train` don't reach the network."""
-    url = args[0] if args else kwargs.get('url', '')
+    url = args[0] if args else kwargs.get("url", "")
     if isinstance(url, urllib.request.Request):
         url = url.full_url
-    if 'benthicattributes' in url:
-        payload: object = {'results': [], 'next': None}
-    elif 'labelmappings' in url:
-        payload = {'results': [], 'next': None}
-    elif 'choices' in url:
-        payload = [{'name': 'growthforms', 'data': []}]
+    if "benthicattributes" in url:
+        payload: object = {"results": [], "next": None}
+    elif "labelmappings" in url:
+        payload = {"results": [], "next": None}
+    elif "choices" in url:
+        payload = [{"name": "growthforms", "data": []}]
     else:
         raise ValueError(f"unexpected url in test: {url!r}")
     return io.BytesIO(json.dumps(payload).encode())
 
 
 def setUpModule():
-    with mock.patch('urllib.request.urlopen', side_effect=_canned_urlopen):
+    with mock.patch("urllib.request.urlopen", side_effect=_canned_urlopen):
         import mermaid_classifier.pyspacer.train  # noqa: F401
 
 
 # ---------- Fixture UUIDs ----------
 
-HARD_CORAL = 'ba-hardcoral-0000-0000-000000000001'
-ACROPORIDAE = 'ba-acroporidae-000-0000-000000000002'
-ACROPORA = 'ba-acropora-0000-0000-000000000003'
-ACROPORA_HUMILIS = 'ba-acrhum-0000-0000-000000000004'
-TURF_ALGAE = 'ba-turf-0000-0000-000000000005'
-ORPHAN_BA = 'ba-orphan-0000-0000-000000000006'
-ORPHAN_FAMILY = 'ba-orphfam-0000-0000-000000000007'
-UNKNOWN_UUID = 'ba-unknown-0000-0000-000000000099'
+HARD_CORAL = "ba-hardcoral-0000-0000-000000000001"
+ACROPORIDAE = "ba-acroporidae-000-0000-000000000002"
+ACROPORA = "ba-acropora-0000-0000-000000000003"
+ACROPORA_HUMILIS = "ba-acrhum-0000-0000-000000000004"
+TURF_ALGAE = "ba-turf-0000-0000-000000000005"
+ORPHAN_BA = "ba-orphan-0000-0000-000000000006"
+ORPHAN_FAMILY = "ba-orphfam-0000-0000-000000000007"
+UNKNOWN_UUID = "ba-unknown-0000-0000-000000000099"
 
 # Iteration 2: Porites + species + exclusions.
-PORITIDAE = 'ba-poritidae-0000-0000-00000000000a'           # NOT top-108
-PORITES = 'ba-porites-0000-0000-00000000000b'                # top-108, genus
-PORITES_LOBATA = 'ba-porlob-0000-0000-00000000000c'          # inherent: massive
-PORITES_COMPRESSA = 'ba-porcom-0000-0000-00000000000d'       # inherent: branching
-PORITES_RUS = 'ba-porrus-0000-0000-00000000000e'             # inherent: submassive (->'')
-PORITES_ANNAE = 'ba-porann-0000-0000-00000000000f'           # inherent: blank (->'')
-PORITES_ASTREOIDES = 'ba-poras-0000-0000-000000000010'       # top-108 species
+PORITIDAE = "ba-poritidae-0000-0000-00000000000a"  # NOT top-108
+PORITES = "ba-porites-0000-0000-00000000000b"  # top-108, genus
+PORITES_LOBATA = "ba-porlob-0000-0000-00000000000c"  # inherent: massive
+PORITES_COMPRESSA = "ba-porcom-0000-0000-00000000000d"  # inherent: branching
+PORITES_RUS = "ba-porrus-0000-0000-00000000000e"  # inherent: submassive (->'')
+PORITES_ANNAE = "ba-porann-0000-0000-00000000000f"  # inherent: blank (->'')
+PORITES_ASTREOIDES = "ba-poras-0000-0000-000000000010"  # top-108 species
 
-BARE_SUBSTRATE = 'ba-bare-0000-0000-000000000011'             # top-108
-DEAD_CORAL = 'ba-dead-0000-0000-000000000012'                 # excluded; parent Bare substrate
-BLEACHED_CORAL = 'ba-bleached-000-0000-000000000013'         # excluded; parent Hard coral
-OTHER_INVERTEBRATES = 'ba-otherinv-000-0000-000000000014'    # excluded; no parent
+BARE_SUBSTRATE = "ba-bare-0000-0000-000000000011"  # top-108
+DEAD_CORAL = "ba-dead-0000-0000-000000000012"  # excluded; parent Bare substrate
+BLEACHED_CORAL = "ba-bleached-000-0000-000000000013"  # excluded; parent Hard coral
+OTHER_INVERTEBRATES = "ba-otherinv-000-0000-000000000014"  # excluded; no parent
 
 # Growth form UUIDs.
-GF_BRANCHING = 'gf-branching-000-0000-000000000001'
-GF_MASSIVE = 'gf-massive-000-0000-000000000002'
-GF_ENCRUSTING = 'gf-encrusting-00-0000-000000000003'
-GF_FOLIOSE = 'gf-foliose-0000-0000-000000000004'
+GF_BRANCHING = "gf-branching-000-0000-000000000001"
+GF_MASSIVE = "gf-massive-000-0000-000000000002"
+GF_ENCRUSTING = "gf-encrusting-00-0000-000000000003"
+GF_FOLIOSE = "gf-foliose-0000-0000-000000000004"
 
 # A top-108 name absent from the fake BA lib (KeyError path).
-GHOST_NAME = 'Ghost Coral That Was Renamed Yesterday'
+GHOST_NAME = "Ghost Coral That Was Renamed Yesterday"
 
 
 def _ba_record(uuid: str, name: str, parent: str | None) -> dict:
-    return {'id': uuid, 'name': name, 'parent': parent}
+    return {"id": uuid, "name": name, "parent": parent}
 
 
 # Hierarchy:
@@ -111,50 +112,60 @@ def _ba_record(uuid: str, name: str, parent: str | None) -> dict:
 #     ORPHAN_BA
 #   OTHER_INVERTEBRATES (excluded, no parent)
 BA_RECORDS = [
-    _ba_record(HARD_CORAL, 'Hard coral', None),
-    _ba_record(ACROPORIDAE, 'Acroporidae', HARD_CORAL),
-    _ba_record(ACROPORA, 'Acropora', ACROPORIDAE),
-    _ba_record(ACROPORA_HUMILIS, 'Acropora humilis', ACROPORA),
-    _ba_record(PORITIDAE, 'Poritidae', HARD_CORAL),
-    _ba_record(PORITES, 'Porites', PORITIDAE),
-    _ba_record(PORITES_LOBATA, 'Porites lobata', PORITES),
-    _ba_record(PORITES_COMPRESSA, 'Porites compressa', PORITES),
-    _ba_record(PORITES_RUS, 'Porites rus', PORITES),
-    _ba_record(PORITES_ANNAE, 'Porites annae', PORITES),
-    _ba_record(PORITES_ASTREOIDES, 'Porites astreoides', PORITES),
-    _ba_record(BLEACHED_CORAL, 'Bleached coral', HARD_CORAL),
-    _ba_record(TURF_ALGAE, 'Turf algae', None),
-    _ba_record(BARE_SUBSTRATE, 'Bare substrate', None),
-    _ba_record(DEAD_CORAL, 'Dead coral', BARE_SUBSTRATE),
-    _ba_record(OTHER_INVERTEBRATES, 'Other invertebrates', None),
-    _ba_record(ORPHAN_FAMILY, 'Orphan family', None),
-    _ba_record(ORPHAN_BA, 'Orphan species', ORPHAN_FAMILY),
+    _ba_record(HARD_CORAL, "Hard coral", None),
+    _ba_record(ACROPORIDAE, "Acroporidae", HARD_CORAL),
+    _ba_record(ACROPORA, "Acropora", ACROPORIDAE),
+    _ba_record(ACROPORA_HUMILIS, "Acropora humilis", ACROPORA),
+    _ba_record(PORITIDAE, "Poritidae", HARD_CORAL),
+    _ba_record(PORITES, "Porites", PORITIDAE),
+    _ba_record(PORITES_LOBATA, "Porites lobata", PORITES),
+    _ba_record(PORITES_COMPRESSA, "Porites compressa", PORITES),
+    _ba_record(PORITES_RUS, "Porites rus", PORITES),
+    _ba_record(PORITES_ANNAE, "Porites annae", PORITES),
+    _ba_record(PORITES_ASTREOIDES, "Porites astreoides", PORITES),
+    _ba_record(BLEACHED_CORAL, "Bleached coral", HARD_CORAL),
+    _ba_record(TURF_ALGAE, "Turf algae", None),
+    _ba_record(BARE_SUBSTRATE, "Bare substrate", None),
+    _ba_record(DEAD_CORAL, "Dead coral", BARE_SUBSTRATE),
+    _ba_record(OTHER_INVERTEBRATES, "Other invertebrates", None),
+    _ba_record(ORPHAN_FAMILY, "Orphan family", None),
+    _ba_record(ORPHAN_BA, "Orphan species", ORPHAN_FAMILY),
 ]
 
 # Top-108 names. Includes the three EXCLUDED_NAMES with top100=1 to
 # verify the defensive exclusion path.
 TOP108_NAMES = [
-    'Hard coral', 'Acropora', 'Turf algae',
-    'Porites', 'Porites astreoides', 'Bare substrate',
+    "Hard coral",
+    "Acropora",
+    "Turf algae",
+    "Porites",
+    "Porites astreoides",
+    "Bare substrate",
     # Excluded — should be filtered out even with top100=1:
-    'Dead coral', 'Bleached coral', 'Other invertebrates',
+    "Dead coral",
+    "Bleached coral",
+    "Other invertebrates",
     GHOST_NAME,
 ]
 
 # Species inherent GF (column 'growth forms' in the labels CSV).
 LABELS_GROWTH_FORMS = {
-    'Porites': 'branching, massive, other/none',  # multi-value: skipped by _load_species_gf_lookup
-    'Porites lobata': 'massive',
-    'Porites compressa': 'branching',
-    'Porites rus': 'submassive',
-    'Porites annae': '',
-    'Porites astreoides': 'massive',
+    "Porites": "branching, massive, other/none",  # multi-value: skipped by _load_species_gf_lookup
+    "Porites lobata": "massive",
+    "Porites compressa": "branching",
+    "Porites rus": "submassive",
+    "Porites annae": "",
+    "Porites astreoides": "massive",
 }
 
 # UUIDs that should appear in included_labels (top-108 minus excluded
 # minus the unresolvable GHOST_NAME).
 EXPECTED_INCLUDED_BA_UUIDS = {
-    HARD_CORAL, ACROPORA, TURF_ALGAE, PORITES, PORITES_ASTREOIDES,
+    HARD_CORAL,
+    ACROPORA,
+    TURF_ALGAE,
+    PORITES,
+    PORITES_ASTREOIDES,
     BARE_SUBSTRATE,
 }
 
@@ -162,36 +173,37 @@ EXPECTED_INCLUDED_BA_UUIDS = {
 def _make_fake_ba_lib() -> BenthicAttributeLibrary:
     fake = BenthicAttributeLibrary.__new__(BenthicAttributeLibrary)
     fake.raw_results = list(BA_RECORDS)
-    fake.by_id = {r['id']: r for r in BA_RECORDS}
-    fake.by_name = {r['name']: r for r in BA_RECORDS}
+    fake.by_id = {r["id"]: r for r in BA_RECORDS}
+    fake.by_name = {r["name"]: r for r in BA_RECORDS}
     fake.by_parent = {}
     for r in BA_RECORDS:
-        fake.by_parent.setdefault(r['parent'], []).append(r)
+        fake.by_parent.setdefault(r["parent"], []).append(r)
     return fake
 
 
 def _make_fake_gf_library() -> GrowthFormLibrary:
     fake = GrowthFormLibrary.__new__(GrowthFormLibrary)
     fake.by_id = {
-        GF_BRANCHING: 'Branching',
-        GF_MASSIVE: 'Massive',
-        GF_ENCRUSTING: 'Encrusting',
-        GF_FOLIOSE: 'Foliose',
+        GF_BRANCHING: "Branching",
+        GF_MASSIVE: "Massive",
+        GF_ENCRUSTING: "Encrusting",
+        GF_FOLIOSE: "Foliose",
     }
     return fake
 
 
 def _make_fake_cn_mapping(entries: list[LabelMappingEntry]) -> CoralNetMermaidMapping:
     fake = CoralNetMermaidMapping.__new__(CoralNetMermaidMapping)
-    fake._endpoint = 'http://test.invalid/'
+    fake._endpoint = "http://test.invalid/"
     fake._mapping = {e.provider_id: e for e in entries}
     return fake
 
 
-def _entry(provider_id: str, ba_id: str, gf_id: str = '',
-           ba_name: str = '', gf_name: str = '') -> LabelMappingEntry:
+def _entry(
+    provider_id: str, ba_id: str, gf_id: str = "", ba_name: str = "", gf_name: str = ""
+) -> LabelMappingEntry:
     return LabelMappingEntry(
-        provider_label=f'CN-{provider_id}',
+        provider_label=f"CN-{provider_id}",
         benthic_attribute_name=ba_name,
         growth_form_name=gf_name,
         provider_id=provider_id,
@@ -204,38 +216,36 @@ def _entry(provider_id: str, ba_id: str, gf_id: str = '',
 # narrow CN lists when they need to isolate a behavior.
 DEFAULT_CN_ENTRIES = [
     # General BA cases (carried over from Iteration 1):
-    _entry('1', ACROPORA, '', 'Acropora'),
-    _entry('2', ACROPORA, GF_BRANCHING, 'Acropora', 'Branching'),
-    _entry('3', ACROPORA_HUMILIS, '', 'Acropora humilis'),
-    _entry('4', ACROPORA_HUMILIS, GF_MASSIVE, 'Acropora humilis', 'Massive'),
-    _entry('5', ACROPORIDAE, '', 'Acroporidae'),
-    _entry('6', TURF_ALGAE, '', 'Turf algae'),
-    _entry('7', ORPHAN_BA, '', 'Orphan species'),
-    _entry('8', UNKNOWN_UUID, '', 'Stale label'),
-    _entry('9', '', '', ''),
-
+    _entry("1", ACROPORA, "", "Acropora"),
+    _entry("2", ACROPORA, GF_BRANCHING, "Acropora", "Branching"),
+    _entry("3", ACROPORA_HUMILIS, "", "Acropora humilis"),
+    _entry("4", ACROPORA_HUMILIS, GF_MASSIVE, "Acropora humilis", "Massive"),
+    _entry("5", ACROPORIDAE, "", "Acroporidae"),
+    _entry("6", TURF_ALGAE, "", "Turf algae"),
+    _entry("7", ORPHAN_BA, "", "Orphan species"),
+    _entry("8", UNKNOWN_UUID, "", "Stale label"),
+    _entry("9", "", "", ""),
     # Iteration 2: Porites genus + buckets.
-    _entry('p1', PORITES, '', 'Porites'),
-    _entry('p2', PORITES, GF_BRANCHING, 'Porites', 'Branching'),
-    _entry('p3', PORITES, GF_MASSIVE, 'Porites', 'Massive'),
-    _entry('p4', PORITES, GF_ENCRUSTING, 'Porites', 'Encrusting'),
-    _entry('p5', PORITES, GF_FOLIOSE, 'Porites', 'Foliose'),
-
+    _entry("p1", PORITES, "", "Porites"),
+    _entry("p2", PORITES, GF_BRANCHING, "Porites", "Branching"),
+    _entry("p3", PORITES, GF_MASSIVE, "Porites", "Massive"),
+    _entry("p4", PORITES, GF_ENCRUSTING, "Porites", "Encrusting"),
+    _entry("p5", PORITES, GF_FOLIOSE, "Porites", "Foliose"),
     # Porites species — CN never supplies GF (per real-data audit).
-    _entry('s1', PORITES_LOBATA, '', 'Porites lobata'),       # inherent: massive
-    _entry('s2', PORITES_COMPRESSA, '', 'Porites compressa'),  # inherent: branching
-    _entry('s3', PORITES_RUS, '', 'Porites rus'),              # inherent: submassive -> ''
-    _entry('s4', PORITES_ANNAE, '', 'Porites annae'),          # inherent: blank -> ''
-    _entry('s5', PORITES_ASTREOIDES, '', 'Porites astreoides'),  # top-108 species
-
+    _entry("s1", PORITES_LOBATA, "", "Porites lobata"),  # inherent: massive
+    _entry("s2", PORITES_COMPRESSA, "", "Porites compressa"),  # inherent: branching
+    _entry("s3", PORITES_RUS, "", "Porites rus"),  # inherent: submassive -> ''
+    _entry("s4", PORITES_ANNAE, "", "Porites annae"),  # inherent: blank -> ''
+    _entry("s5", PORITES_ASTREOIDES, "", "Porites astreoides"),  # top-108 species
     # Excluded labels (defensive — these would otherwise walk to a parent).
-    _entry('e1', DEAD_CORAL, '', 'Dead coral'),
-    _entry('e2', BLEACHED_CORAL, '', 'Bleached coral'),
-    _entry('e3', OTHER_INVERTEBRATES, '', 'Other invertebrates'),
+    _entry("e1", DEAD_CORAL, "", "Dead coral"),
+    _entry("e2", BLEACHED_CORAL, "", "Bleached coral"),
+    _entry("e3", OTHER_INVERTEBRATES, "", "Other invertebrates"),
 ]
 
 
 # ---------- Synthetic input writers ----------
+
 
 def _write_labels_csv(path: Path, names: list[str]) -> None:
     """Write a `mapped_to_mermaid_attributes`-shaped CSV.
@@ -243,59 +253,60 @@ def _write_labels_csv(path: Path, names: list[str]) -> None:
     Includes the `growth forms` column for the species GF lookup.
     All rows have top100=1 (including the excluded names — defensive).
     """
-    with path.open('w', newline='') as f:
-        w = csv.DictWriter(
-            f, fieldnames=['id', 'name', 'top100', 'growth forms'])
+    with path.open("w", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["id", "name", "top100", "growth forms"])
         w.writeheader()
         for i, name in enumerate(names):
-            w.writerow({
-                'id': f'csv-id-{i}',
-                'name': name,
-                'top100': 1,
-                'growth forms': LABELS_GROWTH_FORMS.get(name, ''),
-            })
+            w.writerow(
+                {
+                    "id": f"csv-id-{i}",
+                    "name": name,
+                    "top100": 1,
+                    "growth forms": LABELS_GROWTH_FORMS.get(name, ""),
+                }
+            )
         # Add a few non-top-108 rows for the species GF lookup. Even
         # though top100=blank, the script reads the full labels_df for
         # _load_species_gf_lookup. These match the BA_RECORDS species.
-        for species_name in (
-                'Porites lobata', 'Porites compressa',
-                'Porites rus', 'Porites annae'):
-            w.writerow({
-                'id': _name_to_uuid(species_name),
-                'name': species_name,
-                'top100': '',
-                'growth forms': LABELS_GROWTH_FORMS.get(species_name, ''),
-            })
+        for species_name in ("Porites lobata", "Porites compressa", "Porites rus", "Porites annae"):
+            w.writerow(
+                {
+                    "id": _name_to_uuid(species_name),
+                    "name": species_name,
+                    "top100": "",
+                    "growth forms": LABELS_GROWTH_FORMS.get(species_name, ""),
+                }
+            )
 
 
 def _name_to_uuid(name: str) -> str:
     """Map a fixture name to its UUID (mirrors BA_RECORDS)."""
     for r in BA_RECORDS:
-        if r['name'] == name:
-            return r['id']
+        if r["name"] == name:
+            return r["id"]
     raise KeyError(name)
 
 
-def _write_sources_csv(path: Path, ids: list[int],
-                        column: str = 'id') -> None:
-    with path.open('w', newline='') as f:
-        f.write(column + '\n')
+def _write_sources_csv(path: Path, ids: list[int], column: str = "id") -> None:
+    with path.open("w", newline="") as f:
+        f.write(column + "\n")
         for i in ids:
-            f.write(f'{i}\n')
+            f.write(f"{i}\n")
 
 
 # ---------- Network blocker ----------
+
 
 class _NetworkAccess(AssertionError):
     pass
 
 
 def _block_network(*args, **kwargs):
-    raise _NetworkAccess(
-        f"test attempted live network call: args={args!r} kwargs={kwargs!r}")
+    raise _NetworkAccess(f"test attempted live network call: args={args!r} kwargs={kwargs!r}")
 
 
 # ---------- Test helpers ----------
+
 
 class _GenerateConfigTestCase(unittest.TestCase):
     """Base case: build inputs, run main(), and read outputs."""
@@ -304,9 +315,9 @@ class _GenerateConfigTestCase(unittest.TestCase):
         self.tmp = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
 
-        self.labels_csv = self.tmp / 'labels.csv'
-        self.sources_csv = self.tmp / 'sources_in.csv'
-        self.output_dir = self.tmp / 'config_out'
+        self.labels_csv = self.tmp / "labels.csv"
+        self.sources_csv = self.tmp / "sources_in.csv"
+        self.output_dir = self.tmp / "config_out"
 
         _write_labels_csv(self.labels_csv, TOP108_NAMES)
         _write_sources_csv(self.sources_csv, [10, 20, 30])
@@ -315,25 +326,30 @@ class _GenerateConfigTestCase(unittest.TestCase):
         self.gf_library = _make_fake_gf_library()
         self.cn_mapping = _make_fake_cn_mapping(DEFAULT_CN_ENTRIES)
 
-    def run_main(self, *, extra_args: list[str] | None = None,
-                 cn_entries: list[LabelMappingEntry] | None = None,
-                 sources_csv: Path | None = None) -> int:
-        cn = (_make_fake_cn_mapping(cn_entries)
-              if cn_entries is not None else self.cn_mapping)
+    def run_main(
+        self,
+        *,
+        extra_args: list[str] | None = None,
+        cn_entries: list[LabelMappingEntry] | None = None,
+        sources_csv: Path | None = None,
+    ) -> int:
+        cn = _make_fake_cn_mapping(cn_entries) if cn_entries is not None else self.cn_mapping
         argv = [
-            '--output-dir', str(self.output_dir),
-            '--labels-csv', str(self.labels_csv),
-            '--sources-csv', str(sources_csv or self.sources_csv),
+            "--output-dir",
+            str(self.output_dir),
+            "--labels-csv",
+            str(self.labels_csv),
+            "--sources-csv",
+            str(sources_csv or self.sources_csv),
         ]
         if extra_args:
             argv.extend(extra_args)
-        with mock.patch.object(gtc, '_load_ba_library',
-                               return_value=self.ba_lib), \
-             mock.patch.object(gtc, '_load_gf_library',
-                               return_value=self.gf_library), \
-             mock.patch.object(gtc, '_load_cn_mapping',
-                               return_value=cn), \
-             mock.patch('urllib.request.urlopen', _block_network):
+        with (
+            mock.patch.object(gtc, "_load_ba_library", return_value=self.ba_lib),
+            mock.patch.object(gtc, "_load_gf_library", return_value=self.gf_library),
+            mock.patch.object(gtc, "_load_cn_mapping", return_value=cn),
+            mock.patch("urllib.request.urlopen", _block_network),
+        ):
             return gtc.main(argv)
 
     def read_csv_rows(self, name: str) -> list[dict]:
@@ -341,103 +357,102 @@ class _GenerateConfigTestCase(unittest.TestCase):
             return list(csv.DictReader(f))
 
     def get_rollup_lookup(self) -> dict[tuple[str, str], tuple[str, str]]:
-        return {(r['from_ba_id'], r['from_gf_id']): (
-                    r['to_ba_id'], r['to_gf_id'])
-                for r in self.read_csv_rows('rollups.csv')}
+        return {
+            (r["from_ba_id"], r["from_gf_id"]): (r["to_ba_id"], r["to_gf_id"])
+            for r in self.read_csv_rows("rollups.csv")
+        }
 
     def get_included_set(self) -> set[tuple[str, str]]:
-        return {(r['ba_id'], r['gf_id'])
-                for r in self.read_csv_rows('included_labels.csv')}
+        return {(r["ba_id"], r["gf_id"]) for r in self.read_csv_rows("included_labels.csv")}
 
 
 # ---------- Tests ----------
 
-class HierarchyWalkTests(_GenerateConfigTestCase):
 
+class HierarchyWalkTests(_GenerateConfigTestCase):
     def test_top108_self_emits_no_rollup(self):
         self.run_main()
-        self.assertNotIn((ACROPORA, ''), set(self.get_rollup_lookup()))
+        self.assertNotIn((ACROPORA, ""), set(self.get_rollup_lookup()))
 
     def test_top108_appears_in_included(self):
         self.run_main()
         included = self.get_included_set()
-        self.assertIn((ACROPORA, ''), included)
-        self.assertIn((HARD_CORAL, ''), included)
-        self.assertIn((TURF_ALGAE, ''), included)
+        self.assertIn((ACROPORA, ""), included)
+        self.assertIn((HARD_CORAL, ""), included)
+        self.assertIn((TURF_ALGAE, ""), included)
 
     def test_nested_species_walks_to_nearest_top108(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(rollups[(ACROPORA_HUMILIS, '')], (ACROPORA, ''))
+        self.assertEqual(rollups[(ACROPORA_HUMILIS, "")], (ACROPORA, ""))
 
     def test_intermediate_taxon_walks_one_level_up(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(rollups[(ACROPORIDAE, '')], (HARD_CORAL, ''))
+        self.assertEqual(rollups[(ACROPORIDAE, "")], (HARD_CORAL, ""))
 
     def test_orphan_dropped(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
         included_ba = {ba for (ba, _) in self.get_included_set()}
-        self.assertNotIn((ORPHAN_BA, ''), set(rollups))
+        self.assertNotIn((ORPHAN_BA, ""), set(rollups))
         self.assertNotIn(ORPHAN_BA, included_ba)
 
     def test_unknown_uuid_dropped(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertNotIn((UNKNOWN_UUID, ''), set(rollups))
+        self.assertNotIn((UNKNOWN_UUID, ""), set(rollups))
 
     def test_null_ba_id_skipped(self):
         self.run_main()
         for from_ba, _gf in self.get_rollup_lookup():
-            self.assertNotEqual(from_ba, '')
+            self.assertNotEqual(from_ba, "")
 
     def test_root_top108_label(self):
         self.run_main()
-        rollups_for_turf = [r for r in self.read_csv_rows('rollups.csv')
-                             if r['from_ba_id'] == TURF_ALGAE]
+        rollups_for_turf = [
+            r for r in self.read_csv_rows("rollups.csv") if r["from_ba_id"] == TURF_ALGAE
+        ]
         included_ba = {ba for (ba, _) in self.get_included_set()}
         self.assertEqual(rollups_for_turf, [])
         self.assertIn(TURF_ALGAE, included_ba)
 
 
 class GrowthFormCollapseTests(_GenerateConfigTestCase):
-
     def test_top108_with_gf_collapses_to_empty(self):
         """Non-Porites top-108 BA with a GF -> rollup to (BA, '')."""
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(rollups[(ACROPORA, GF_BRANCHING)], (ACROPORA, ''))
+        self.assertEqual(rollups[(ACROPORA, GF_BRANCHING)], (ACROPORA, ""))
 
     def test_cross_ba_rollup_drops_gf(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(
-            rollups[(ACROPORA_HUMILIS, GF_MASSIVE)], (ACROPORA, ''))
+        self.assertEqual(rollups[(ACROPORA_HUMILIS, GF_MASSIVE)], (ACROPORA, ""))
 
     def test_non_porites_included_labels_have_blank_gf(self):
         """Every included row has blank GF EXCEPT Porites buckets."""
         self.run_main()
-        for r in self.read_csv_rows('included_labels.csv'):
-            if r['ba_id'] == PORITES:
+        for r in self.read_csv_rows("included_labels.csv"):
+            if r["ba_id"] == PORITES:
                 # Porites contributes both '' and the bucket UUIDs.
                 continue
-            self.assertEqual(
-                r['gf_id'], '',
-                f"non-Porites row {r} has unexpected GF")
+            self.assertEqual(r["gf_id"], "", f"non-Porites row {r} has unexpected GF")
 
 
 class PoritesBucketTests(_GenerateConfigTestCase):
-
     def test_porites_three_buckets_in_included_labels(self):
         self.run_main()
         included = self.get_included_set()
         porites_rows = {row for row in included if row[0] == PORITES}
-        self.assertEqual(porites_rows, {
-            (PORITES, ''),
-            (PORITES, GF_BRANCHING),
-            (PORITES, GF_MASSIVE),
-        })
+        self.assertEqual(
+            porites_rows,
+            {
+                (PORITES, ""),
+                (PORITES, GF_BRANCHING),
+                (PORITES, GF_MASSIVE),
+            },
+        )
 
     def test_porites_genus_branching_no_rollup(self):
         self.run_main()
@@ -453,98 +468,91 @@ class PoritesBucketTests(_GenerateConfigTestCase):
     def test_porites_genus_no_gf_no_rollup(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertNotIn((PORITES, ''), rollups)
+        self.assertNotIn((PORITES, ""), rollups)
 
     def test_porites_genus_other_gf_rollup_to_empty(self):
         """(Porites, Encrusting) -> (Porites, '')."""
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(rollups[(PORITES, GF_ENCRUSTING)], (PORITES, ''))
-        self.assertEqual(rollups[(PORITES, GF_FOLIOSE)], (PORITES, ''))
+        self.assertEqual(rollups[(PORITES, GF_ENCRUSTING)], (PORITES, ""))
+        self.assertEqual(rollups[(PORITES, GF_FOLIOSE)], (PORITES, ""))
 
 
 class PoritesSpeciesTests(_GenerateConfigTestCase):
-
     def test_porites_species_inherent_massive(self):
         """Porites lobata (inherent: massive) -> (Porites, Massive_uuid)."""
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(
-            rollups[(PORITES_LOBATA, '')], (PORITES, GF_MASSIVE))
+        self.assertEqual(rollups[(PORITES_LOBATA, "")], (PORITES, GF_MASSIVE))
 
     def test_porites_species_inherent_branching(self):
         """Porites compressa (inherent: branching) -> (Porites, Branching_uuid)."""
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(
-            rollups[(PORITES_COMPRESSA, '')], (PORITES, GF_BRANCHING))
+        self.assertEqual(rollups[(PORITES_COMPRESSA, "")], (PORITES, GF_BRANCHING))
 
     def test_porites_species_submassive_collapses_to_empty(self):
         """Porites rus (inherent: submassive) -> (Porites, '')."""
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(rollups[(PORITES_RUS, '')], (PORITES, ''))
+        self.assertEqual(rollups[(PORITES_RUS, "")], (PORITES, ""))
 
     def test_porites_species_blank_inherent_collapses(self):
         """Porites annae (inherent: blank) -> (Porites, '')."""
         self.run_main()
         rollups = self.get_rollup_lookup()
-        self.assertEqual(rollups[(PORITES_ANNAE, '')], (PORITES, ''))
+        self.assertEqual(rollups[(PORITES_ANNAE, "")], (PORITES, ""))
 
     def test_porites_species_cn_gf_overrides_inherent(self):
         """If CN supplies a non-empty GF for a Porites species, CN wins."""
         # Porites lobata's inherent is 'massive', but CN says Branching.
         cn = list(DEFAULT_CN_ENTRIES) + [
-            _entry('s_override', PORITES_LOBATA, GF_BRANCHING,
-                   'Porites lobata', 'Branching'),
+            _entry("s_override", PORITES_LOBATA, GF_BRANCHING, "Porites lobata", "Branching"),
         ]
         self.run_main(cn_entries=cn)
         rollups = self.get_rollup_lookup()
         # The CN-supplied GF entry rolls to Branching, overriding the
         # inherent massive bucket.
-        self.assertEqual(
-            rollups[(PORITES_LOBATA, GF_BRANCHING)], (PORITES, GF_BRANCHING))
+        self.assertEqual(rollups[(PORITES_LOBATA, GF_BRANCHING)], (PORITES, GF_BRANCHING))
         # The inherent-GF entry (no CN GF) still rolls to Massive.
-        self.assertEqual(
-            rollups[(PORITES_LOBATA, '')], (PORITES, GF_MASSIVE))
+        self.assertEqual(rollups[(PORITES_LOBATA, "")], (PORITES, GF_MASSIVE))
 
     def test_porites_astreoides_stays_own_class(self):
         """Top-108 Porites species: classified as itself, not in Porites buckets."""
         self.run_main()
         rollups = self.get_rollup_lookup()
         included = self.get_included_set()
-        self.assertNotIn((PORITES_ASTREOIDES, ''), rollups)
-        self.assertIn((PORITES_ASTREOIDES, ''), included)
+        self.assertNotIn((PORITES_ASTREOIDES, ""), rollups)
+        self.assertIn((PORITES_ASTREOIDES, ""), included)
 
 
 class ExclusionTests(_GenerateConfigTestCase):
-
     def test_dead_coral_dropped_not_walked(self):
         """Dead coral annotations should NOT roll up to Bare substrate."""
         self.run_main()
         rollups = self.get_rollup_lookup()
         included = self.get_included_set()
         # No rollup row from Dead coral.
-        self.assertNotIn((DEAD_CORAL, ''), rollups)
+        self.assertNotIn((DEAD_CORAL, ""), rollups)
         # Not in included_labels.
-        self.assertNotIn((DEAD_CORAL, ''), included)
+        self.assertNotIn((DEAD_CORAL, ""), included)
         # Bare substrate IS in included_labels (parent of Dead coral but in top-108).
-        self.assertIn((BARE_SUBSTRATE, ''), included)
+        self.assertIn((BARE_SUBSTRATE, ""), included)
 
     def test_bleached_coral_dropped(self):
         """Bleached coral annotations should NOT roll up to Hard coral."""
         self.run_main()
         rollups = self.get_rollup_lookup()
         included = self.get_included_set()
-        self.assertNotIn((BLEACHED_CORAL, ''), rollups)
-        self.assertNotIn((BLEACHED_CORAL, ''), included)
+        self.assertNotIn((BLEACHED_CORAL, ""), rollups)
+        self.assertNotIn((BLEACHED_CORAL, ""), included)
 
     def test_other_invertebrates_dropped(self):
         self.run_main()
         rollups = self.get_rollup_lookup()
         included = self.get_included_set()
-        self.assertNotIn((OTHER_INVERTEBRATES, ''), rollups)
-        self.assertNotIn((OTHER_INVERTEBRATES, ''), included)
+        self.assertNotIn((OTHER_INVERTEBRATES, ""), rollups)
+        self.assertNotIn((OTHER_INVERTEBRATES, ""), included)
 
     def test_excluded_top108_membership_defensive(self):
         """Even with top100=1 in the labels CSV, EXCLUDED_NAMES are dropped."""
@@ -558,7 +566,6 @@ class ExclusionTests(_GenerateConfigTestCase):
 
 
 class IncludedLabelCountTests(_GenerateConfigTestCase):
-
     def test_included_label_ba_uuids_match_expected(self):
         """included_labels has exactly the resolvable, non-excluded BAs."""
         self.run_main()
@@ -567,44 +574,41 @@ class IncludedLabelCountTests(_GenerateConfigTestCase):
 
 
 class SourcesPassthroughTests(_GenerateConfigTestCase):
-
     def test_sources_passthrough_id_column(self):
         self.run_main()
-        ids = [r['id'] for r in self.read_csv_rows('sources.csv')]
-        self.assertEqual(ids, ['10', '20', '30'])
+        ids = [r["id"] for r in self.read_csv_rows("sources.csv")]
+        self.assertEqual(ids, ["10", "20", "30"])
 
     def test_sources_passthrough_source_id_column(self):
-        alt = self.tmp / 'sources_alt.csv'
-        _write_sources_csv(alt, [42, 99], column='Source ID')
+        alt = self.tmp / "sources_alt.csv"
+        _write_sources_csv(alt, [42, 99], column="Source ID")
         self.run_main(sources_csv=alt)
-        ids = [r['id'] for r in self.read_csv_rows('sources.csv')]
-        self.assertEqual(ids, ['42', '99'])
+        ids = [r["id"] for r in self.read_csv_rows("sources.csv")]
+        self.assertEqual(ids, ["42", "99"])
 
 
 class ValidationTests(_GenerateConfigTestCase):
-
     def test_outputs_round_trip_through_pipeline(self):
         rc = self.run_main()
         self.assertEqual(rc, 0)
 
     def test_every_to_ba_in_included_labels(self):
-        self.run_main(extra_args=['--skip-validation'])
-        rollups_path = self.output_dir / 'rollups.csv'
+        self.run_main(extra_args=["--skip-validation"])
+        rollups_path = self.output_dir / "rollups.csv"
         with rollups_path.open() as f:
             content = f.read()
-        broken = content.rstrip() + '\nbogus-from-ba,,bogus-to-ba,\n'
+        broken = content.rstrip() + "\nbogus-from-ba,,bogus-to-ba,\n"
         rollups_path.write_text(broken)
         with self.assertRaises(ValueError):
             gtc.validate_outputs(self.output_dir)
 
 
 class UnresolvedTop108Tests(_GenerateConfigTestCase):
-
     def test_skipped_top108_logged_not_crashed(self):
         rc = self.run_main()
         self.assertEqual(rc, 0)
-        readme = (self.output_dir / 'README.md').read_text()
-        self.assertIn('Unresolved top-108 names', readme)
+        readme = (self.output_dir / "README.md").read_text()
+        self.assertIn("Unresolved top-108 names", readme)
         self.assertIn(GHOST_NAME, readme)
         # Resolved BAs match expected (excluded names + GHOST_NAME filtered out).
         included_ba = {ba for (ba, _) in self.get_included_set()}
@@ -612,34 +616,32 @@ class UnresolvedTop108Tests(_GenerateConfigTestCase):
 
 
 class ReadmeTests(_GenerateConfigTestCase):
-
     def test_readme_documents_gf_deviation(self):
         self.run_main()
-        readme = (self.output_dir / 'README.md').read_text()
-        self.assertIn('Deviation from notebook', readme)
-        self.assertIn('drop_growthforms', readme)
+        readme = (self.output_dir / "README.md").read_text()
+        self.assertIn("Deviation from notebook", readme)
+        self.assertIn("drop_growthforms", readme)
 
     def test_readme_lists_excluded_names(self):
         self.run_main()
-        readme = (self.output_dir / 'README.md').read_text()
-        self.assertIn('Excluded labels', readme)
-        for name in ('Dead coral', 'Bleached coral', 'Other invertebrates'):
+        readme = (self.output_dir / "README.md").read_text()
+        self.assertIn("Excluded labels", readme)
+        for name in ("Dead coral", "Bleached coral", "Other invertebrates"):
             self.assertIn(name, readme)
 
     def test_readme_lists_porites_buckets(self):
         self.run_main()
-        readme = (self.output_dir / 'README.md').read_text()
-        self.assertIn('Porites buckets', readme)
-        self.assertIn('Branching', readme)
-        self.assertIn('Massive', readme)
+        readme = (self.output_dir / "README.md").read_text()
+        self.assertIn("Porites buckets", readme)
+        self.assertIn("Branching", readme)
+        self.assertIn("Massive", readme)
 
 
 class NoNetworkTests(_GenerateConfigTestCase):
-
     def test_no_network_in_tests(self):
         rc = self.run_main()
         self.assertEqual(rc, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -1,4 +1,5 @@
 """Tests for scripts/release_artifact.py."""
+
 from __future__ import annotations
 
 import json
@@ -12,35 +13,34 @@ from botocore.exceptions import ClientError
 
 # Allow importing scripts/release_artifact.py (mirrors test_generate_training_config).
 REPO_ROOT = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(REPO_ROOT / 'scripts'))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import release_artifact as ra  # noqa: E402
 
 
 def _not_found_error():
-    return ClientError({'Error': {'Code': '404', 'Message': 'Not Found'}},
-                       'HeadObject')
+    return ClientError({"Error": {"Code": "404", "Message": "Not Found"}}, "HeadObject")
 
 
 class VersionValidationTest(unittest.TestCase):
     def test_accepts_vN(self):
-        ra.validate_version('v3')  # no raise
-        ra.validate_version('v0')
+        ra.validate_version("v3")  # no raise
+        ra.validate_version("v0")
 
     def test_rejects_bad_versions(self):
-        for bad in ('3', 'v', 'latest', 'v1.0', 'V3', 'v-1', ''):
+        for bad in ("3", "v", "latest", "v1.0", "V3", "v-1", ""):
             with self.assertRaises(ValueError, msg=bad):
                 ra.validate_version(bad)
 
 
 class ParseS3UriTest(unittest.TestCase):
     def test_parses_bucket_and_key(self):
-        bucket, key = ra.parse_s3_uri('s3://mermaid-config/classifier/efficientnet.pt')
-        self.assertEqual(bucket, 'mermaid-config')
-        self.assertEqual(key, 'classifier/efficientnet.pt')
+        bucket, key = ra.parse_s3_uri("s3://mermaid-config/classifier/efficientnet.pt")
+        self.assertEqual(bucket, "mermaid-config")
+        self.assertEqual(key, "classifier/efficientnet.pt")
 
     def test_rejects_non_s3(self):
-        for bad in ('https://x/y', '/local/path', 's3://', 'file.pt'):
+        for bad in ("https://x/y", "/local/path", "s3://", "file.pt"):
             with self.assertRaises(ValueError, msg=bad):
                 ra.parse_s3_uri(bad)
 
@@ -48,24 +48,26 @@ class ParseS3UriTest(unittest.TestCase):
 class ValidateArtifactTest(unittest.TestCase):
     def _export(self, tmp):
         """Export a real small artifact; return (model_pt, model_json)."""
-        from mermaid_classifier.pyspacer.inference import export_artifact
         from pyspacer._calibrated_model_fixture import make_calibrated_model
+
+        from mermaid_classifier.pyspacer.inference import export_artifact
+
         model, X = make_calibrated_model()
         model_pt, _manifest, _ = export_artifact(model, tmp, X)
-        return Path(model_pt), Path(tmp) / 'model.json'
+        return Path(model_pt), Path(tmp) / "model.json"
 
     def test_valid_artifact_returns_manifest(self):
         with tempfile.TemporaryDirectory() as tmp:
             model_pt, model_json = self._export(tmp)
             manifest = ra.validate_artifact(model_pt, model_json)
-            self.assertEqual(manifest['task'], 'pyspacer_mlp_classifier')
-            self.assertTrue(manifest['classes'])
+            self.assertEqual(manifest["task"], "pyspacer_mlp_classifier")
+            self.assertTrue(manifest["classes"])
 
     def test_rejects_wrong_task(self):
         with tempfile.TemporaryDirectory() as tmp:
             model_pt, model_json = self._export(tmp)
             m = json.loads(model_json.read_text())
-            m['task'] = 'something_else'
+            m["task"] = "something_else"
             model_json.write_text(json.dumps(m))
             with self.assertRaises(ValueError):
                 ra.validate_artifact(model_pt, model_json)
@@ -74,7 +76,7 @@ class ValidateArtifactTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             model_pt, model_json = self._export(tmp)
             m = json.loads(model_json.read_text())
-            del m['trained_with']
+            del m["trained_with"]
             model_json.write_text(json.dumps(m))
             with self.assertRaises(ValueError):
                 ra.validate_artifact(model_pt, model_json)
@@ -83,10 +85,11 @@ class ValidateArtifactTest(unittest.TestCase):
         # load_predictor probes the graph: a manifest claiming the wrong class
         # count must raise (ManifestError is a subclass-agnostic failure here).
         from mermaid_classifier.pyspacer.inference import ManifestError
+
         with tempfile.TemporaryDirectory() as tmp:
             model_pt, model_json = self._export(tmp)
             m = json.loads(model_json.read_text())
-            m['classes'] = m['classes'][:-1]  # drop one -> count mismatch
+            m["classes"] = m["classes"][:-1]  # drop one -> count mismatch
             model_json.write_text(json.dumps(m))
             with self.assertRaises(ManifestError):
                 ra.validate_artifact(model_pt, model_json)
@@ -96,55 +99,58 @@ class S3ExistsTest(unittest.TestCase):
     def test_true_when_head_succeeds(self):
         client = mock.Mock()
         client.head_object.return_value = {}
-        self.assertTrue(ra.s3_object_exists(client, 'b', 'k'))
+        self.assertTrue(ra.s3_object_exists(client, "b", "k"))
 
     def test_false_on_404(self):
         client = mock.Mock()
         client.head_object.side_effect = _not_found_error()
-        self.assertFalse(ra.s3_object_exists(client, 'b', 'k'))
+        self.assertFalse(ra.s3_object_exists(client, "b", "k"))
 
     def test_reraises_other_clienterror(self):
         client = mock.Mock()
         client.head_object.side_effect = ClientError(
-            {'Error': {'Code': 'AccessDenied'}}, 'HeadObject')
+            {"Error": {"Code": "AccessDenied"}}, "HeadObject"
+        )
         with self.assertRaises(ClientError):
-            ra.s3_object_exists(client, 'b', 'k')
+            ra.s3_object_exists(client, "b", "k")
 
 
 class AssembleLayoutTest(unittest.TestCase):
     def test_uploads_pair_and_copies_weights(self):
         client = mock.Mock()
         with tempfile.TemporaryDirectory() as tmp:
-            mp = Path(tmp) / 'model.pt'
-            mp.write_bytes(b'pt')
-            mj = Path(tmp) / 'model.json'
-            mj.write_text('{}')
+            mp = Path(tmp) / "model.pt"
+            mp.write_bytes(b"pt")
+            mj = Path(tmp) / "model.json"
+            mj.write_text("{}")
             uris = ra.assemble_s3_layout(
                 client,
-                dest_bucket='mermaid-config',
-                dest_prefix='classifier',
-                version='v7',
+                dest_bucket="mermaid-config",
+                dest_prefix="classifier",
+                version="v7",
                 model_pt=mp,
                 model_json=mj,
-                weights_uri='s3://mermaid-config/classifier/efficientnet.pt',
+                weights_uri="s3://mermaid-config/classifier/efficientnet.pt",
             )
 
-        self.assertEqual(uris, {
-            'model.pt': 's3://mermaid-config/classifier/v7/model.pt',
-            'model.json': 's3://mermaid-config/classifier/v7/model.json',
-            'efficientnet.pt': 's3://mermaid-config/classifier/v7/efficientnet.pt',
-        })
+        self.assertEqual(
+            uris,
+            {
+                "model.pt": "s3://mermaid-config/classifier/v7/model.pt",
+                "model.json": "s3://mermaid-config/classifier/v7/model.json",
+                "efficientnet.pt": "s3://mermaid-config/classifier/v7/efficientnet.pt",
+            },
+        )
         # model.pt + model.json uploaded by file.
-        uploaded_keys = {c.kwargs.get('Key') or c.args[2]
-                         for c in client.upload_file.call_args_list}
-        self.assertEqual(uploaded_keys,
-                         {'classifier/v7/model.pt', 'classifier/v7/model.json'})
+        uploaded_keys = {
+            c.kwargs.get("Key") or c.args[2] for c in client.upload_file.call_args_list
+        }
+        self.assertEqual(uploaded_keys, {"classifier/v7/model.pt", "classifier/v7/model.json"})
         # efficientnet.pt is a server-side copy from the weights source.
         client.copy_object.assert_called_once_with(
-            Bucket='mermaid-config',
-            Key='classifier/v7/efficientnet.pt',
-            CopySource={'Bucket': 'mermaid-config',
-                        'Key': 'classifier/efficientnet.pt'},
+            Bucket="mermaid-config",
+            Key="classifier/v7/efficientnet.pt",
+            CopySource={"Bucket": "mermaid-config", "Key": "classifier/efficientnet.pt"},
         )
 
     def test_cleans_up_already_written_objects_on_failure(self):
@@ -152,26 +158,25 @@ class AssembleLayoutTest(unittest.TestCase):
         # uploaded objects must be deleted so the partial prefix doesn't brick
         # reruns of this version, and the original error must propagate.
         client = mock.Mock()
-        client.copy_object.side_effect = RuntimeError('copy boom')
+        client.copy_object.side_effect = RuntimeError("copy boom")
         with tempfile.TemporaryDirectory() as tmp:
-            mp = Path(tmp) / 'model.pt'
-            mp.write_bytes(b'pt')
-            mj = Path(tmp) / 'model.json'
-            mj.write_text('{}')
+            mp = Path(tmp) / "model.pt"
+            mp.write_bytes(b"pt")
+            mj = Path(tmp) / "model.json"
+            mj.write_text("{}")
             with self.assertRaises(RuntimeError):
                 ra.assemble_s3_layout(
                     client,
-                    dest_bucket='mermaid-config',
-                    dest_prefix='classifier',
-                    version='v7',
+                    dest_bucket="mermaid-config",
+                    dest_prefix="classifier",
+                    version="v7",
                     model_pt=mp,
                     model_json=mj,
-                    weights_uri='s3://mermaid-config/classifier/efficientnet.pt',
+                    weights_uri="s3://mermaid-config/classifier/efficientnet.pt",
                 )
 
-        deleted_keys = {c.kwargs['Key'] for c in client.delete_object.call_args_list}
-        self.assertEqual(deleted_keys,
-                         {'classifier/v7/model.pt', 'classifier/v7/model.json'})
+        deleted_keys = {c.kwargs["Key"] for c in client.delete_object.call_args_list}
+        self.assertEqual(deleted_keys, {"classifier/v7/model.pt", "classifier/v7/model.json"})
 
 
 class MainTest(unittest.TestCase):
@@ -179,19 +184,22 @@ class MainTest(unittest.TestCase):
         # A real exported pair the fetch seam will "return".
         self._tmp = tempfile.TemporaryDirectory()
         tmp = Path(self._tmp.name)
-        from mermaid_classifier.pyspacer.inference import export_artifact
         from pyspacer._calibrated_model_fixture import make_calibrated_model
+
+        from mermaid_classifier.pyspacer.inference import export_artifact
+
         model, X = make_calibrated_model()
         model_pt, _m, _ = export_artifact(model, tmp, X)
-        self._pair = (Path(model_pt), tmp / 'model.json')
+        self._pair = (Path(model_pt), tmp / "model.json")
         self.addCleanup(self._tmp.cleanup)
 
     def _run(self, client, cwd):
-        argv = ['--mlflow-model-id', 'm-' + 'a' * 30, '--version', 'v9']
-        with mock.patch.object(ra.boto3, 'client', return_value=client), \
-             mock.patch.object(ra, 'resolve_classifier_artifact',
-                               return_value=self._pair), \
-             mock.patch.object(ra.Path, 'cwd', return_value=cwd):
+        argv = ["--mlflow-model-id", "m-" + "a" * 30, "--version", "v9"]
+        with (
+            mock.patch.object(ra.boto3, "client", return_value=client),
+            mock.patch.object(ra, "resolve_classifier_artifact", return_value=self._pair),
+            mock.patch.object(ra.Path, "cwd", return_value=cwd),
+        ):
             return ra.main(argv)
 
     def test_happy_path_uploads_and_emits(self):
@@ -204,23 +212,21 @@ class MainTest(unittest.TestCase):
             self.assertEqual(client.upload_file.call_count, 2)
             client.copy_object.assert_called_once()
             # Artifacts copied to CWD for the workflow to attach.
-            self.assertTrue((Path(cwd) / 'model.pt').is_file())
-            self.assertTrue((Path(cwd) / 'model.json').is_file())
+            self.assertTrue((Path(cwd) / "model.pt").is_file())
+            self.assertTrue((Path(cwd) / "model.json").is_file())
 
     def test_existing_version_fails_before_any_write(self):
         client = mock.Mock()
         # weights source exists (True), destination model.pt ALSO exists (True).
         client.head_object.side_effect = [{}, {}]
-        with tempfile.TemporaryDirectory() as cwd:
-            with self.assertRaises(SystemExit):
-                self._run(client, Path(cwd))
+        with tempfile.TemporaryDirectory() as cwd, self.assertRaises(SystemExit):
+            self._run(client, Path(cwd))
         client.upload_file.assert_not_called()
         client.copy_object.assert_not_called()
 
     def test_missing_weights_source_fails_before_any_write(self):
         client = mock.Mock()
         client.head_object.side_effect = [_not_found_error()]  # weights absent
-        with tempfile.TemporaryDirectory() as cwd:
-            with self.assertRaises(SystemExit):
-                self._run(client, Path(cwd))
+        with tempfile.TemporaryDirectory() as cwd, self.assertRaises(SystemExit):
+            self._run(client, Path(cwd))
         client.upload_file.assert_not_called()

--- a/tests/training/test_sample_weighting/fakes.py
+++ b/tests/training/test_sample_weighting/fakes.py
@@ -9,6 +9,7 @@ accessors are monkeypatched:
   - ``get_ancestor_ids(ba_id)``: list[str], root-first
   - ``GFLibrary.id_to_name`` / ``BALibrary.id_to_name``: id -> name.
 """
+
 from __future__ import annotations
 
 
@@ -61,15 +62,15 @@ class FakeGFLibrary:
 def small_tree() -> FakeBALibrary:
     """A small canonical tree used by several tests:
 
-        root (None)
-         |- A
-         |   |- A1
-         |   |- A2
-         |- B
-         |   |- B1
-         |- C   (single-child chain to test depth collapse)
-         |   |- C1
-         |       |- C1a
+    root (None)
+     |- A
+     |   |- A1
+     |   |- A2
+     |- B
+     |   |- B1
+     |- C   (single-child chain to test depth collapse)
+     |   |- C1
+     |       |- C1a
     """
     edges: list[tuple[str, str | None]] = [
         ("A", None),

--- a/tests/training/test_sample_weighting/test_effective_number.py
+++ b/tests/training/test_sample_weighting/test_effective_number.py
@@ -1,4 +1,5 @@
 """compute_class_weights unit tests (effective number of samples, Cui 2019)."""
+
 from __future__ import annotations
 
 import math
@@ -6,7 +7,8 @@ import unittest
 
 from mermaid_classifier.common.benthic_attributes import combine_ba_gf
 from mermaid_classifier.training.sample_weighting import (
-    SampleWeightingOptions, compute_class_weights,
+    SampleWeightingOptions,
+    compute_class_weights,
 )
 from mermaid_classifier.training.sample_weighting.effective_number import (
     BETA,
@@ -25,13 +27,11 @@ class EffectiveNumberTest(unittest.TestCase):
         w = self._run(counts)
 
         def expected(n):
-            en = (1.0 - BETA ** n) / (1.0 - BETA)
+            en = (1.0 - BETA**n) / (1.0 - BETA)
             return 1.0 / en
 
-        self.assertTrue(math.isclose(
-            w[combine_ba_gf("A1", "g1")], expected(100), rel_tol=1e-9))
-        self.assertTrue(math.isclose(
-            w[combine_ba_gf("A2", "g1")], expected(10), rel_tol=1e-9))
+        self.assertTrue(math.isclose(w[combine_ba_gf("A1", "g1")], expected(100), rel_tol=1e-9))
+        self.assertTrue(math.isclose(w[combine_ba_gf("A2", "g1")], expected(10), rel_tol=1e-9))
 
     def test_rare_class_outweighs_common(self):
         counts = {

--- a/tests/training/test_sample_weighting/test_invariants.py
+++ b/tests/training/test_sample_weighting/test_invariants.py
@@ -1,4 +1,5 @@
 """Invariants for compute_class_weights (effective-number weighting)."""
+
 from __future__ import annotations
 
 import math
@@ -36,8 +37,7 @@ class WeightInvariantsTest(unittest.TestCase):
     def test_no_zero_weights(self):
         weights = compute_class_weights(self.counts, SampleWeightingOptions())
         for label, w in weights.items():
-            self.assertGreater(
-                w, 0.0, f"weight for {label!r} is non-positive: {w!r}")
+            self.assertGreater(w, 0.0, f"weight for {label!r} is non-positive: {w!r}")
 
     def test_deterministic(self):
         opts = SampleWeightingOptions()
@@ -50,21 +50,18 @@ class WeightInvariantsTest(unittest.TestCase):
             )
 
     def test_disabled_returns_empty(self):
-        weights = compute_class_weights(
-            self.counts, SampleWeightingOptions(enabled=False))
+        weights = compute_class_weights(self.counts, SampleWeightingOptions(enabled=False))
         self.assertEqual(weights, {})
 
     def test_empty_counts_returns_empty(self):
-        self.assertEqual(
-            compute_class_weights({}, SampleWeightingOptions()), {})
+        self.assertEqual(compute_class_weights({}, SampleWeightingOptions()), {})
 
     def test_weight_ratio_cap_bounds_weight_spread(self):
         # weight_ratio_cap=R must ensure max/min <= R. Weights are
         # universally positive, so the cap applies to the full set.
         cap = 5.0
         tol = 1e-9
-        weights = compute_class_weights(
-            self.counts, SampleWeightingOptions(weight_ratio_cap=cap))
+        weights = compute_class_weights(self.counts, SampleWeightingOptions(weight_ratio_cap=cap))
         self.assertGreaterEqual(len(weights), 2)
         ws = list(weights.values())
         self.assertLessEqual(max(ws) / min(ws), cap + tol)

--- a/tests/training/test_sample_weighting/test_options.py
+++ b/tests/training/test_sample_weighting/test_options.py
@@ -1,4 +1,5 @@
 """SampleWeightingOptions validation tests."""
+
 from __future__ import annotations
 
 import unittest
@@ -34,8 +35,7 @@ class OptionsValidationTest(unittest.TestCase):
 
     def test_to_log_dict_includes_weight_ratio_cap_when_set(self):
         opts = SampleWeightingOptions(weight_ratio_cap=10.0)
-        self.assertEqual(
-            opts.to_log_dict()["weighting/weight_ratio_cap"], 10.0)
+        self.assertEqual(opts.to_log_dict()["weighting/weight_ratio_cap"], 10.0)
 
 
 if __name__ == "__main__":

--- a/tests/training/test_sample_weighting/test_torch_classifier_integration.py
+++ b/tests/training/test_sample_weighting/test_torch_classifier_integration.py
@@ -8,6 +8,7 @@ These verify that:
     bit-for-bit (regression guard for "off by default = no behavior change").
   - A class assigned weight=0 has its gradient signal nulled.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -33,8 +34,7 @@ def _make_imbalanced_dataset(seed: int = 0):
 class TorchClassifierWeightTest(unittest.TestCase):
     def test_default_no_class_weight(self):
         X, y = _make_imbalanced_dataset(seed=1)
-        clf = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), max_iter=3, random_state=0)
+        clf = TorchMLPClassifier(hidden_layer_sizes=(8,), max_iter=3, random_state=0)
         clf.fit(X, y)
         # No class_weight → tensor is None.
         self.assertIsNone(clf._class_weight_tensor)
@@ -42,15 +42,16 @@ class TorchClassifierWeightTest(unittest.TestCase):
     def test_class_weight_tensor_in_classes_order(self):
         X, y = _make_imbalanced_dataset(seed=2)
         clf = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), max_iter=2, random_state=0,
+            hidden_layer_sizes=(8,),
+            max_iter=2,
+            random_state=0,
             class_weight={"a": 1.0, "b": 5.0, "c": 25.0},
         )
         clf.fit(X, y)
         self.assertIsNotNone(clf._class_weight_tensor)
         # classes_ is sorted alphabetically -> ["a", "b", "c"]
         self.assertEqual(list(clf.classes_), ["a", "b", "c"])
-        np.testing.assert_allclose(
-            clf._class_weight_tensor.numpy(), [1.0, 5.0, 25.0])
+        np.testing.assert_allclose(clf._class_weight_tensor.numpy(), [1.0, 5.0, 25.0])
 
     def test_weighted_vs_unweighted_loss_differs(self):
         # On imbalanced data, applying inverse-frequency-style weights
@@ -59,17 +60,17 @@ class TorchClassifierWeightTest(unittest.TestCase):
         # Larger weights on rare classes.
         weights = {"a": 1.0, "b": 2.0, "c": 20.0}
 
-        baseline = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), max_iter=5, random_state=42)
+        baseline = TorchMLPClassifier(hidden_layer_sizes=(8,), max_iter=5, random_state=42)
         baseline.fit(X, y)
 
         weighted = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), max_iter=5, random_state=42,
-            class_weight=weights)
+            hidden_layer_sizes=(8,), max_iter=5, random_state=42, class_weight=weights
+        )
         weighted.fit(X, y)
 
         self.assertNotAlmostEqual(
-            baseline.loss_curve_[-1], weighted.loss_curve_[-1],
+            baseline.loss_curve_[-1],
+            weighted.loss_curve_[-1],
             places=5,
         )
 
@@ -84,20 +85,23 @@ class TorchClassifierWeightTest(unittest.TestCase):
 
         weights = {"a": 1.0, "b": 1.0, "c": 0.0}
         clf = TorchMLPClassifier(
-            hidden_layer_sizes=(8,), max_iter=10, random_state=42,
+            hidden_layer_sizes=(8,),
+            max_iter=10,
+            random_state=42,
             class_weight=weights,
         )
         clf.fit(X, y)
         # The class 'c' index in classes_:
         c_idx = list(clf.classes_).index("c")
         # weight tensor entry for 'c' must be exactly zero.
-        self.assertEqual(
-            float(clf._class_weight_tensor[c_idx]), 0.0)
+        self.assertEqual(float(clf._class_weight_tensor[c_idx]), 0.0)
 
     def test_missing_weight_for_class_raises(self):
         X, y = _make_imbalanced_dataset(seed=5)
         clf = TorchMLPClassifier(
-            hidden_layer_sizes=(4,), max_iter=1, random_state=0,
+            hidden_layer_sizes=(4,),
+            max_iter=1,
+            random_state=0,
             class_weight={"a": 1.0, "b": 1.0},  # missing 'c'
         )
         with self.assertRaisesRegex(ValueError, "class_weight is missing"):
@@ -106,7 +110,9 @@ class TorchClassifierWeightTest(unittest.TestCase):
     def test_negative_weight_rejected(self):
         X, y = _make_imbalanced_dataset(seed=6)
         clf = TorchMLPClassifier(
-            hidden_layer_sizes=(4,), max_iter=1, random_state=0,
+            hidden_layer_sizes=(4,),
+            max_iter=1,
+            random_state=0,
             class_weight={"a": 1.0, "b": -2.0, "c": 1.0},
         )
         with self.assertRaisesRegex(ValueError, "negative"):
@@ -118,20 +124,16 @@ class TorchClassifierWeightTest(unittest.TestCase):
         # detect any silent regression by re-implementing the unweighted
         # CE inline and comparing on a single batch.
         X, y = _make_imbalanced_dataset(seed=7)
-        clf = TorchMLPClassifier(
-            hidden_layer_sizes=(4,), max_iter=1, random_state=0)
+        clf = TorchMLPClassifier(hidden_layer_sizes=(4,), max_iter=1, random_state=0)
         clf.fit(X[:20], y[:20])  # just to set up classes_ and module
         # Forward a batch and compare CE with weight=None vs no kwarg.
         clf._module.eval()
         with torch.no_grad():
             x_t = torch.from_numpy(X[:20].astype(np.float32))
-            y_idx = torch.from_numpy(
-                np.searchsorted(clf.classes_, y[:20]).astype(np.int64))
+            y_idx = torch.from_numpy(np.searchsorted(clf.classes_, y[:20]).astype(np.int64))
             logits = clf._module(x_t)
-            ce_kwarg = torch.nn.functional.cross_entropy(
-                logits, y_idx, weight=None)
-            ce_no_kwarg = torch.nn.functional.cross_entropy(
-                logits, y_idx)
+            ce_kwarg = torch.nn.functional.cross_entropy(logits, y_idx, weight=None)
+            ce_no_kwarg = torch.nn.functional.cross_entropy(logits, y_idx)
         self.assertTrue(torch.equal(ce_kwarg, ce_no_kwarg))
 
 

--- a/tests/training/test_sample_weighting/test_trainer_pipeline.py
+++ b/tests/training/test_sample_weighting/test_trainer_pipeline.py
@@ -7,6 +7,7 @@ monkeypatching the module globals in train.py with fakes — those real
 classes hit the MERMAID API on construction, which is unsuitable for
 unit tests.
 """
+
 from __future__ import annotations
 
 import types
@@ -20,7 +21,8 @@ from mermaid_classifier.training.sample_weighting import (
 )
 
 from .fakes import (
-    FakeGFLibrary, small_tree,
+    FakeGFLibrary,
+    small_tree,
 )
 
 
@@ -42,13 +44,15 @@ class TrainerPipelineTest(unittest.TestCase):
     def setUpClass(cls):
         # Import train.py with the MERMAID API singletons patched out.
         # This avoids any network call at import time.
-        with mock.patch(
-            "mermaid_classifier.common.benthic_attributes."
-            "BenthicAttributeLibrary",
-            return_value=small_tree(),
-        ), mock.patch(
-            "mermaid_classifier.common.benthic_attributes.GrowthFormLibrary",
-            return_value=FakeGFLibrary({"g1": "GF1", "g2": "GF2"}),
+        with (
+            mock.patch(
+                "mermaid_classifier.common.benthic_attributes.BenthicAttributeLibrary",
+                return_value=small_tree(),
+            ),
+            mock.patch(
+                "mermaid_classifier.common.benthic_attributes.GrowthFormLibrary",
+                return_value=FakeGFLibrary({"g1": "GF1", "g2": "GF2"}),
+            ),
         ):
             from mermaid_classifier.pyspacer import train as train_mod
         cls.train_mod = train_mod
@@ -61,12 +65,8 @@ class TrainerPipelineTest(unittest.TestCase):
         fake_ba = small_tree()
         fake_gf = FakeGFLibrary({"g1": "GF1", "g2": "GF2"})
         self._patches = [
-            mock.patch.object(
-                self.train_mod, "get_benthic_attribute_library",
-                lambda: fake_ba),
-            mock.patch.object(
-                self.train_mod, "get_growth_form_library",
-                lambda: fake_gf),
+            mock.patch.object(self.train_mod, "get_benthic_attribute_library", lambda: fake_ba),
+            mock.patch.object(self.train_mod, "get_growth_form_library", lambda: fake_gf),
         ]
         for p in self._patches:
             p.start()
@@ -90,8 +90,7 @@ class TrainerPipelineTest(unittest.TestCase):
         self.assertEqual(log, {"enabled": False})
 
     def test_weighting_disabled_skips_computation(self):
-        runner = self._make_runner(
-            weighting=SampleWeightingOptions(enabled=False))
+        runner = self._make_runner(weighting=SampleWeightingOptions(enabled=False))
         labels = _fake_labels({combine_ba_gf("A1", "g1"): 100})
         weights, log = runner._compute_class_weights(labels)
         self.assertIsNone(weights)
@@ -110,8 +109,7 @@ class TrainerPipelineTest(unittest.TestCase):
         self.assertIsNotNone(weights)
         self.assertEqual(set(weights), set(counts))
         for label, w in weights.items():
-            self.assertGreater(
-                w, 0.0, f"weight for {label!r} should be positive")
+            self.assertGreater(w, 0.0, f"weight for {label!r} should be positive")
         self.assertTrue(log["enabled"])
 
     def test_log_structure_contains_required_summary_keys(self):
@@ -124,8 +122,12 @@ class TrainerPipelineTest(unittest.TestCase):
         self.assertIn("per_class_df", log)
         self.assertIn("summary", log)
         for key in (
-            "weight_mean", "weight_median", "weight_p5", "weight_p95",
-            "weight_max_min_ratio", "n_classes",
+            "weight_mean",
+            "weight_median",
+            "weight_p5",
+            "weight_p95",
+            "weight_max_min_ratio",
+            "n_classes",
         ):
             self.assertIn(key, log["summary"])
         # Per-class DataFrame no longer carries a rare_action column —

--- a/tests/training/test_subsample/test_options.py
+++ b/tests/training/test_subsample/test_options.py
@@ -1,4 +1,5 @@
 """SubsampleOptions validation + to_log_dict tests."""
+
 from __future__ import annotations
 
 import unittest

--- a/tests/training/test_subsample/test_registry.py
+++ b/tests/training/test_subsample/test_registry.py
@@ -1,4 +1,5 @@
 """compute_per_class_targets allocator behavior tests."""
+
 from __future__ import annotations
 
 import unittest
@@ -66,8 +67,7 @@ class StratifiedTest(unittest.TestCase):
         targets = compute_per_class_targets(opts, counts)
         self.assertEqual(len(targets), 5)
         for cls, t in targets.items():
-            self.assertGreaterEqual(
-                t, 10, f"{cls} trimmed below min_per_class floor")
+            self.assertGreaterEqual(t, 10, f"{cls} trimmed below min_per_class floor")
 
     def test_overshoot_trims_largest_class(self):
         # Three equal-size classes, budget=100. Naive rounding gives

--- a/tests/training/test_subsample/test_subsample_in_duckdb.py
+++ b/tests/training/test_subsample/test_subsample_in_duckdb.py
@@ -10,6 +10,7 @@ without spinning up the full TrainingDataset pipeline, so it stays fast
 and self-contained. If the SQL in train.py changes, mirror the update
 here.
 """
+
 from __future__ import annotations
 
 import unittest
@@ -30,7 +31,6 @@ def _build_synthetic_annotations(seed: int = 0) -> pd.DataFrame:
     Each row gets a unique (site, project_id, image_id, row, col) tuple
     so the deterministic ORDER BY produces a stable order.
     """
-    rng = pd.Series(range(1000), name="i")
     # Skewed distribution: class 0 has 500 rows, class 1 has 200,
     # class 2 has 100, classes 3-9 split the rest.
     weights = [500, 200, 100, 50, 50, 30, 30, 20, 10, 10]
@@ -39,32 +39,31 @@ def _build_synthetic_annotations(seed: int = 0) -> pd.DataFrame:
     idx = 0
     for cls_i, w in enumerate(weights):
         for j in range(w):
-            rows.append({
-                "site": "coralnet",
-                "project_id": "p1",
-                "image_id": f"img_{idx:05d}",
-                "row": j,
-                "col": j,
-                "benthic_attribute_id": f"ba_{cls_i:02d}",
-                "growth_form_id": f"gf_{cls_i:02d}",
-                "feature_vector": f"feat_{idx}",
-            })
+            rows.append(
+                {
+                    "site": "coralnet",
+                    "project_id": "p1",
+                    "image_id": f"img_{idx:05d}",
+                    "row": j,
+                    "col": j,
+                    "benthic_attribute_id": f"ba_{cls_i:02d}",
+                    "growth_form_id": f"gf_{cls_i:02d}",
+                    "feature_vector": f"feat_{idx}",
+                }
+            )
             idx += 1
     df = pd.DataFrame(rows)
     # Shuffle so the natural row order is NOT the deterministic one.
     return df.sample(frac=1, random_state=seed).reset_index(drop=True)
 
 
-def _apply_sql(conn: duckdb.DuckDBPyConnection,
-               annotations: pd.DataFrame,
-               targets: dict[tuple[str, str], int]) -> set[str]:
+def _apply_sql(
+    conn: duckdb.DuckDBPyConnection, annotations: pd.DataFrame, targets: dict[tuple[str, str], int]
+) -> set[str]:
     """Apply the same SQL as TrainingDataset._apply_subsample and
     return the set of surviving image_ids."""
     conn.register("_input_annotations", annotations)
-    conn.execute(
-        "CREATE OR REPLACE TABLE annotations AS"
-        " SELECT * FROM _input_annotations"
-    )
+    conn.execute("CREATE OR REPLACE TABLE annotations AS SELECT * FROM _input_annotations")
     targets_df = pd.DataFrame(
         [
             {
@@ -103,12 +102,11 @@ class SubsampleSqlDeterminismTest(unittest.TestCase):
     def setUp(self):
         self.annotations = _build_synthetic_annotations()
         opts = SubsampleOptions(
-            strategy="stratified", total_annotations=200,
+            strategy="stratified",
+            total_annotations=200,
         )
         counts = (
-            self.annotations.groupby(
-                ["benthic_attribute_id", "growth_form_id"]
-            ).size().to_dict()
+            self.annotations.groupby(["benthic_attribute_id", "growth_form_id"]).size().to_dict()
         )
         self.targets = compute_per_class_targets(opts, counts)
 
@@ -123,10 +121,8 @@ class SubsampleSqlDeterminismTest(unittest.TestCase):
     def test_two_connections_select_identical_rows(self):
         # Same input, different connections, different thread counts.
         # If the SQL is non-deterministic, these sets will diverge.
-        rows_a = _apply_sql(self._new_conn(threads=1), self.annotations,
-                            self.targets)
-        rows_b = _apply_sql(self._new_conn(threads=4), self.annotations,
-                            self.targets)
+        rows_a = _apply_sql(self._new_conn(threads=1), self.annotations, self.targets)
+        rows_b = _apply_sql(self._new_conn(threads=4), self.annotations, self.targets)
         self.assertEqual(rows_a, rows_b)
 
     def test_repeated_run_in_same_connection_is_stable(self):
@@ -152,12 +148,11 @@ class SubsampleSqlDeterminismTest(unittest.TestCase):
         # per-class budget of 40. Classes smaller than 40 are kept in
         # full (not oversampled); larger classes are capped at 40.
         opts = SubsampleOptions(
-            strategy="balanced", total_annotations=400,
+            strategy="balanced",
+            total_annotations=400,
         )
         counts = (
-            self.annotations.groupby(
-                ["benthic_attribute_id", "growth_form_id"]
-            ).size().to_dict()
+            self.annotations.groupby(["benthic_attribute_id", "growth_form_id"]).size().to_dict()
         )
         targets = compute_per_class_targets(opts, counts)
         conn = self._new_conn(threads=2)
@@ -165,14 +160,12 @@ class SubsampleSqlDeterminismTest(unittest.TestCase):
         # Class 9 only has 10 rows; balanced should NOT produce more
         # than 10 surviving rows for it.
         n_class_9 = conn.execute(
-            "SELECT COUNT(*) FROM annotations"
-            " WHERE benthic_attribute_id = 'ba_09'"
+            "SELECT COUNT(*) FROM annotations WHERE benthic_attribute_id = 'ba_09'"
         ).fetchone()[0]
         self.assertEqual(n_class_9, 10)
         # Common class capped at 40.
         n_class_0 = conn.execute(
-            "SELECT COUNT(*) FROM annotations"
-            " WHERE benthic_attribute_id = 'ba_00'"
+            "SELECT COUNT(*) FROM annotations WHERE benthic_attribute_id = 'ba_00'"
         ).fetchone()[0]
         self.assertEqual(n_class_0, 40)
         # Sanity: total survivors equal target sum.

--- a/uv.lock
+++ b/uv.lock
@@ -162,6 +162,18 @@ wheels = [
 ]
 
 [[package]]
+name = "basedpyright"
+version = "1.39.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/62/8550c75850b2185df984d1de437b4805b039ba856cacbee2966236203133/basedpyright-1.39.8.tar.gz", hash = "sha256:bb1a86d4d71425d52d1501b317fe23d45527baed06bd5d5e1a07cd4b60d07b55", size = 25488230, upload-time = "2026-06-14T09:05:30.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/94/878454aefe94328ba7ad808ecd63da8311aae1198da46cfb29f5cfe130a8/basedpyright-1.39.8-py3-none-any.whl", hash = "sha256:a79d89928064bd9023d429b50c625d87d023bacc2fe3932ef6c7bd13b5426048", size = 13182726, upload-time = "2026-06-14T09:05:26.368Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1656,6 +1668,12 @@ training = [
     { name = "torchvision", version = "0.23.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.14' and sys_platform == 'linux') or (platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')" },
 ]
 
+[package.dev-dependencies]
+lint = [
+    { name = "basedpyright" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'training'" },
@@ -1687,6 +1705,10 @@ requires-dist = [
 provides-extras = ["inference", "training", "jupyterlab", "sagemaker"]
 
 [package.metadata.requires-dev]
+lint = [
+    { name = "basedpyright" },
+    { name = "ruff" },
+]
 sagemaker = []
 
 [[package]]
@@ -1883,6 +1905,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
 ]
 
 [[package]]
@@ -2843,6 +2881,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/dc/35b341fc554ba02f217fc10da57d1a75168cfbcf75b0ef2202176d4c4f2d/ruff-0.15.20.tar.gz", hash = "sha256:1416eb04349192646b54de98f146c4f59afe37d0decfc02c3cbbf396f3a28566", size = 4755489, upload-time = "2026-06-25T17:20:37.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/d9/2d5014f0253ba541d2061d9fa7193f48e941c8b21bb88a7ff9bbe0bd0596/ruff-0.15.20-py3-none-linux_armv6l.whl", hash = "sha256:00e188c53e499c3c1637f73c91dcf2fb56d576cab76ce1be50a27c4e80e37078", size = 10839665, upload-time = "2026-06-25T17:19:44.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/d3/ac1798ba64f670698867fcfc591d50e7e421bef137db564858f619a30fcf/ruff-0.15.20-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9ebd1fd9b9c95fc0bd7b2761aebec1f030013d2e193a2901b224af68fe47251b", size = 11208649, upload-time = "2026-06-25T17:19:48.787Z" },
+    { url = "https://files.pythonhosted.org/packages/47/47/d3ac899991202095dfcf3d5176be4272642be3cf981a2f1a30f72a2afb95/ruff-0.15.20-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5b16cdd67ca108185cd36dce98c576350c03b1660a751de725fb049193a0632", size = 10622638, upload-time = "2026-06-25T17:19:51.354Z" },
+    { url = "https://files.pythonhosted.org/packages/33/13/4e043fe30aa94d4ff5213a9881fc296d12960f5971b234a5263fdc225312/ruff-0.15.20-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3413bb3c3d2ca6a8208f1f4809cd2dca3c6de6d0b491c0e70847672bde6e6efd", size = 10984227, upload-time = "2026-06-25T17:19:54.044Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e6/92e7bf40388bc5800073b96564f56264f7e48bfd1a498f5ced6ae6d5a769/ruff-0.15.20-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bd7ec42b3bb3da066488db093308a69c4ac5ee6d2af333a86ba6e2eb2e7dd44b", size = 10622882, upload-time = "2026-06-25T17:19:57.037Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7a/43460be3f24495a3aa46d4b16873e2c4941b3b5f0b00cf88c03b7b94b339/ruff-0.15.20-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e1a36ad0eb77fba9aabfb69ede54de6f376d04ac18ebea022847046d340a8267", size = 11474808, upload-time = "2026-06-25T17:20:00.357Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a0/f37077884873221c6b33b4ab49eb18f9f88e54a16a25a5bca59bef46dd66/ruff-0.15.20-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b6df3b1e4610432f0386dba04d853b5f08cbbc903410c6fcc02f620f05aff53c", size = 12293094, upload-time = "2026-06-25T17:20:03.446Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/74/165545b60256a9704c21ac0ec4a0d07933b320812f9584836c9f4aca4292/ruff-0.15.20-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e89f198a1ea6ef0d727c1cf16088bc91a6cb0ab947dedc966715691647186eae", size = 11526176, upload-time = "2026-06-25T17:20:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/86/b1/a976a136d40ade83ce743578399865f57001003a409acadc0ecbb3051082/ruff-0.15.20-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:309809086c2acb67624950a3c8133e80f32d0d3e27106c0cd60ff26657c9f24b", size = 11520767, upload-time = "2026-06-25T17:20:09.191Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/f032696cb01c9b54c0263fa393474d7758f1cdc021a01b04e3cbc2500999/ruff-0.15.20-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:2d2374caa2f2c2f9e2b7da0a50802cfb8b79f55a9b5e49379f564544fbf56487", size = 11500132, upload-time = "2026-06-25T17:20:13.602Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f4/51b1a14bc69e8c224b15dab9cce8e99b425e0455d462caa2b3c9be2b6a8e/ruff-0.15.20-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a1ed17b65293e0c2f22fc387bc13198a5de94bf4429589b0ff6946b0feaf21a3", size = 10943828, upload-time = "2026-06-25T17:20:16.635Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4b/fe267640783cd02bf6c5cc290b1df1051be2ec294c678b5c15fe19e52343/ruff-0.15.20-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:f701305e66b38ea6c91882490eb73459796808e4c6362a1b765255e0cdcd4053", size = 10645418, upload-time = "2026-06-25T17:20:19.4Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c0/a65aa4ec2f5e87a1df32dc3ec1fede434fe3dfd5cbcf3b503cafc676ab54/ruff-0.15.20-py3-none-musllinux_1_2_i686.whl", hash = "sha256:5b9c0c367ad8e5d0d5b5b8537864c469a0a0e55417aadfbeca41fa61333be9f4", size = 11211770, upload-time = "2026-06-25T17:20:22.033Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/0caa331d954ae2723d729d351c989cb4ca8b6077d5c6c2cb6de75e98c041/ruff-0.15.20-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:01cc00dd58f0df339d0e902219dd53990ea99996a0344e5d9cc8d45d5307e460", size = 11618698, upload-time = "2026-06-25T17:20:25.259Z" },
+    { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #67.

Makes Ruff (format + lint) and basedpyright a CI-enforced contract across the repo, and brings the existing code to green. No pre-commit hooks — a forgotten local check just fails the PR.

## What changed

- **`build:`** Added `[tool.ruff]` + `[tool.basedpyright]` config and a `lint` dependency group (`ruff`, `basedpyright`) to `pyproject.toml`. Ruff config mirrors `mermaid-segmentation` for workspace consistency (`line-length=100`, `target-version=py312`, `select=["E","F","I","UP","B","C4","RET","SIM","PD"]`, double quotes).
- **`style:`** `ruff format` + `ruff check --fix` across the whole repo (excl. `v1/`); `.ruff_cache/` added to `.gitignore`.
- **`types:`** Annotated `mermaid_classifier/` + `scripts/` to pass basedpyright. **5 latent bugs surfaced and fixed** (possibly-unbound var, a signature/return mismatch, an unguarded `None` passed to `urlopen`, an impossible `None` comparison, and an unsafe pre-`run()` access).
- **`ci:`** New `.github/workflows/lint.yml` PR gate: `uv lock --check`, `ruff check`, `ruff format --check`, `basedpyright` (installs real deps so pyright can resolve torch/pyspacer/duckdb/mlflow imports).
- **`docs:`** Documented the contract in `README.md` under "For developers". (`CLAUDE.md` is gitignored, so it's updated locally only, not committed.)

## Typing scope — "pragmatic strict"

basedpyright runs **strict** over `mermaid_classifier/` + `scripts/`, with one deliberate relaxation: the untyped-third-party-dependency "unknown type" rules (`reportUnknownMemberType`/`VariableType`/`ArgumentType`/`LambdaType`) are disabled, because torch/pyspacer/duckdb/mlflow/sklearn ship no type stubs. Enforcing them would mean ~1,400 noise-only `# pyright: ignore` comments burying the real findings.

The full picture: of the 1,958 errors strict surfaced, ~82% were that untyped-dep leakage. Disabling the leakage family left ~540 valuable errors (None-safety, argument/return mismatches, unannotated own-function signatures, etc.), all fixed in code. **Own-signature annotation requirements and every real-bug rule remain ON.** `tests/` are linted/formatted but not type-checked; `v1/` is excluded entirely. See `[tool.basedpyright]` in `pyproject.toml`.

## Verification

All gates pass on HEAD; the unittest suite is **unchanged** (this is tooling, not refactoring):

- `uv lock --check` ✅
- `uv run --no-sync ruff check .` ✅
- `uv run --no-sync ruff format --check .` ✅
- `uv run --no-sync basedpyright` → **0 errors** (1 pre-existing warning: tqdm missing module source)
- `python -m unittest` → **352 OK, 2 skipped** (same as base)

The 72 inline suppressions are all rule-scoped with reasons; none silence a kept rule wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)