### PR TITLE
docs: accuracy pass on the training/extraction pipeline (feature bucket, CPU/GPU, MLflow, SageMaker usage)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,7 +53,7 @@ AWS_SESSION_TOKEN="..."
 #
 # You'll basically need to set this unless you train with
 # disable_mlflow = True.
-MLFLOW_TRACKING_SERVER=arn:aws:sagemaker:us-east-1:123456781234:mlflow-tracking-server/my-classifiers
+MLFLOW_TRACKING_SERVER=arn:aws:sagemaker:us-east-1:123456781234:mlflow-app/app-xxxxxxxxxxxx
 
 # Filesystem directory to use for caching extractor weights that
 # were downloaded from S3 or from a URL.

--- a/.env.example
+++ b/.env.example
@@ -42,12 +42,14 @@ AWS_SESSION_TOKEN="..."
 # Settings - Other
 #
 
-# URI of the MLflow tracking server.
+# MLflow tracking URI — where runs/models are logged. No server process is
+# needed to log; this just tells MLflow where to write.
 #
-# The URI format depends on how the server's set up. For example, this
-# could be an ARN referring to a SageMaker MLflow tracking server, starting
-# with 'arn:aws:sagemaker:', as demonstrated below.
-# Or it could be a localhost address, like http://127.0.0.1:8080
+#   Local: a SQLite DB or directory store MLflow writes to directly, e.g.
+#     sqlite:///mlflow.db  or  file:./mlruns
+#   SageMaker: the ARN of MERMAID's always-running SageMaker MLflow App
+#     (starts with 'arn:aws:sagemaker:', as shown below) — just set it and
+#     logging happens automatically.
 #
 # You'll basically need to set this unless you train with
 # disable_mlflow = True.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mermaid-classifier
 
-This Python repository enables data scientists to experiment with PySpacer-based classifiers. It also has MERMAID-relevant utilities which aren't specific to the type of classifier being developed.
+Everything needed to **train** the MERMAID coral-reef image classifier and **deploy it for inference**: the PySpacer-based training pipeline and the portable, pickle-free model artifact (and loader) it produces. Also includes shared MERMAID taxonomy/data utilities used along the way.
 
 
 ## Overview
@@ -59,8 +59,9 @@ extra you need, e.g. `pip install "mermaid-classifier[inference] @ git+https://g
 ### Configuration
 
 Training a classifier (or running inference) needs a few configuration values —
-S3 buckets, the feature-extractor weights location, the MLflow tracking URI,
-etc. Provide them with an `.env` file in the directory you run from (copy
+S3 buckets, the feature-extractor weights location, the MLflow tracking
+destination (`MLFLOW_TRACKING_SERVER` — note: not MLflow's standard
+`MLFLOW_TRACKING_URI`), etc. Provide them with an `.env` file in the directory you run from (copy
 [`.env.example`](.env.example) from the repo root to `.env` and fill it in —
 `Settings` only reads a file literally named `.env`), or set the values as
 environment variables.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ superset. Trained models ship as a portable, pickle-free **TorchScript head +
 lockstep across both extras because calibration semantics can shift between
 releases.
 
+**Compute:** the classifier this repo trains and serves runs entirely on **CPU**
+(it's an MLP head over precomputed feature vectors, plus TorchScript inference).
+The only GPU-accelerated step is the one-off **feature extraction** — running the
+fixed pretrained EfficientNet backbone over images to produce those feature
+vectors (see [docs/feature_extraction_at_scale.md](docs/feature_extraction_at_scale.md)).
+
 For the full architecture, conventions, training-pipeline flow, settings, and
 testing patterns, see **[CLAUDE.md](CLAUDE.md)** — it is the source of truth and
 is kept current.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ extra you need, e.g. `pip install "mermaid-classifier[inference] @ git+https://g
 ### Configuration
 
 Training a classifier (or running inference) needs a few configuration values —
