### PR TITLE
test: trim unit-test over-coverage (keep robust coverage) (#85)

### DIFF
--- a/tests/pyspacer/test_inference_decoupling.py
+++ b/tests/pyspacer/test_inference_decoupling.py
@@ -2,40 +2,52 @@
 
 Loading a trained classifier for inference (mermaid-classifier[inference]) must
 not require the training-only settings deps (pydantic-settings, psutil). That
-holds only if importing the ``mermaid_classifier.pyspacer`` subpackage does NOT
-import ``mermaid_classifier.pyspacer.settings`` (whose import pulls those deps
-and used to run as a side effect of the subpackage ``__init__``).
+holds only if importing the inference-facing packages does NOT import
+``mermaid_classifier.pyspacer.settings`` (whose import pulls those deps and used
+to run as a side effect of the subpackage ``__init__``).
 
-We assert this in a fresh subprocess so an already-imported settings module in
-the test session can't mask a regression.
+Both serving-relevant entry points are guarded: the ``mermaid_classifier.pyspacer``
+subpackage and the ``mermaid_classifier.pyspacer.inference`` module that serving
+code imports directly. Each import is checked in a fresh subprocess so an
+already-imported settings module in the test session can't mask a regression.
 """
 
 import subprocess
 import sys
 import unittest
 
+_SETTINGS_MODULE = "mermaid_classifier.pyspacer.settings"
+
+# Entry points the [inference] extra must be able to import without pulling in
+# the training-only settings layer.
+_INFERENCE_IMPORTS = [
+    "mermaid_classifier.pyspacer",
+    "mermaid_classifier.pyspacer.inference",
+]
+
+
+def _child_script(import_target: str) -> str:
+    return (
+        "import sys\n"
+        f"import {import_target}  # noqa: F401\n"
+        f"if {_SETTINGS_MODULE!r} in sys.modules:\n"
+        f"    sys.stderr.write('settings was imported via {import_target}')\n"
+        "    raise SystemExit(1)\n"
+        "print('ok')\n"
+    )
+
 
 class InferenceDecouplingTest(unittest.TestCase):
-    CHILD = """
-import sys
-import mermaid_classifier.pyspacer  # noqa: F401
-mod = "mermaid_classifier.pyspacer.settings"
-if mod in sys.modules:
-    raise SystemExit(
-        "importing mermaid_classifier.pyspacer must not import settings "
-        "(breaks the [inference] dependency split)"
-    )
-print("ok")
-"""
-
-    def test_importing_pyspacer_subpackage_does_not_import_settings(self):
-        result = subprocess.run(
-            [sys.executable, "-c", self.CHILD],
-            capture_output=True,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("ok", result.stdout)
+    def test_inference_imports_do_not_import_settings(self):
+        for import_target in _INFERENCE_IMPORTS:
+            with self.subTest(import_target=import_target):
+                result = subprocess.run(
+                    [sys.executable, "-c", _child_script(import_target)],
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, msg=result.stderr)
+                self.assertIn("ok", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/pyspacer/test_metrics_classification.py
+++ b/tests/pyspacer/test_metrics_classification.py
@@ -3,7 +3,6 @@
 import unittest
 
 import matplotlib.pyplot as plt
-from spacer.data_classes import ValResults
 
 from mermaid_classifier.pyspacer.metrics._context import (
     MetricsContext,
@@ -15,44 +14,22 @@ from mermaid_classifier.pyspacer.metrics.classification import (
     compute_confusion_matrices,
     compute_precision_recall_f1,
 )
-
-
-class _MockBALibrary:
-    """Minimal mock of BenthicAttributeLibrary for testing."""
-
-    def bagf_id_to_name(self, bagf_id, gf_library):
-        return f"name_{bagf_id}"
-
-
-class _MockGFLibrary:
-    """Minimal mock of GrowthFormLibrary for testing."""
-
-    pass
-
-
-def _make_val_results(gt_indices, est_indices, classes):
-    """Helper to build a ValResults with dummy scores."""
-    scores = [1.0] * len(gt_indices)
-    return ValResults(
-        scores=scores,
-        gt=gt_indices,
-        est=est_indices,
-        classes=classes,
-    )
-
-
-def _format_metric(value):
-    return round(float(value), 3)
+from pyspacer.metrics_test_helpers import (
+    MockBALibrary,
+    MockGFLibrary,
+    format_metric,
+    make_val_results,
+)
 
 
 def _make_ctx(gt_indices, est_indices, classes):
     """Build a MetricsContext from simple index lists."""
-    val_results = _make_val_results(gt_indices, est_indices, classes)
+    val_results = make_val_results(gt_indices, est_indices, classes)
     return MetricsContext(
         val_results=val_results,
-        ba_library=_MockBALibrary(),
-        gf_library=_MockGFLibrary(),
-        format_func=_format_metric,
+        ba_library=MockBALibrary(),
+        gf_library=MockGFLibrary(),
+        format_func=format_metric,
     )
 
 
@@ -268,16 +245,16 @@ class MetricsContextValidationTest(unittest.TestCase):
         """Build a MetricsContext with a pre-built ValResults."""
         return MetricsContext(
             val_results=val_results,
-            ba_library=ba_library or _MockBALibrary(),
-            gf_library=_MockGFLibrary(),
-            format_func=_format_metric,
+            ba_library=ba_library or MockBALibrary(),
+            gf_library=MockGFLibrary(),
+            format_func=format_metric,
         )
 
     def test_empty_gt_raises(self):
         """Empty ground truth should fail validation."""
         # Build a valid ValResults, then clear gt/est to simulate
         # an edge case (ValResults.__init__ validates non-empty).
-        val_results = _make_val_results(gt_indices=[0], est_indices=[0], classes=["a::"])
+        val_results = make_val_results(gt_indices=[0], est_indices=[0], classes=["a::"])
         val_results.gt = []
         val_results.est = []
         ctx = self._make_ctx_with_val_results(val_results)
@@ -291,7 +268,7 @@ class MetricsContextValidationTest(unittest.TestCase):
             def bagf_id_to_name(self, bagf_id, gf_library):
                 raise KeyError(f"Unknown ID: {bagf_id}")
 
-        val_results = _make_val_results(gt_indices=[0], est_indices=[0], classes=["unknown::"])
+        val_results = make_val_results(gt_indices=[0], est_indices=[0], classes=["unknown::"])
         ctx = self._make_ctx_with_val_results(val_results, ba_library=_BrokenBALibrary())
         with self.assertRaises(MetricsContextError):
             ctx.validate()
@@ -308,7 +285,7 @@ class MetricsContextValidationTest(unittest.TestCase):
     def test_out_of_range_class_index_raises(self):
         """Class indices beyond len(classes) should fail validation."""
         # Build valid ValResults, then inject an out-of-range index.
-        val_results = _make_val_results(gt_indices=[0], est_indices=[0], classes=["a::"])
+        val_results = make_val_results(gt_indices=[0], est_indices=[0], classes=["a::"])
         val_results.gt = [0, 5]
         val_results.est = [0, 0]
         val_results.scores = [1.0, 1.0]

--- a/tests/pyspacer/test_portable_artifact.py
+++ b/tests/pyspacer/test_portable_artifact.py
@@ -2,8 +2,6 @@
 
 import json
 import os
-import subprocess
-import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -22,23 +20,6 @@ from mermaid_classifier.pyspacer.inference import (
 )
 from mermaid_classifier.pyspacer.inference.head import build_calibrated_head
 from pyspacer._calibrated_model_fixture import make_calibrated_model
-
-
-class ScaffoldTest(unittest.TestCase):
-    def test_importing_inference_does_not_import_settings(self):
-        # The [inference] extra must not pull training-only settings deps.
-        child = (
-            "import sys\n"
-            "import mermaid_classifier.pyspacer.inference  # noqa: F401\n"
-            "mod = 'mermaid_classifier.pyspacer.settings'\n"
-            "raise SystemExit(1 if mod in sys.modules else 0)\n"
-        )
-        result = subprocess.run(
-            [sys.executable, "-c", child],
-            capture_output=True,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
 
 
 class HeadParityTest(unittest.TestCase):

--- a/tests/pyspacer/test_portable_artifact.py
+++ b/tests/pyspacer/test_portable_artifact.py
@@ -14,8 +14,6 @@ import torch
 
 from mermaid_classifier.pyspacer.inference import (
     PARITY_PROVEN_SKLEARN,
-    SCHEMA_VERSION,
-    TASK_NAME,
     ManifestError,
     ParityError,
     SklearnPinError,
@@ -27,12 +25,6 @@ from pyspacer._calibrated_model_fixture import make_calibrated_model
 
 
 class ScaffoldTest(unittest.TestCase):
-    def test_constants_and_exceptions_exported(self):
-        self.assertEqual(SCHEMA_VERSION, 1)
-        self.assertEqual(TASK_NAME, "pyspacer_mlp_classifier")
-        self.assertTrue(issubclass(ParityError, Exception))
-        self.assertTrue(issubclass(ManifestError, Exception))
-
     def test_importing_inference_does_not_import_settings(self):
         # The [inference] extra must not pull training-only settings deps.
         child = (

--- a/tests/pyspacer/test_trainer.py
+++ b/tests/pyspacer/test_trainer.py
@@ -101,15 +101,13 @@ class CalibrateInBatchesTest(unittest.TestCase):
 
         return clf_standard, clf_batched, X_ref
 
-    def test_mlp_multiclass_calibration_equivalence(self):
-        """MLPClassifier with 5 classes: batch == standard."""
-        std, batched, X = self._train_and_calibrate_both_ways(5)
-        self._assert_calibration_equivalent(std, batched, X)
-
-    def test_mlp_binary_calibration_equivalence(self):
-        """MLPClassifier with 2 classes (binary edge case): batch == standard."""
-        std, batched, X = self._train_and_calibrate_both_ways(2)
-        self._assert_calibration_equivalent(std, batched, X)
+    def test_mlp_calibration_equivalence(self):
+        """Batched calibration matches standard, for multiclass and the binary edge case."""
+        # 2 classes exercises sklearn's binary calibration path; 5 the multiclass path.
+        for n_classes in (5, 2):
+            with self.subTest(n_classes=n_classes):
+                std, batched, X = self._train_and_calibrate_both_ways(n_classes)
+                self._assert_calibration_equivalent(std, batched, X)
 
     def _assert_calibration_equivalent(self, clf_std, clf_batched, X_test):
         """

--- a/tests/test_classifier_train.py
+++ b/tests/test_classifier_train.py
@@ -79,13 +79,24 @@ class ClassifierTrainMainTest(unittest.TestCase):
         # from the YAML's dataset block into DatasetOptions.
         self.assertEqual(dataset_options.include_mermaid, expected.dataset.include_mermaid)
 
-    def test_default_config_dir_is_coralnet_top108_best(self):
-        """With no --config-dir, the default points at the committed best config."""
-        self.assertEqual(self.module.DEFAULT_CONFIG_DIR.name, "coralnet_top108_best")
+    def test_default_config_dir_is_in_repo_and_loads(self):
+        """The default config dir is repo-root-relative and its config loads.
+
+        Asserts the behavioral invariant (in-repo + a loadable config) rather
+        than a magic directory name, so renaming the default config doesn't
+        break this test while a broken/missing default still would.
+        """
+        from mermaid_classifier.sagemaker.config import TrainingRunConfig
+
+        default_dir = self.module.DEFAULT_CONFIG_DIR
         self.assertTrue(
-            self.module.DEFAULT_CONFIG_DIR.is_relative_to(REPO_ROOT),
+            default_dir.is_relative_to(REPO_ROOT),
             msg="default config dir must be in-repo (repo-root-relative)",
         )
+        config_path = default_dir / self.module.CONFIG_FILENAME
+        self.assertTrue(config_path.is_file(), msg=f"missing {config_path}")
+        # A malformed default config is a real regression; from_yaml_path raises.
+        TrainingRunConfig.from_yaml_path(config_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #85.

Trims tests that cost more to maintain than the confidence they provide, while keeping coverage of real behavior robust. **Test-only; no production code changes.** Each commit keeps the suite green.

Sorting principle used: keep guards of **live** invariants (a future change could still violate them); cut tautological/duplicate/over-coverage tests. The "no pickle" guard the issue cited as an example actually guards a live invariant (pyspacer still ships the pickle API) — so it (and the sklearn-pin and inference-decoupling guards) are **kept**.

## Changes (5 commits)
1. **Remove the tautological scaffold test** — it asserted module constants equal their literals and that exception classes subclass `Exception`. No coverage lost: those constants/exceptions are exercised by the real export/load/mismatch tests.
2. **Consolidate the inference-decoupling guard** — there were two near-duplicate subprocess-import guards (one per entry point: `mermaid_classifier.pyspacer` vs `…​.inference`). Merged both into `test_inference_decoupling.py` via `subTest`, so both serving-relevant import paths are guarded from one home; removed the copy in `test_portable_artifact.py`. The guard now covers **more**, not less.
3. **Behavioral default-config test** — replaced "default dir name == `coralnet_top108_best`" with assertions that survive a rename: the default config dir is repo-root-relative and its `training_config.yaml` loads.
4. **De-duplicate metrics mocks** — `test_metrics_classification.py` re-defined mock BA/GF libraries + `make_val_results`/`format_metric` that already live in the shared `metrics_test_helpers`; now imports them (verified behavior-identical). Other `test_metrics_*` files already use the shared module and were left alone.
5. **Parameterize the calibration-equivalence pair** — the binary and multiclass trainer tests were near-identical; folded into one test looping over `n_classes ∈ {5, 2}` with `subTest` (stdlib, no new dependency); both cases still run.

## Explicitly kept / out of scope
The 3 architectural guards (no-pickle, sklearn-pin, inference-decoupling), the trainer cleanup-scan guards, the per-metric "result shape" structure tests, the manifest per-field mismatch tests, and the taxonomy-helper tests — all kept.

## Verification
- `cd tests && uv run python -m unittest` — **447 tests, OK** (was 450; net −3 method count, coverage unchanged/stronger).
- `ruff check` / `ruff format --check` / `basedpyright` / `uv lock --check` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)