### PR TITLE
test: characterization & unit safety net for train.py pipeline, duckdb_utils, csv_utils, metrics coordinator (#72)

### DIFF
--- a/tests/common/test_csv_utils.py
+++ b/tests/common/test_csv_utils.py
@@ -1,0 +1,118 @@
+"""Characterization unit tests for common/csv_utils.py (CsvSpec / ColumnSpec).
+
+Uses a minimal concrete subclass defined in this module. All tests assert
+exact observed behavior — these are characterization tests intended to guard
+refactoring in issues #73 and #74.
+"""
+
+import unittest
+from io import StringIO
+
+from mermaid_classifier.common.csv_utils import ColumnSpec, CsvSpec
+
+
+class _Spec(CsvSpec):
+    """Minimal concrete subclass for testing CsvSpec."""
+
+    column_specs = [
+        ColumnSpec(name="id", allow_blank=False),
+        ColumnSpec(name=["gf", "growth_form"]),
+    ]
+
+    def __init__(self, csv_file):
+        self.rows: list[dict] = []
+        super().__init__(csv_file=csv_file)
+
+    def per_row_init_action(self, row: dict) -> None:
+        self.rows.append(row)
+
+
+class HappyPathTest(unittest.TestCase):
+    """Normal CSV input: per_row_init_action is called once per row."""
+
+    def test_two_rows_both_collected(self):
+        spec = _Spec(StringIO("id,gf\n1,Branching\n2,Massive\n"))
+        self.assertEqual(len(spec.rows), 2)
+
+    def test_row_dict_contains_expected_keys(self):
+        spec = _Spec(StringIO("id,gf\n42,Encrusting\n"))
+        self.assertEqual(spec.rows[0]["id"], 42)
+        self.assertEqual(spec.rows[0]["gf"], "Encrusting")
+
+
+class EmptyToNoneTest(unittest.TestCase):
+    """Empty CSV cells are normalised to None by the base class."""
+
+    def test_empty_gf_cell_is_none(self):
+        """An empty gf cell should arrive as None in per_row_init_action."""
+        spec = _Spec(StringIO("id,gf\n99,\n"))
+        self.assertIsNone(spec.rows[0]["gf"], msg="Blank gf cell should become None")
+
+    def test_non_empty_value_is_not_none(self):
+        spec = _Spec(StringIO("id,gf\n1,Branching\n"))
+        self.assertIsNotNone(spec.rows[0]["gf"])
+
+
+class AlternateColumnNamesTest(unittest.TestCase):
+    """ColumnSpec with name list resolves to the first matching header."""
+
+    def test_growth_form_header_accepted_in_place_of_gf(self):
+        """When header has 'growth_form' instead of 'gf', the spec resolves correctly."""
+        spec = _Spec(StringIO("id,growth_form\n1,Branching\n"))
+        # No exception, and one row collected.
+        self.assertEqual(len(spec.rows), 1)
+
+    def test_value_accessible_under_actual_header_key(self):
+        """The dict key in per_row_init_action uses the actual header name found."""
+        spec = _Spec(StringIO("id,growth_form\n1,Branching\n"))
+        # Header was 'growth_form', so the key is 'growth_form', not 'gf'.
+        self.assertIn("growth_form", spec.rows[0])
+        self.assertEqual(spec.rows[0]["growth_form"], "Branching")
+
+    def test_primary_column_name_still_used_when_present(self):
+        """If 'gf' is in the header, the key is 'gf'."""
+        spec = _Spec(StringIO("id,gf\n1,Massive\n"))
+        self.assertIn("gf", spec.rows[0])
+        self.assertEqual(spec.rows[0]["gf"], "Massive")
+
+
+class MissingRequiredColumnTest(unittest.TestCase):
+    """A CSV missing a required column raises ValueError."""
+
+    def test_missing_id_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            _Spec(StringIO("name,gf\nfoo,Branching\n"))
+
+    def test_missing_all_alternate_names_raises_value_error(self):
+        """If neither 'gf' nor 'growth_form' is present, ValueError is raised."""
+        with self.assertRaises(ValueError):
+            _Spec(StringIO("id,something_else\n1,x\n"))
+
+
+class EmptyFileTest(unittest.TestCase):
+    """An empty or header-only CSV produces no rows and no exception."""
+
+    def test_header_only_no_rows_collected(self):
+        spec = _Spec(StringIO("id,gf\n"))
+        self.assertEqual(spec.rows, [], msg="per_row_init_action should not be called")
+
+    def test_header_only_dataframe_is_empty(self):
+        spec = _Spec(StringIO("id,gf\n"))
+        self.assertTrue(spec.csv_dataframe.empty)
+
+    def test_completely_empty_file_no_rows(self):
+        """Completely empty CSV (no content at all) — no exception, no rows."""
+        spec = _Spec(StringIO(""))
+        self.assertEqual(spec.rows, [])
+        self.assertTrue(spec.csv_dataframe.empty)
+
+    def test_no_exception_on_empty_file(self):
+        """Empty file must not raise."""
+        try:
+            _Spec(StringIO(""))
+        except Exception as exc:
+            self.fail(f"Unexpected exception on empty file: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/common/test_duckdb_utils.py
+++ b/tests/common/test_duckdb_utils.py
@@ -1,0 +1,363 @@
+"""Characterization unit tests for common/duckdb_utils.py.
+
+Each TestCase covers one public function. All tests use in-memory DuckDB
+connections and assert exact observed behavior — these are characterization
+tests intended to guard refactoring in issues #73 and #74.
+"""
+
+import unittest
+
+import duckdb
+import pandas as pd
+
+from mermaid_classifier.common.duckdb_utils import (
+    duckdb_add_column,
+    duckdb_batched_rows,
+    duckdb_filter_on_column,
+    duckdb_grouped_rows,
+    duckdb_replace_column,
+    duckdb_temp_table_name,
+    duckdb_transform_column,
+)
+
+
+def _make_conn() -> duckdb.DuckDBPyConnection:
+    return duckdb.connect()
+
+
+class TempTableNameTest(unittest.TestCase):
+    """Tests for duckdb_temp_table_name."""
+
+    def test_yields_temp_prefixed_name_with_no_base(self):
+        conn = _make_conn()
+        with duckdb_temp_table_name(conn) as name:
+            self.assertTrue(name.startswith("temp_"), msg=f"Expected temp_ prefix, got {name!r}")
+
+    def test_yields_deterministic_name_with_base_name(self):
+        conn = _make_conn()
+        with duckdb_temp_table_name(conn, base_name="foo") as name:
+            self.assertEqual(name, "temp_foo")
+
+    def test_table_is_dropped_after_context_exits(self):
+        conn = _make_conn()
+        captured_name = None
+        with duckdb_temp_table_name(conn) as name:
+            captured_name = name
+            # Create the table inside the context.
+            conn.execute(f"CREATE TABLE {name} (x INTEGER)")
+            # Verify it exists.
+            result = conn.execute(
+                f"SELECT count(*) FROM information_schema.tables WHERE table_name = '{name}'"
+            ).fetchone()[0]
+            self.assertEqual(result, 1)
+
+        # After exit, the table should no longer exist.
+        result = conn.execute(
+            f"SELECT count(*) FROM information_schema.tables WHERE table_name = '{captured_name}'"
+        ).fetchone()[0]
+        self.assertEqual(result, 0, msg="Table should be dropped after context manager exits")
+
+    def test_table_dropped_even_if_never_created(self):
+        """No-op DROP IF EXISTS — should not raise if table was never created."""
+        conn = _make_conn()
+        with duckdb_temp_table_name(conn, base_name="never_created") as name:
+            self.assertEqual(name, "temp_never_created")
+        # If we get here, no exception was raised.
+
+
+class ReplaceColumnTest(unittest.TestCase):
+    """Tests for duckdb_replace_column."""
+
+    def test_old_column_replaced_by_new_column(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"k": ["a", "b"], "new_k": ["A", "B"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_replace_column(conn, "t", column_name="k", new_values_column_name="new_k")
+
+        cols = [row[0] for row in conn.execute("DESCRIBE t").fetchall()]
+        self.assertIn("k", cols, msg="Renamed column should be called 'k'")
+        self.assertNotIn("new_k", cols, msg="Original new_k column should be gone")
+
+        values = sorted(row[0] for row in conn.execute("SELECT k FROM t").fetchall())
+        self.assertEqual(values, ["A", "B"], msg="Column should hold the new values")
+
+    def test_original_column_name_is_reused(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"x": [1, 2, 3], "y": [10, 20, 30]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_replace_column(conn, "t", column_name="x", new_values_column_name="y")
+
+        cols = [row[0] for row in conn.execute("DESCRIBE t").fetchall()]
+        # After replace, only 'x' should remain (y was renamed to x).
+        self.assertEqual(cols, ["x"])
+        values = sorted(row[0] for row in conn.execute("SELECT x FROM t").fetchall())
+        self.assertEqual(values, [10, 20, 30])
+
+
+class TransformColumnTest(unittest.TestCase):
+    """Tests for duckdb_transform_column."""
+
+    def test_transform_applied_to_all_values(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"name": ["alice", "bob", "carol"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_transform_column(conn, "t", "name", lambda v: (v or "").upper())
+
+        values = sorted(row[0] for row in conn.execute("SELECT name FROM t").fetchall())
+        self.assertEqual(values, ["ALICE", "BOB", "CAROL"])
+
+    def test_transform_of_empty_string(self):
+        """Empty string '' is a distinct value (not NULL). The func receives ''."""
+        conn = _make_conn()
+        received: list[str | None] = []
+
+        df = pd.DataFrame({"val": ["x", ""]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        def spy(v: str | None) -> str | None:
+            received.append(v)
+            return v
+
+        duckdb_transform_column(conn, "t", "val", spy)
+
+        # '' should be one of the values passed to the function.
+        self.assertIn("", received, msg="Empty string should be passed to transform_func")
+
+    def test_transform_result_applied_to_all_rows(self):
+        """Duplicate values: both rows with value 'a' get the same transform result."""
+        conn = _make_conn()
+        df = pd.DataFrame({"v": ["a", "a", "b"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_transform_column(conn, "t", "v", lambda v: (v or "").upper())
+
+        values = sorted(row[0] for row in conn.execute("SELECT v FROM t").fetchall())
+        self.assertEqual(values, ["A", "A", "B"])
+
+    def test_column_name_unchanged_after_transform(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"status": ["open", "closed"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_transform_column(conn, "t", "status", lambda v: v)
+
+        cols = [row[0] for row in conn.execute("DESCRIBE t").fetchall()]
+        self.assertEqual(cols, ["status"])
+
+
+class AddColumnTest(unittest.TestCase):
+    """Tests for duckdb_add_column."""
+
+    def test_new_column_added_and_base_column_intact(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"code": ["A", "B", "C"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_add_column(conn, "t", "code", "label", lambda v: f"label_{v}")
+
+        rows = conn.execute("SELECT code, label FROM t ORDER BY code").fetchall()
+        self.assertEqual(rows, [("A", "label_A"), ("B", "label_B"), ("C", "label_C")])
+
+    def test_both_columns_present_after_call(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"id": ["x"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_add_column(conn, "t", "id", "derived", lambda v: (v or "").upper())
+
+        cols = [row[0] for row in conn.execute("DESCRIBE t").fetchall()]
+        self.assertIn("id", cols)
+        self.assertIn("derived", cols)
+
+    def test_new_column_computed_from_base(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"n": [1, 2, 3]})  # noqa: F841
+        conn.execute("CREATE TABLE t (n INTEGER)")
+        conn.execute("INSERT INTO t SELECT * FROM df")
+
+        # DuckDB add_column works via distinct-value mapping.
+        # n is an integer; we cast via str in the func.
+        duckdb_add_column(conn, "t", "n", "doubled", lambda v: str(int(v) * 2) if v else None)
+
+        rows = conn.execute("SELECT n, doubled FROM t ORDER BY n").fetchall()
+        self.assertEqual(rows, [(1, "2"), (2, "4"), (3, "6")])
+
+
+class FilterOnColumnTest(unittest.TestCase):
+    """Tests for duckdb_filter_on_column."""
+
+    def test_only_matching_rows_remain(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"val": ["keep", "drop", "keep", "drop"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_filter_on_column(conn, "t", "val", lambda v: v == "keep")
+
+        values = sorted(row[0] for row in conn.execute("SELECT val FROM t").fetchall())
+        self.assertEqual(values, ["keep", "keep"])
+
+    def test_excluded_rows_gone(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"status": ["a", "b", "c", "a"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_filter_on_column(conn, "t", "status", lambda v: v != "b")
+
+        values = sorted(row[0] for row in conn.execute("SELECT status FROM t").fetchall())
+        self.assertEqual(values, ["a", "a", "c"])
+
+    def test_included_column_not_left_on_table(self):
+        """The temp 'included' column must NOT appear on the table after the call."""
+        conn = _make_conn()
+        df = pd.DataFrame({"x": ["p", "q"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_filter_on_column(conn, "t", "x", lambda v: True)
+
+        cols = [row[0] for row in conn.execute("DESCRIBE t").fetchall()]
+        self.assertNotIn(
+            "included",
+            cols,
+            msg="The 'included' temp column should not be left on the table",
+        )
+
+    def test_all_rows_kept_when_func_always_true(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"v": ["a", "b", "c"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_filter_on_column(conn, "t", "v", lambda v: True)
+
+        count = conn.execute("SELECT count(*) FROM t").fetchone()[0]
+        self.assertEqual(count, 3)
+
+    def test_all_rows_removed_when_func_always_false(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"v": ["a", "b", "c"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        duckdb_filter_on_column(conn, "t", "v", lambda v: False)
+
+        count = conn.execute("SELECT count(*) FROM t").fetchone()[0]
+        self.assertEqual(count, 0)
+
+
+class BatchedRowsTest(unittest.TestCase):
+    """Tests for duckdb_batched_rows."""
+
+    def test_all_rows_yielded(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": ["x", "y", "z", "w", "v"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        relation = conn.execute("SELECT * FROM t ORDER BY a")
+        rows = list(duckdb_batched_rows(relation))
+
+        self.assertEqual(len(rows), 5)
+
+    def test_row_field_values_correct(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"id": [42], "name": ["hello"]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        relation = conn.execute("SELECT * FROM t")
+        rows = list(duckdb_batched_rows(relation))
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], 42)
+        self.assertEqual(rows[0]["name"], "hello")
+
+    def test_empty_table_yields_no_rows(self):
+        conn = _make_conn()
+        conn.execute("CREATE TABLE t (x INTEGER)")
+
+        relation = conn.execute("SELECT * FROM t")
+        rows = list(duckdb_batched_rows(relation))
+
+        self.assertEqual(rows, [])
+
+    def test_yields_pandas_series(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"v": [99]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        relation = conn.execute("SELECT * FROM t")
+        rows = list(duckdb_batched_rows(relation))
+
+        import pandas
+
+        self.assertIsInstance(rows[0], pandas.Series)
+
+
+class GroupedRowsTest(unittest.TestCase):
+    """Tests for duckdb_grouped_rows."""
+
+    def test_two_groups_yielded(self):
+        conn = _make_conn()
+        df = pd.DataFrame(  # noqa: F841
+            {"grp": ["a", "a", "b", "b", "b"], "val": [1, 2, 3, 4, 5]}
+        )
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        groups = list(duckdb_grouped_rows(conn, "t", ["grp"]))
+
+        self.assertEqual(len(groups), 2)
+
+    def test_group_row_counts_correct(self):
+        conn = _make_conn()
+        df = pd.DataFrame(  # noqa: F841
+            {"grp": ["a", "a", "b", "b", "b"], "val": [1, 2, 3, 4, 5]}
+        )
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        groups = list(duckdb_grouped_rows(conn, "t", ["grp"]))
+        # Ordered by grp column → 'a' first, then 'b'.
+        self.assertEqual(len(groups[0]), 2, msg="Group 'a' should have 2 rows")
+        self.assertEqual(len(groups[1]), 3, msg="Group 'b' should have 3 rows")
+
+    def test_groups_ordered_by_grouping_column(self):
+        conn = _make_conn()
+        df = pd.DataFrame(  # noqa: F841
+            {"grp": ["z", "z", "a", "m"], "n": [1, 2, 3, 4]}
+        )
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        groups = list(duckdb_grouped_rows(conn, "t", ["grp"]))
+        # ORDER BY grp → a, m, z
+        first_grp = groups[0][0]["grp"]
+        self.assertEqual(first_grp, "a")
+
+    def test_single_row_group(self):
+        conn = _make_conn()
+        df = pd.DataFrame({"g": ["only"], "v": [7]})  # noqa: F841
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        groups = list(duckdb_grouped_rows(conn, "t", ["g"]))
+
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(groups[0]), 1)
+        self.assertEqual(groups[0][0]["v"], 7)
+
+    def test_multi_column_grouping(self):
+        conn = _make_conn()
+        df = pd.DataFrame(  # noqa: F841
+            {
+                "site": ["cn", "cn", "mm", "mm"],
+                "proj": ["p1", "p1", "p2", "p2"],
+                "val": [1, 2, 3, 4],
+            }
+        )
+        conn.execute("CREATE TABLE t AS SELECT * FROM df")
+
+        groups = list(duckdb_grouped_rows(conn, "t", ["site", "proj"]))
+
+        self.assertEqual(len(groups), 2)
+        for group in groups:
+            self.assertEqual(len(group), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pyspacer/test_label_specs.py
+++ b/tests/pyspacer/test_label_specs.py
@@ -1,0 +1,245 @@
+"""Characterization tests for LabelFilter, LabelRollupSpec, and CNSourceFilter.
+
+All three classes live in mermaid_classifier.pyspacer.train and subclass CsvSpec.
+Tests cover both the pure-Python methods and the in-DuckDB pipeline methods.
+
+Empty growth form is the empty string '' (never NULL) per the BA+GF convention.
+BA+GF separator is '::' (BAGF_SEP).
+"""
+
+import unittest
+from io import StringIO
+
+import duckdb
+import pandas as pd
+
+from mermaid_classifier.pyspacer.train import CNSourceFilter, LabelFilter, LabelRollupSpec
+
+
+def _make_conn() -> duckdb.DuckDBPyConnection:
+    return duckdb.connect()
+
+
+def _seed_annotations(
+    conn: duckdb.DuckDBPyConnection,
+    ba_ids: list[str],
+    gf_ids: list[str],
+) -> None:
+    """Seed a minimal annotations table with benthic_attribute_id + growth_form_id."""
+    assert len(ba_ids) == len(gf_ids)
+    df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL
+        {
+            "benthic_attribute_id": ba_ids,
+            "growth_form_id": gf_ids,
+        }
+    )
+    conn.execute("CREATE OR REPLACE TABLE annotations AS SELECT * FROM df")
+
+
+# ---------------------------------------------------------------------------
+# LabelFilter
+# ---------------------------------------------------------------------------
+
+
+_FILTER_CSV = "ba_id,gf_id\nBA1,GF1\nBA2,\n"
+
+
+class LabelFilterInclusionTest(unittest.TestCase):
+    """Tests for LabelFilter with inclusion=True (default)."""
+
+    def setUp(self):
+        self.f = LabelFilter(StringIO(_FILTER_CSV), inclusion=True)
+
+    def test_known_ba_gf_accepted(self):
+        self.assertTrue(self.f.accepts_bagf("BA1::GF1"))
+
+    def test_known_ba_empty_gf_accepted(self):
+        """BA2 with no growth form is in the spec (empty gf_id cell)."""
+        self.assertTrue(self.f.accepts_bagf("BA2::"))
+
+    def test_unknown_bagf_rejected(self):
+        self.assertFalse(self.f.accepts_bagf("BA9::GF9"))
+
+    def test_none_rejected(self):
+        """None bagf_id is not accepted by an inclusion filter."""
+        self.assertFalse(self.f.accepts_bagf(None))
+
+
+class LabelFilterExclusionTest(unittest.TestCase):
+    """Tests for LabelFilter with inclusion=False."""
+
+    def setUp(self):
+        self.f = LabelFilter(StringIO(_FILTER_CSV), inclusion=False)
+
+    def test_known_ba_gf_excluded(self):
+        """BA1::GF1 is in the exclusion set → not accepted."""
+        self.assertFalse(self.f.accepts_bagf("BA1::GF1"))
+
+    def test_unknown_bagf_accepted(self):
+        """BA9::GF9 is NOT in the exclusion set → accepted."""
+        self.assertTrue(self.f.accepts_bagf("BA9::GF9"))
+
+    def test_none_accepted(self):
+        """None bagf_id passes through an exclusion filter."""
+        self.assertTrue(self.f.accepts_bagf(None))
+
+
+class LabelFilterInDuckDBTest(unittest.TestCase):
+    """Tests for LabelFilter.filter_in_duckdb."""
+
+    def test_only_included_rows_remain(self):
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA1", "BA2", "BA9"], ["GF1", "", "GF9"])
+
+        f = LabelFilter(StringIO(_FILTER_CSV), inclusion=True)
+        f.filter_in_duckdb(conn, "annotations")
+
+        rows = conn.execute(
+            "SELECT benthic_attribute_id, growth_form_id FROM annotations"
+            " ORDER BY benthic_attribute_id"
+        ).fetchall()
+        self.assertEqual(rows, [("BA1", "GF1"), ("BA2", "")])
+
+    def test_excluded_row_removed(self):
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA9"], ["GF9"])
+
+        f = LabelFilter(StringIO(_FILTER_CSV), inclusion=True)
+        f.filter_in_duckdb(conn, "annotations")
+
+        count = conn.execute("SELECT count(*) FROM annotations").fetchone()[0]
+        self.assertEqual(count, 0)
+
+    def test_bagf_id_temp_column_absent_after_filter(self):
+        """The temp 'bagf_id' column added during filtering must be dropped."""
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA1", "BA2"], ["GF1", ""])
+
+        f = LabelFilter(StringIO(_FILTER_CSV), inclusion=True)
+        f.filter_in_duckdb(conn, "annotations")
+
+        cols = [row[0] for row in conn.execute("DESCRIBE annotations").fetchall()]
+        self.assertNotIn("bagf_id", cols, msg="bagf_id temp column must be removed after filter")
+
+    def test_exclusion_filter_keeps_unknown_rows(self):
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA1", "BA9"], ["GF1", "GF9"])
+
+        f = LabelFilter(StringIO(_FILTER_CSV), inclusion=False)
+        f.filter_in_duckdb(conn, "annotations")
+
+        rows = conn.execute("SELECT benthic_attribute_id FROM annotations").fetchall()
+        self.assertEqual(rows, [("BA9",)])
+
+
+# ---------------------------------------------------------------------------
+# LabelRollupSpec
+# ---------------------------------------------------------------------------
+
+
+_ROLLUP_CSV = "from_ba_id,from_gf_id,to_ba_id,to_gf_id\nBA1,GF1,BA10,GF10\nBA2,,BA20,\n"
+
+
+class LabelRollupSpecRollUpTest(unittest.TestCase):
+    """Tests for LabelRollupSpec.roll_up (pure Python)."""
+
+    def setUp(self):
+        self.r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+
+    def test_mapped_bagf_rolled_up(self):
+        self.assertEqual(self.r.roll_up("BA1::GF1"), "BA10::GF10")
+
+    def test_empty_gf_rolled_up(self):
+        """BA2 with empty GF maps to BA20 with empty GF."""
+        self.assertEqual(self.r.roll_up("BA2::"), "BA20::")
+
+    def test_unmapped_bagf_unchanged(self):
+        """A BA+GF not in the rollup spec is returned unchanged."""
+        self.assertEqual(self.r.roll_up("BA9::GF9"), "BA9::GF9")
+
+    def test_none_returns_none(self):
+        self.assertIsNone(self.r.roll_up(None))
+
+
+class LabelRollupSpecInDuckDBTest(unittest.TestCase):
+    """Tests for LabelRollupSpec.roll_up_in_duckdb."""
+
+    def test_mapped_rows_have_updated_ba_gf(self):
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA1", "BA2", "BA9"], ["GF1", "", "GF9"])
+
+        r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+        r.roll_up_in_duckdb(conn, "annotations")
+
+        rows = conn.execute(
+            "SELECT benthic_attribute_id, growth_form_id FROM annotations ORDER BY benthic_attribute_id"
+        ).fetchall()
+        # BA1::GF1 → BA10::GF10; BA2:: → BA20::; BA9::GF9 unchanged
+        self.assertIn(("BA10", "GF10"), rows)
+        self.assertIn(("BA20", ""), rows)
+        self.assertIn(("BA9", "GF9"), rows)
+
+    def test_bagf_id_temp_column_absent_after_rollup(self):
+        """The temp 'bagf_id' column added during rollup must be dropped."""
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA1"], ["GF1"])
+
+        r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+        r.roll_up_in_duckdb(conn, "annotations")
+
+        cols = [row[0] for row in conn.execute("DESCRIBE annotations").fetchall()]
+        self.assertNotIn("bagf_id", cols, msg="bagf_id temp column must be removed after rollup")
+
+    def test_unmapped_row_count_unchanged(self):
+        """Rollup does not drop unmapped rows — count stays the same."""
+        conn = _make_conn()
+        _seed_annotations(conn, ["BA1", "BA9"], ["GF1", "GF9"])
+
+        r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+        r.roll_up_in_duckdb(conn, "annotations")
+
+        count = conn.execute("SELECT count(*) FROM annotations").fetchone()[0]
+        self.assertEqual(count, 2)
+
+
+# ---------------------------------------------------------------------------
+# CNSourceFilter
+# ---------------------------------------------------------------------------
+
+
+class CNSourceFilterTest(unittest.TestCase):
+    """Tests for CNSourceFilter."""
+
+    def test_is_empty_false_when_sources_present(self):
+        f = CNSourceFilter(StringIO("id\n123\n456\n"))
+        self.assertFalse(f.is_empty())
+
+    def test_source_id_list_length(self):
+        f = CNSourceFilter(StringIO("id\n123\n456\n"))
+        self.assertEqual(len(f.source_id_list), 2)
+
+    def test_source_id_list_values(self):
+        """Actual characterization: pandas reads integer IDs as numpy int64."""
+        f = CNSourceFilter(StringIO("id\n123\n456\n"))
+        # The ids are numeric (pandas infers int64 from all-numeric column)
+        # and compare equal to plain Python ints.
+        self.assertEqual(int(f.source_id_list[0]), 123)
+        self.assertEqual(int(f.source_id_list[1]), 456)
+
+    def test_is_empty_true_when_header_only(self):
+        """A CSV with only a header row (no data rows) yields is_empty() == True."""
+        f = CNSourceFilter(StringIO("id\n"))
+        self.assertTrue(f.is_empty())
+
+    def test_is_empty_true_when_empty_csv(self):
+        """A completely empty CSV yields is_empty() == True."""
+        f = CNSourceFilter(StringIO(""))
+        self.assertTrue(f.is_empty())
+
+    def test_source_id_list_empty_when_no_data(self):
+        f = CNSourceFilter(StringIO("id\n"))
+        self.assertEqual(f.source_id_list, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pyspacer/test_metrics_coordinator.py
+++ b/tests/pyspacer/test_metrics_coordinator.py
@@ -1,0 +1,249 @@
+"""Characterization tests for MetricsCoordinator.compute_and_log_all().
+
+The coordinator orchestrates all metric groups and logs results to MLflow.
+These tests characterize:
+
+1. Happy path: compute_and_log_all() completes, records ≥1 mlflow.log_metric call,
+   and a known metric name (precision_macro) appears.
+2. Per-group error isolation: if one metric group raises, the coordinator catches it
+   and still logs metrics from other groups — this is the key invariant that
+   issue #73's registry refactor must preserve.
+3. Invalid context: if ctx.validate() fails, compute_and_log_all() returns early
+   without raising and logs no metrics.
+
+No clf or dataset is provided in any test, so only the always-available groups run
+(confusion_matrices, precision_recall_f1, balanced_accuracy_mcc, taxonomic,
+calibration). This keeps the test offline and dependency-free.
+"""
+
+import unittest
+from unittest import mock
+
+import duckdb
+
+from mermaid_classifier.pyspacer.metrics import MetricsContext, MetricsCoordinator
+from pyspacer.metrics_test_helpers import (
+    MockBALibrary,
+    MockGFLibrary,
+    format_metric,
+    make_val_results,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx() -> MetricsContext:
+    """Build a minimal valid MetricsContext with 3 classes and 7 predictions."""
+    # Classes must be keys that MockBALibrary.by_id knows (A1, A2, B1)
+    # combined with an empty GF string to form valid bagf IDs.
+    classes = ["A1::", "A2::", "B1::"]
+    gt = [0, 1, 2, 0, 1, 2, 0]
+    est = [0, 1, 2, 1, 0, 2, 0]
+    val_results = make_val_results(gt, est, classes)
+    return MetricsContext(
+        val_results=val_results,
+        ba_library=MockBALibrary(),
+        gf_library=MockGFLibrary(),
+        format_func=format_metric,
+    )
+
+
+def _make_bad_ctx() -> MetricsContext:
+    """Build a context whose validate() will fail (unknown class in ba_library)."""
+
+    class _BadBALibrary:
+        def bagf_id_to_name(self, bagf_id, gf_library):
+            raise KeyError(f"unknown: {bagf_id}")
+
+    classes = ["UNKNOWN_CLASS::"]
+    val_results = make_val_results([0], [0], classes)
+    return MetricsContext(
+        val_results=val_results,
+        ba_library=_BadBALibrary(),
+        gf_library=MockGFLibrary(),
+        format_func=format_metric,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class HappyPathTest(unittest.TestCase):
+    """compute_and_log_all() completes and records metrics."""
+
+    def setUp(self):
+        self.conn = duckdb.connect()
+        self.ctx = _make_ctx()
+
+    def test_completes_without_raising(self):
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow"),
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            # If this raises, the test fails.
+            coord.compute_and_log_all()
+
+    def test_at_least_one_metric_logged(self):
+        """At least one mlflow.log_metric call is made on a valid context."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_mlflow,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            coord.compute_and_log_all()
+
+        self.assertGreater(len(mock_mlflow.log_metric.call_args_list), 0)
+
+    def test_precision_macro_metric_is_logged(self):
+        """A known stable metric name — precision_macro — must appear in the calls."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_mlflow,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            coord.compute_and_log_all()
+
+        metric_names = [call.args[0] for call in mock_mlflow.log_metric.call_args_list]
+        self.assertIn(
+            "precision_macro",
+            metric_names,
+            msg=f"precision_macro not found in logged metrics: {metric_names}",
+        )
+
+    def test_precision_macro_value_is_numeric(self):
+        """The logged precision_macro value should be a finite float."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_mlflow,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            coord.compute_and_log_all()
+
+        # Find the precision_macro call
+        for call in mock_mlflow.log_metric.call_args_list:
+            if call.args[0] == "precision_macro":
+                value = call.args[1]
+                self.assertIsInstance(value, (int, float))
+                self.assertGreater(value, 0.0)
+                return
+        self.fail("precision_macro not logged")
+
+
+class ErrorIsolationTest(unittest.TestCase):
+    """A failing metric group must not abort the remaining groups."""
+
+    def setUp(self):
+        self.conn = duckdb.connect()
+        self.ctx = _make_ctx()
+
+    def test_failed_group_does_not_raise(self):
+        """If calibration raises, compute_and_log_all() still completes."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow"),
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+            mock.patch(
+                "mermaid_classifier.pyspacer.metrics.coordinator.compute_calibration",
+                side_effect=RuntimeError("injected failure"),
+            ),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            # Must not raise even though calibration fails.
+            coord.compute_and_log_all()
+
+    def test_other_groups_still_log_after_one_fails(self):
+        """Metrics from other groups are still logged when calibration fails."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_mlflow,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+            mock.patch(
+                "mermaid_classifier.pyspacer.metrics.coordinator.compute_calibration",
+                side_effect=RuntimeError("injected failure"),
+            ),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            coord.compute_and_log_all()
+
+        # precision_recall_f1 group (which is separate from calibration) must
+        # still have logged precision_macro.
+        metric_names = [call.args[0] for call in mock_mlflow.log_metric.call_args_list]
+        self.assertIn(
+            "precision_macro",
+            metric_names,
+            msg=(
+                "precision_macro should still be logged even when calibration fails;"
+                f" got metric_names={metric_names}"
+            ),
+        )
+
+    def test_failed_group_logs_fewer_metrics_than_healthy_run(self):
+        """A run with one failed group logs fewer metrics than a clean run."""
+        # Clean run
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_clean,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            MetricsCoordinator(self.ctx, self.conn).compute_and_log_all()
+        clean_count = len(mock_clean.log_metric.call_args_list)
+
+        # Run with calibration failing
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_broken,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+            mock.patch(
+                "mermaid_classifier.pyspacer.metrics.coordinator.compute_calibration",
+                side_effect=RuntimeError("injected failure"),
+            ),
+        ):
+            MetricsCoordinator(self.ctx, self.conn).compute_and_log_all()
+        broken_count = len(mock_broken.log_metric.call_args_list)
+
+        self.assertGreater(
+            clean_count,
+            broken_count,
+            msg=(
+                f"Broken run ({broken_count}) should log fewer metrics"
+                f" than clean run ({clean_count})"
+            ),
+        )
+
+
+class InvalidContextTest(unittest.TestCase):
+    """An invalid context causes compute_and_log_all to return early, logging nothing."""
+
+    def setUp(self):
+        self.conn = duckdb.connect()
+        self.ctx = _make_bad_ctx()
+
+    def test_does_not_raise_on_invalid_context(self):
+        """compute_and_log_all() must not raise when context validation fails."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow"),
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            # Must not raise.
+            coord.compute_and_log_all()
+
+    def test_no_metrics_logged_on_invalid_context(self):
+        """When context is invalid, no mlflow.log_metric calls are made."""
+        with (
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.mlflow") as mock_mlflow,
+            mock.patch("mermaid_classifier.pyspacer.metrics.coordinator.log_dataframe"),
+        ):
+            coord = MetricsCoordinator(self.ctx, self.conn)
+            coord.compute_and_log_all()
+
+        self.assertEqual(
+            len(mock_mlflow.log_metric.call_args_list),
+            0,
+            msg="No metrics should be logged when context validation fails",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pyspacer/test_training_dataset_pipeline.py
+++ b/tests/pyspacer/test_training_dataset_pipeline.py
@@ -1,0 +1,391 @@
+"""Characterization tests for the TrainingDataset in-DuckDB pipeline.
+
+Rather than driving the full TrainingDataset.__init__ (which reads from S3),
+these tests use the NoInitDataset pattern to characterize the core in-DuckDB
+pipeline steps forward from a seeded synthetic ``annotations`` table:
+
+  rollup (LabelRollupSpec.roll_up_in_duckdb)
+  → filter (LabelFilter.filter_in_duckdb)
+  → subsample (_apply_subsample)
+  → prep + split (prep_annotations_for_pyspacer → preprocess_labels)
+  → tag rows (add_training_set_names)
+
+``download_features_parallel`` is mocked throughout so no S3 access occurs.
+
+Sub-steps characterized
+-----------------------
+- rollup_in_duckdb: row count + BA/GF values change as expected
+- filter_in_duckdb: excluded rows removed
+- _apply_subsample: row count drops to per-class cap; audit df populated
+- prep_annotations_for_pyspacer: returns TrainingTaskLabels with .train/.ref/.val;
+  total points across splits equals input count; split respects ref_val_ratios
+- add_training_set_names: annotations table gains training_set column with
+  values in {train, ref, val}; no NULLs
+
+Sub-steps NOT characterized (with reason)
+------------------------------------------
+- set_train_summary_stats: requires ``get_benthic_attribute_library()`` and
+  ``get_growth_form_library()``, which hit the MERMAID API. Mocking them
+  would involve patching the entire library lookup layer; that work is out
+  of scope for this characterization pass.
+- The full TrainingDataset.__init__ end-to-end: reads CoralNet CSVs and a
+  MERMAID Parquet from S3 via DuckDB, which is impractical to run offline.
+"""
+
+import tempfile
+import unittest
+from io import StringIO
+from unittest import mock
+
+import pandas as pd
+
+from mermaid_classifier.pyspacer.train import (
+    DatasetOptions,
+    LabelFilter,
+    LabelRollupSpec,
+)
+from mermaid_classifier.training.subsample import SubsampleOptions
+
+# Reuse scaffolding from the existing test module.
+from pyspacer.test_train import NoInitDataset, override_settings
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_N_PER_CLASS = 10
+_BA_IDS = ["ba_a", "ba_b", "ba_c"]
+
+
+def _make_dataset() -> NoInitDataset:
+    """Return a NoInitDataset with all attributes needed by the pipeline methods."""
+    dataset = NoInitDataset()
+    dataset._feature_dir = tempfile.mkdtemp()
+    dataset.profiled_sections = []
+    dataset._feature_path_to_s3_location = {}
+    dataset.feature_loc_to_source = {}
+    dataset.options = DatasetOptions(ref_val_ratios=(0.1, 0.1))
+    # artifacts is already set by NoInitDataset.__init__ (Artifacts())
+    return dataset
+
+
+def _seed_annotations(dataset: NoInitDataset) -> None:
+    """Seed a deterministic 30-row annotations table over 3 BA classes."""
+    rows = []
+    for i, ba in enumerate(_BA_IDS):
+        for j in range(_N_PER_CLASS):
+            rows.append(
+                {
+                    "image_id": f"img_{i}_{j}",
+                    "row": j,
+                    "col": j,
+                    "label_id": "100",
+                    "benthic_attribute_id": ba,
+                    "growth_form_id": "",
+                    "site": "mermaid",
+                    "bucket": "my-bucket",
+                    "project_id": f"p{i}",
+                    "feature_vector": f"{ba}/img_{j}.fv",
+                }
+            )
+    df = pd.DataFrame(rows)  # noqa: F841 — referenced by name in DuckDB SQL
+    dataset.duck_conn.execute("CREATE OR REPLACE TABLE annotations AS SELECT * FROM df")
+
+
+_ROLLUP_CSV = "from_ba_id,from_gf_id,to_ba_id,to_gf_id\nba_a,,ba_top,\n"
+_FILTER_CSV = "ba_id,gf_id\nba_top,\nba_b,\n"
+
+
+# ---------------------------------------------------------------------------
+# 1. Rollup step
+# ---------------------------------------------------------------------------
+
+
+class RollupStepTest(unittest.TestCase):
+    """Characterize LabelRollupSpec.roll_up_in_duckdb on the pipeline table."""
+
+    def setUp(self):
+        self.override = override_settings(aws_anonymous="True")
+        self.override.__enter__()
+        self.dataset = _make_dataset()
+        _seed_annotations(self.dataset)
+
+    def tearDown(self):
+        self.override.__exit__(None, None, None)
+
+    def test_rollup_changes_ba_id_for_mapped_class(self):
+        """ba_a maps to ba_top; ba_b and ba_c are unchanged."""
+        r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+        r.roll_up_in_duckdb(self.dataset.duck_conn, "annotations")
+
+        ba_ids = {
+            row[0]
+            for row in self.dataset.duck_conn.execute(
+                "SELECT DISTINCT benthic_attribute_id FROM annotations"
+            ).fetchall()
+        }
+        self.assertIn("ba_top", ba_ids, msg="ba_a should have been rolled up to ba_top")
+        self.assertNotIn("ba_a", ba_ids, msg="ba_a should be gone after rollup")
+        self.assertIn("ba_b", ba_ids)
+        self.assertIn("ba_c", ba_ids)
+
+    def test_rollup_preserves_row_count(self):
+        """Rollup does not drop rows."""
+        r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+        r.roll_up_in_duckdb(self.dataset.duck_conn, "annotations")
+
+        count = self.dataset.duck_conn.execute("SELECT count(*) FROM annotations").fetchone()[0]
+        self.assertEqual(count, 30)
+
+    def test_rollup_temp_column_absent(self):
+        """bagf_id temp column must not survive after rollup."""
+        r = LabelRollupSpec(StringIO(_ROLLUP_CSV))
+        r.roll_up_in_duckdb(self.dataset.duck_conn, "annotations")
+
+        cols = [row[0] for row in self.dataset.duck_conn.execute("DESCRIBE annotations").fetchall()]
+        self.assertNotIn("bagf_id", cols)
+
+
+# ---------------------------------------------------------------------------
+# 2. Filter step
+# ---------------------------------------------------------------------------
+
+
+class FilterStepTest(unittest.TestCase):
+    """Characterize LabelFilter.filter_in_duckdb on the pipeline table."""
+
+    def setUp(self):
+        self.override = override_settings(aws_anonymous="True")
+        self.override.__enter__()
+        self.dataset = _make_dataset()
+        _seed_annotations(self.dataset)
+
+    def tearDown(self):
+        self.override.__exit__(None, None, None)
+
+    def test_filter_removes_excluded_class(self):
+        """ba_c is not in the inclusion filter → should be removed."""
+        f = LabelFilter(StringIO(_FILTER_CSV), inclusion=True)
+        f.filter_in_duckdb(self.dataset.duck_conn, "annotations")
+
+        ba_ids = {
+            row[0]
+            for row in self.dataset.duck_conn.execute(
+                "SELECT DISTINCT benthic_attribute_id FROM annotations"
+            ).fetchall()
+        }
+        self.assertNotIn("ba_c", ba_ids, msg="ba_c should be filtered out")
+        self.assertIn("ba_b", ba_ids)
+
+    def test_filter_reduces_row_count(self):
+        """The filter CSV keeps ba_b only (ba_top not in original table) → 10 rows."""
+        f = LabelFilter(StringIO(_FILTER_CSV), inclusion=True)
+        f.filter_in_duckdb(self.dataset.duck_conn, "annotations")
+
+        count = self.dataset.duck_conn.execute("SELECT count(*) FROM annotations").fetchone()[0]
+        self.assertEqual(count, 10)
+
+
+# ---------------------------------------------------------------------------
+# 3. Subsample step
+# ---------------------------------------------------------------------------
+
+
+class SubsampleStepTest(unittest.TestCase):
+    """Characterize _apply_subsample on a seeded annotations table."""
+
+    def setUp(self):
+        self.override = override_settings(aws_anonymous="True")
+        self.override.__enter__()
+        self.dataset = _make_dataset()
+        _seed_annotations(self.dataset)
+
+    def tearDown(self):
+        self.override.__exit__(None, None, None)
+
+    def test_subsample_reduces_row_count_to_target(self):
+        """balanced subsample with total_annotations=6 → 2 rows per class."""
+        opts = SubsampleOptions(strategy="balanced", total_annotations=6)
+        self.dataset._apply_subsample(opts)
+
+        count = self.dataset.duck_conn.execute("SELECT count(*) FROM annotations").fetchone()[0]
+        self.assertEqual(count, 6)
+
+    def test_subsample_caps_per_class(self):
+        """Each class should have exactly 2 rows after balanced subsample."""
+        opts = SubsampleOptions(strategy="balanced", total_annotations=6)
+        self.dataset._apply_subsample(opts)
+
+        per_class = self.dataset.duck_conn.execute(
+            "SELECT benthic_attribute_id, count(*) FROM annotations GROUP BY 1 ORDER BY 1"
+        ).fetchall()
+        for _ba, count in per_class:
+            with self.subTest(ba=_ba):
+                self.assertEqual(count, 2)
+
+    def test_subsample_audit_df_populated(self):
+        """_subsample_audit_df and _subsample_realized_total are set after the call."""
+        opts = SubsampleOptions(strategy="balanced", total_annotations=6)
+        self.dataset._apply_subsample(opts)
+
+        self.assertIsNotNone(self.dataset._subsample_audit_df)
+        self.assertEqual(self.dataset._subsample_realized_total, 6)
+
+    def test_subsample_audit_df_has_correct_columns(self):
+        opts = SubsampleOptions(strategy="balanced", total_annotations=6)
+        self.dataset._apply_subsample(opts)
+
+        df = self.dataset._subsample_audit_df
+        self.assertIn("pre_count", df.columns)
+        self.assertIn("target_n", df.columns)
+        self.assertIn("realized_n", df.columns)
+
+    def test_subsample_no_op_when_annotations_empty(self):
+        """_apply_subsample on an empty table logs a warning and returns cleanly."""
+        self.dataset.duck_conn.execute("DELETE FROM annotations")
+        opts = SubsampleOptions(strategy="balanced", total_annotations=6)
+        with self.assertLogs(logger="train", level="WARNING"):
+            self.dataset._apply_subsample(opts)
+
+        count = self.dataset.duck_conn.execute("SELECT count(*) FROM annotations").fetchone()[0]
+        self.assertEqual(count, 0)
+
+
+# ---------------------------------------------------------------------------
+# 4. prep_annotations_for_pyspacer + split
+# ---------------------------------------------------------------------------
+
+
+class PrepAnnotationsTest(unittest.TestCase):
+    """Characterize prep_annotations_for_pyspacer and the train/ref/val split."""
+
+    def setUp(self):
+        self.override = override_settings(aws_anonymous="True", download_max_workers=1)
+        self.override.__enter__()
+        self.dataset = _make_dataset()
+        _seed_annotations(self.dataset)
+
+    def tearDown(self):
+        self.override.__exit__(None, None, None)
+
+    def _call_prep(self):
+        with mock.patch(
+            "mermaid_classifier.pyspacer.train.download_features_parallel",
+            return_value=set(),
+        ):
+            return self.dataset.prep_annotations_for_pyspacer()
+
+    def test_returns_training_task_labels(self):
+        """prep_annotations_for_pyspacer returns an object with .train/.ref/.val."""
+        labels = self._call_prep()
+        self.assertTrue(
+            hasattr(labels, "train") and hasattr(labels, "ref") and hasattr(labels, "val")
+        )
+
+    def test_total_labels_equal_input_count(self):
+        """Sum of train+ref+val label counts equals the number of annotations."""
+        labels = self._call_prep()
+        total = labels.train.label_count + labels.ref.label_count + labels.val.label_count
+        # 30 annotations, 3 classes × 10 each — all survive stratified split.
+        self.assertEqual(total, 30)
+
+    def test_split_is_non_empty_across_all_sets(self):
+        """With 3 classes × 10 points each, all three splits are non-empty."""
+        labels = self._call_prep()
+        self.assertGreater(labels.train.label_count, 0)
+        self.assertGreater(labels.ref.label_count, 0)
+        self.assertGreater(labels.val.label_count, 0)
+
+    def test_ref_val_are_smaller_than_train(self):
+        """With default (0.1, 0.1) ratios, ref and val are smaller than train."""
+        labels = self._call_prep()
+        self.assertLess(labels.ref.label_count, labels.train.label_count)
+        self.assertLess(labels.val.label_count, labels.train.label_count)
+
+    def test_all_three_classes_in_train(self):
+        """All three BA classes should appear in the train split."""
+        labels = self._call_prep()
+        classes = labels.train.classes_set
+        self.assertIn("ba_a::", classes)
+        self.assertIn("ba_b::", classes)
+        self.assertIn("ba_c::", classes)
+
+    def test_feature_path_to_s3_location_populated(self):
+        """After prep, _feature_path_to_s3_location maps local paths → S3 keys."""
+        self._call_prep()
+        self.assertGreater(len(self.dataset._feature_path_to_s3_location), 0)
+
+
+# ---------------------------------------------------------------------------
+# 5. add_training_set_names
+# ---------------------------------------------------------------------------
+
+
+class AddTrainingSetNamesTest(unittest.TestCase):
+    """Characterize add_training_set_names populating the training_set column."""
+
+    def setUp(self):
+        self.override = override_settings(aws_anonymous="True", download_max_workers=1)
+        self.override.__enter__()
+        self.dataset = _make_dataset()
+        _seed_annotations(self.dataset)
+
+    def tearDown(self):
+        self.override.__exit__(None, None, None)
+
+    def test_training_set_column_values_in_expected_set(self):
+        """After add_training_set_names, all training_set values are train/ref/val."""
+        with mock.patch(
+            "mermaid_classifier.pyspacer.train.download_features_parallel",
+            return_value=set(),
+        ):
+            labels = self.dataset.prep_annotations_for_pyspacer()
+        self.dataset.labels = labels
+        self.dataset.add_training_set_names()
+
+        distinct = {
+            row[0]
+            for row in self.dataset.duck_conn.execute(
+                "SELECT DISTINCT training_set FROM annotations"
+            ).fetchall()
+        }
+        self.assertEqual(distinct, {"train", "ref", "val"})
+
+    def test_no_null_training_set(self):
+        """Every row should have a non-NULL training_set after the call."""
+        with mock.patch(
+            "mermaid_classifier.pyspacer.train.download_features_parallel",
+            return_value=set(),
+        ):
+            labels = self.dataset.prep_annotations_for_pyspacer()
+        self.dataset.labels = labels
+        self.dataset.add_training_set_names()
+
+        null_count = self.dataset.duck_conn.execute(
+            "SELECT count(*) FROM annotations WHERE training_set IS NULL"
+        ).fetchone()[0]
+        self.assertEqual(null_count, 0)
+
+    def test_train_ref_val_counts_match_labels(self):
+        """Row counts per set in the table match the label counts from prep."""
+        with mock.patch(
+            "mermaid_classifier.pyspacer.train.download_features_parallel",
+            return_value=set(),
+        ):
+            labels = self.dataset.prep_annotations_for_pyspacer()
+        self.dataset.labels = labels
+        self.dataset.add_training_set_names()
+
+        counts = {
+            row[0]: row[1]
+            for row in self.dataset.duck_conn.execute(
+                "SELECT training_set, count(*) FROM annotations GROUP BY training_set"
+            ).fetchall()
+        }
+        self.assertEqual(counts["train"], labels.train.label_count)
+        self.assertEqual(counts["ref"], labels.ref.label_count)
+        self.assertEqual(counts["val"], labels.val.label_count)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pyspacer/test_training_dataset_pipeline.py
+++ b/tests/pyspacer/test_training_dataset_pipeline.py
@@ -32,6 +32,7 @@ Sub-steps NOT characterized (with reason)
   MERMAID Parquet from S3 via DuckDB, which is impractical to run offline.
 """
 
+import shutil
 import tempfile
 import unittest
 from io import StringIO
@@ -57,10 +58,15 @@ _N_PER_CLASS = 10
 _BA_IDS = ["ba_a", "ba_b", "ba_c"]
 
 
-def _make_dataset() -> NoInitDataset:
-    """Return a NoInitDataset with all attributes needed by the pipeline methods."""
+def _make_dataset(test_case: unittest.TestCase) -> NoInitDataset:
+    """Return a NoInitDataset with all attributes needed by the pipeline methods.
+
+    The temp feature dir is removed via the test case's cleanup so the suite
+    stays hermetic and doesn't leak directories.
+    """
     dataset = NoInitDataset()
     dataset._feature_dir = tempfile.mkdtemp()
+    test_case.addCleanup(shutil.rmtree, dataset._feature_dir, ignore_errors=True)
     dataset.profiled_sections = []
     dataset._feature_path_to_s3_location = {}
     dataset.feature_loc_to_source = {}
@@ -107,7 +113,7 @@ class RollupStepTest(unittest.TestCase):
     def setUp(self):
         self.override = override_settings(aws_anonymous="True")
         self.override.__enter__()
-        self.dataset = _make_dataset()
+        self.dataset = _make_dataset(self)
         _seed_annotations(self.dataset)
 
     def tearDown(self):
@@ -157,7 +163,7 @@ class FilterStepTest(unittest.TestCase):
     def setUp(self):
         self.override = override_settings(aws_anonymous="True")
         self.override.__enter__()
-        self.dataset = _make_dataset()
+        self.dataset = _make_dataset(self)
         _seed_annotations(self.dataset)
 
     def tearDown(self):
@@ -197,7 +203,7 @@ class SubsampleStepTest(unittest.TestCase):
     def setUp(self):
         self.override = override_settings(aws_anonymous="True")
         self.override.__enter__()
-        self.dataset = _make_dataset()
+        self.dataset = _make_dataset(self)
         _seed_annotations(self.dataset)
 
     def tearDown(self):
@@ -262,7 +268,7 @@ class PrepAnnotationsTest(unittest.TestCase):
     def setUp(self):
         self.override = override_settings(aws_anonymous="True", download_max_workers=1)
         self.override.__enter__()
-        self.dataset = _make_dataset()
+        self.dataset = _make_dataset(self)
         _seed_annotations(self.dataset)
 
     def tearDown(self):
@@ -327,7 +333,7 @@ class AddTrainingSetNamesTest(unittest.TestCase):
     def setUp(self):
         self.override = override_settings(aws_anonymous="True", download_max_workers=1)
         self.override.__enter__()
-        self.dataset = _make_dataset()
+        self.dataset = _make_dataset(self)
         _seed_annotations(self.dataset)
 
     def tearDown(self):


### PR DESCRIPTION
Closes #72.

Third sub-issue of the #68 refactor & cleanup, and the **safety net** that gates #73's metrics-registry change and all of #74 (the train.py split). **Test code only — zero production changes** (`git diff --stat` is `tests/`-only).

Adds 92 tests (suite 352 → 444), characterizing current behavior of the repo's least-protected code:

- **`tests/common/test_duckdb_utils.py`** — the 7 untested DuckDB helpers (temp-table, replace/transform/add column, filter, batched/grouped rows), incl. the `''`-not-NULL empty-growth-form handling and temp-column cleanup.
- **`tests/common/test_csv_utils.py`** — `CsvSpec`/`ColumnSpec`: header validation, alternate column names, `'' → None` at parse, missing-column `ValueError`, empty-file no-op.
- **`tests/pyspacer/test_label_specs.py`** — `LabelFilter`/`LabelRollupSpec`/`CNSourceFilter`, both pure-Python (`accepts_bagf`, `roll_up`, `is_empty`) and in-DuckDB (`filter_in_duckdb`, `roll_up_in_duckdb`), inclusion + exclusion + None paths.
- **`tests/pyspacer/test_training_dataset_pipeline.py`** — the load-bearing pipeline seeded from a synthetic `annotations` table: rollup → filter → subsample → `prep_annotations_for_pyspacer` → train/ref/val split, asserting split totals and the `training_set` tagging. S3 (`download_features_parallel`) mocked.
- **`tests/pyspacer/test_metrics_coordinator.py`** — `compute_and_log_all()` orchestration: happy path logs real computed metrics, **per-group exception isolation** (the invariant #73's registry must preserve), and invalid-context early return. MLflow sink mocked.

Reuses existing scaffolding (`NoInitDataset`, `override_settings`, `MockBALibrary`/`MockGFLibrary`, `make_val_results`).

**Known gap:** `set_train_summary_stats` is not covered (it needs the full MERMAID API library mock layer). The pipeline stages most at risk in the #74 split are all characterized; this is a candidate follow-up.

## Verification
- `cd tests && uv run python -m unittest` — 444 tests, OK (2 pre-existing skips).
- `ruff check` / `ruff format --check` — green.
- `git diff --stat main..HEAD` — only `tests/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)