-S3 buckets, the feature-extractor weights location, the MLflow tracking server,
+S3 buckets, the feature-extractor weights location, the MLflow tracking URI,
 etc. Provide them with an `.env` file in the directory you run from (copy
 [`.env.example`](.env.example) from the repo root to `.env` and fill it in —
 `Settings` only reads a file literally named `.env`), or set the values as
@@ -73,14 +73,14 @@ AWS SageMaker advantages over local:
 
 - Easily and securely access private S3 files through spaces, as long as the SageMaker domain is set up with an applicable Space execution role.
 - Web-based IDE spaces with real-time collaboration.
-- MLflow tracking servers can be shared by everyone who can access the SageMaker domain.
+- The always-running SageMaker MLflow App is shared by everyone who can access the SageMaker domain (point `MLFLOW_TRACKING_SERVER` at its ARN — no server to start).
 - Default distribution image already has many Python packages relevant to this project. This could be preferable over maintaining a 3 GB local venv.
 
 Local env advantages over SageMaker:
 
 - Don't have to worry about the AWS web session expiring every so often, and don't need constant internet to keep working.
 - More IDE choices, not just VSCode (Code Editor spaces) or JupyterLab.
-- Can run a local MLflow tracking server with very low startup and cost.
+- MLflow logs to a local SQLite DB with no tracking server to run; start the MLflow UI only when you want to browse results.
 - Easier to customize and persist the packages that are installed in the environment.
 
 If you're on a local dev machine and accessing public S3 files, the `AWS_ANONYMOUS` setting may be useful.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@ and conventions live in **[../CLAUDE.md](../CLAUDE.md)**.
 - [workflow.md](workflow.md) — the end-to-end script workflow (config → features → train → report → release) and when to use local vs SageMaker.
 
 ## Setup
-- [mlflow.md](mlflow.md) — set up an MLflow tracking server (local or SageMaker).
-- [mermaid_sagemaker.md](mermaid_sagemaker.md) — access SageMaker for the MERMAID team (IDEs, kernels, gotchas).
+- [mlflow.md](mlflow.md) — where runs get logged (local SQLite DB vs the SageMaker MLflow App) and how to view them; logging needs no server.
+- [mermaid_sagemaker.md](mermaid_sagemaker.md) — how the project uses SageMaker (submit jobs from local vs. Studio for MLflow + job monitoring), plus Studio access, IDEs, and gotchas.
 
 ## Runbooks
 - [pyspacer/train.md](pyspacer/train.md) — train a PySpacer classifier: the YAML training config, data sources, label rollup/filtering, subsampling/weighting, and the programmatic API.

--- a/docs/feature_extraction_at_scale.md
+++ b/docs/feature_extraction_at_scale.md
@@ -1,5 +1,10 @@
 # Feature extraction at scale (SageMaker ProcessingJobs)
 
+Feature extraction is the **only GPU-accelerated step** in the pipeline: it runs
+the fixed pretrained EfficientNet backbone over images to produce the feature
+vectors that training consumes. The classifier trained on those vectors — and
+inference with it — runs entirely on CPU (see [training_at_scale.md](training_at_scale.md)).
+
 `scripts/build_feature_bucket.py` is GPU-bound and single-process: it
 walks N CoralNet sources sequentially. To run in parallel, use
 `scripts/launch_processing.py` with `processing.shard:` set — it

--- a/docs/feature_extraction_at_scale.md
+++ b/docs/feature_extraction_at_scale.md
@@ -5,11 +5,12 @@ the fixed pretrained EfficientNet backbone over images to produce the feature
 vectors that training consumes. The classifier trained on those vectors — and
 inference with it — runs entirely on CPU (see [training_at_scale.md](training_at_scale.md)).
 
-`scripts/build_feature_bucket.py` is GPU-bound and single-process: it
-walks N CoralNet sources sequentially. To run in parallel, use
-`scripts/launch_processing.py` with `processing.shard:` set — it
-submits N parallel SageMaker ProcessingJobs, each handling a sharded
-subset of source IDs.
+`scripts/build_feature_bucket.py` is GPU-bound and runs on a single
+machine: it processes the CoralNet sources with threaded S3 I/O
+(`--max-io-workers`) but a single process for the GPU forward pass. To
+parallelize across machines, use `scripts/launch_processing.py` with
+`processing.shard:` set — it submits N parallel SageMaker ProcessingJobs,
+each handling a sharded subset of source IDs.
 
 > The launcher convention (role ARN, bucket, schema, ECR tagging) is
 > defined in

--- a/docs/mermaid_sagemaker.md
+++ b/docs/mermaid_sagemaker.md
@@ -3,6 +3,33 @@
 These notes are for MERMAID team's data scientists and developers who are working with SageMaker.
 
 
+## How this project uses SageMaker
+
+There are two distinct ways you interact with SageMaker, and they happen in
+different places — don't conflate them:
+
+1. **Submit jobs from your *local* machine** (not from inside Studio). With AWS
+   SSO configured, the launcher scripts create and run SageMaker jobs; the heavy
+   compute runs in SageMaker while you just kick it off from your terminal:
+   - `scripts/launch_training.py` → a **TrainingJob** that trains the classifier
+     (CPU). See [training_at_scale.md](training_at_scale.md).
+   - `scripts/launch_processing.py` → **ProcessingJob(s)** that do feature-vector
+     extraction (GPU; optionally sharded across parallel jobs). See
+     [feature_extraction_at_scale.md](feature_extraction_at_scale.md).
+
+2. **Use SageMaker Studio (in the browser)** to *look at* things, not to launch
+   jobs:
+   - Open the **MLflow App** to browse logged runs and models (see
+     [mlflow.md](mlflow.md)).
+   - Monitor the **Training / Processing Jobs** you submitted (status, logs,
+     metrics) under SageMaker AI → Training / Processing.
+   - Optionally, work inside SageMaker via the in-browser IDEs (below).
+
+So: you do **not** open Studio to run training or feature extraction — submit
+those from your local machine. Studio is for MLflow and for watching the jobs
+run.
+
+
 ## Accessing SageMaker Studio
 
 - Sign into AWS through MERMAID's SSO setup, using the awsapps link for that.
@@ -19,7 +46,7 @@ There are three in-browser IDEs offered by SageMaker: JupyterLab, Code Editor (V
 - MERMAID has only used the first two; the RStudio option requires a professional license for Posit Workbench.
 - Each IDE offering can be used by starting and then opening a Space. There are shared spaces and private spaces; shared spaces enable real-time collaboration. Each space has its own file storage.
 
-Under the MLflow app, MERMAID has an MLflow tracking server set up for PySpacer classifiers.
+MERMAID runs an always-on SageMaker MLflow App for PySpacer classifiers. To log to it, point `MLFLOW_TRACKING_SERVER` at the App's ARN (see [mlflow.md](mlflow.md)) — there's no server to start.
 
 MERMAID isn't using Canvas, which is a "no-code" offering and likely not as flexible.
 

--- a/docs/mlflow.md
+++ b/docs/mlflow.md
@@ -1,10 +1,45 @@
 # MLflow notes
 
+MLflow has two separate concerns that are easy to conflate:
 
-## MLflow tracking server
+1. **Logging** runs and models — happens automatically during training (and is
+   what annotation/inference read back from). It's controlled by the
+   `MLFLOW_TRACKING_SERVER` setting (the tracking URI). **No server process is
+   needed to log.**
+2. **Viewing** logged runs/models in a browser — *that's* what an MLflow server /
+   UI is for. You only need it to look at results, not to produce them.
 
-To log models to MLflow or look up info on logged models, you need to have an MLflow tracking server running.
+## Where runs get logged (the tracking URI)
 
-- On a local development machine, this can be done with `mlflow ui --port 8080` in a terminal with the mermaid-classifier Python environment activated. Then the server can be visited using a web browser at a URL like `http://localhost:8080`. Artifacts and runs get saved to the current directory by default, but this can be [configured](https://mlflow.org/docs/latest/ml/tracking/server/#tracking-server-artifact-store).
+Set `MLFLOW_TRACKING_SERVER` in your `.env` (see `.env.example`):
 
-- On SageMaker, this means navigating to SageMaker Studio > MLflow, and starting the MLflow tracking server. You'll probably need to wait around 20 minutes for it to start up. Then the server can be visited by clicking the ... next to the server, and choosing Open MLflow. Artifacts and runs get saved to the location specified in the SageMaker-defined server options.
+- **Local dev** — point it at a local store and MLflow writes there **directly,
+  with nothing to start**. A SQLite DB is the usual choice:
+
+      MLFLOW_TRACKING_SERVER=sqlite:///mlflow.db
+
+  (a `file:./mlruns` directory store works too). Training and annotation log
+  straight to that DB/directory.
+
+- **SageMaker** — point it at MERMAID's **SageMaker-managed MLflow App** by its
+  ARN:
+
+      MLFLOW_TRACKING_SERVER=arn:aws:sagemaker:<region>:<account>:mlflow-tracking-server/<name>
+
+  The App is always running (provisioned by IaC — see
+  [training_at_scale.md](training_at_scale.md)), so there's **nothing to start or
+  wait for**: with the ARN set, runs are logged to it automatically.
+
+## Viewing logged runs and models
+
+This is the only part that needs a server/UI:
+
+- **Local** — start the MLflow UI against the same store you logged to, e.g.
+  `mlflow ui --backend-store-uri sqlite:///mlflow.db --port 8080`, then open
+  `http://localhost:8080`. (This is purely a viewer; it is not required in order
+  to log.)
+- **SageMaker** — in SageMaker Studio, open the MLflow App (Studio → MLflow →
+  the App → Open MLflow).
+
+For a self-contained HTML report of a single run — no MLflow UI required — use
+`scripts/generate_report.py`.

--- a/docs/mlflow.md
+++ b/docs/mlflow.md
@@ -24,7 +24,10 @@ Set `MLFLOW_TRACKING_SERVER` in your `.env` (see `.env.example`):
 - **SageMaker** — point it at MERMAID's **SageMaker-managed MLflow App** by its
   ARN:
 
-      MLFLOW_TRACKING_SERVER=arn:aws:sagemaker:<region>:<account>:mlflow-tracking-server/<name>
+      MLFLOW_TRACKING_SERVER=arn:aws:sagemaker:<region>:<account>:mlflow-app/<app-id>
+
+  (discover the exact ARN with `aws sagemaker list-mlflow-apps` — see
+  [training_at_scale.md](training_at_scale.md))
 
   The App is always running (provisioned by IaC — see
   [training_at_scale.md](training_at_scale.md)), so there's **nothing to start or

--- a/docs/pyspacer/annotation.md
+++ b/docs/pyspacer/annotation.md
@@ -19,7 +19,7 @@ row,column
 
 The classifier location can be specified as any of the following strings:
 
-- An MLflow registered Model ID; starts with `m-`. Resolves the logged model's `model.pt` + `model.json` artifact. Requires the applicable MLflow tracking server to be running.
+- An MLflow registered Model ID; starts with `m-`. Resolves the logged model's `model.pt` + `model.json` artifact. Requires `MLFLOW_TRACKING_SERVER` to point at wherever the model was logged — a local SQLite DB/store, or the SageMaker MLflow App's ARN (the App is always running). No server process needs to be started for a local store.
 - An S3 URI to the **directory** containing `model.pt` + `model.json`; starts with `s3://` (e.g. `s3://bucket/models/run-abc/`). Both files are downloaded to a temp dir.
 - A local **directory** path containing `model.pt` + `model.json`.
 

--- a/docs/pyspacer/train.md
+++ b/docs/pyspacer/train.md
@@ -6,8 +6,9 @@ drives both local and SageMaker runs, so there's a single source of truth and th
 two paths can't drift:
 
 - **Local:** `uv run python scripts/classifier_train.py --config-dir sagemaker/configs/<name>`
-  (defaults to `coralnet_top108_best`). Requires AWS SSO and an MLflow tracking
-  destination — a tracking server, or a local `file:` URI (e.g. `file:./mlruns`).
+  (defaults to `coralnet_top108_best`). Requires AWS SSO and an
+  `MLFLOW_TRACKING_SERVER` to log to — a local SQLite DB / store
+  (e.g. `sqlite:///mlflow.db`, no server to run) or the SageMaker MLflow App ARN.
 - **SageMaker:** `scripts/launch_training.py` uploads the config dir and runs it in a
   TrainingJob — see [training_at_scale.md](../training_at_scale.md).
 
@@ -136,7 +137,8 @@ below). Two runner classes are available:
   server or experiment needed; handy for tests). The `mlflow` package is still a
   dependency of the training install either way.
 - `MLflowTrainingRunner` — logs the model, metrics, and artifacts to MLflow. Set
-  `MLFLOW_TRACKING_SERVER` to a tracking server or a local `file:` URI.
+  `MLFLOW_TRACKING_SERVER` to where it should log — a local SQLite DB/store or the
+  SageMaker MLflow App ARN (no server to run; see [../mlflow.md](../mlflow.md)).
 
 With no arguments, either runner trains on all MERMAID annotations with no
 filtering or rollup:

--- a/docs/training_at_scale.md
+++ b/docs/training_at_scale.md
@@ -338,8 +338,8 @@ restarts from epoch zero. Use only for runs you're OK retrying.
 
 ## MLflow
 
-The container needs to reach the MLflow tracking server. The URI
-flows through the launcher's `--mlflow-tracking-uri` flag into the
+The container needs to reach MLflow (the always-on SageMaker MLflow App).
+The URI flows through the launcher's `--mlflow-tracking-uri` flag into the
 `MLFLOW_TRACKING_SERVER` env var on the Estimator. The training run
 appears under whatever `experiment_name` is set in the YAML.
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -47,7 +47,9 @@ EfficientNet extractor over every annotated image in a set of CoralNet sources
 and writes a CoralNet-layout feature-vector bucket
 (`s{source_id}/features/i{image_id}.featurevector`) that training then points at
 via `CORALNET_TRAIN_DATA_BUCKET`. It's the heavy, scale-sensitive step — a large
-CoralNet source set is a lot of images to run through the extractor.
+CoralNet source set is a lot of images to run through the extractor — and the
+**only GPU-accelerated step** (the EfficientNet backbone). Generating the config
+(Step 1), training (Step 3), and inference all run on CPU.
 
 The two scripts do the *same* extraction; they differ in how they run it:
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -55,7 +55,7 @@ The two scripts do the *same* extraction; they differ in how they run it:
 
 | Script | Role |
 | - | - |
-| `build_feature_bucket.py` | The extractor itself. Single-process: walks the given CoralNet sources sequentially and writes their feature vectors. Idempotent and resumable (a re-run skips images already extracted), so it can grind through a large source set across restarts. Run it directly to build or update the bucket. |
+| `build_feature_bucket.py` | The extractor itself. Runs on a **single machine** (no SageMaker sharding) — threaded S3 I/O (`--max-io-workers`), one process for the EfficientNet forward pass. Idempotent and resumable (a re-run skips images already extracted), so it can grind through a large source set across restarts. Run it directly to build or update the bucket. |
 | `launch_processing.py` | Runs that same extraction **in parallel** for throughput: fans out N sharded SageMaker ProcessingJobs over the source set. Reach for this when a single process would take too long. See [feature_extraction_at_scale.md](feature_extraction_at_scale.md). |
 
 > `extract_reference_features.py` is a one-off maintenance script: it stacks

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -40,14 +40,21 @@ uv run python scripts/generate_training_config.py \
 
 ---
 
-## Step 2 — Extract / build features
+## Step 2 — Extract features (build the feature-vector bucket)
 
-Choose one path based on scale:
+Training reads **feature vectors**, not raw images. This step runs pyspacer's
+EfficientNet extractor over every annotated image in a set of CoralNet sources
+and writes a CoralNet-layout feature-vector bucket
+(`s{source_id}/features/i{image_id}.featurevector`) that training then points at
+via `CORALNET_TRAIN_DATA_BUCKET`. It's the heavy, scale-sensitive step — a large
+CoralNet source set is a lot of images to run through the extractor.
 
-| Path | Script | When |
-| - | - | - |
-| **Local** | `build_feature_bucket.py` | Building or updating a CoralNet-layout feature-vector bucket for a small/medium source set. Idempotent and resumable. |
-| **SageMaker** | `launch_processing.py` | Full-dataset feature extraction via parallel SageMaker ProcessingJobs (optional sharding). See [feature_extraction_at_scale.md](feature_extraction_at_scale.md). |
+The two scripts do the *same* extraction; they differ in how they run it:
+
+| Script | Role |
+| - | - |
+| `build_feature_bucket.py` | The extractor itself. Single-process: walks the given CoralNet sources sequentially and writes their feature vectors. Idempotent and resumable (a re-run skips images already extracted), so it can grind through a large source set across restarts. Run it directly to build or update the bucket. |
+| `launch_processing.py` | Runs that same extraction **in parallel** for throughput: fans out N sharded SageMaker ProcessingJobs over the source set. Reach for this when a single process would take too long. See [feature_extraction_at_scale.md](feature_extraction_at_scale.md). |
 
 > `extract_reference_features.py` is a one-off maintenance script: it stacks
 > real EfficientNet feature vectors into a `.npy` for the TorchScript-vs-sklearn


### PR DESCRIPTION
Documentation-only. A consolidated accuracy pass fixing several misleading descriptions of how the training + feature-extraction pipeline actually works. No code/config changes.

### 1. Feature-bucket description (`workflow.md`)
Was framed as "Local / small-medium" vs "SageMaker / full-dataset." Reframed by the scripts' real roles: `build_feature_bucket.py` **is** the extractor (single-process, sequential, idempotent/resumable so it handles large sets); `launch_processing.py` runs that **same** extraction in parallel (sharded ProcessingJobs).

### 2. CPU/GPU split
The docs scoped GPU/CPU correctly per-file but never stated the distinction. Made it explicit (README Architecture, `feature_extraction_at_scale.md`, `workflow.md`): the **classifier trains + infers on CPU**; the **only GPU step is feature extraction** (the pretrained EfficientNet backbone). Verified against `features.Dockerfile` (CUDA), `training.Dockerfile` (CPU), and the run-config instance types (`ml.g5` vs `ml.c5`/`ml.m5`).

### 3. MLflow — no server needed to log
The docs implied you must run an MLflow tracking server. Corrected the framing throughout (`docs/mlflow.md` rewritten, plus README, `.env.example`, `docs/README.md`, `mermaid_sagemaker.md`, `training_at_scale.md`, `train.md`, `annotation.md`):
- **Logging** needs no server — locally MLflow writes **directly** to a SQLite DB / file store; on SageMaker it's the **always-on managed MLflow App** (set `MLFLOW_TRACKING_SERVER` to its ARN and logging is automatic — nothing to start).
- A **server/UI is only for viewing** results (`mlflow ui` locally, or the MLflow App in Studio).

### 4. SageMaker usage (local job submission vs. Studio)
Added a "How this project uses SageMaker" section to `mermaid_sagemaker.md` distinguishing:
- **Submit jobs from your local machine** — `launch_training.py` → TrainingJob (training), `launch_processing.py` → ProcessingJob (feature extraction). You run these from your terminal; compute runs in SageMaker.
- **SageMaker Studio** is for *viewing* only — the MLflow App, and monitoring submitted jobs. You don't open Studio to run training/extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)