### PR TITLE
fix(dataset): check CoralNet feature-vector presence (close MERMAID-only gap)

### DIFF
--- a/mermaid_classifier/pyspacer/dataset.py
+++ b/mermaid_classifier/pyspacer/dataset.py
@@ -544,16 +544,9 @@ class TrainingDataset:
         )
 
         with (
-            duckdb_temp_table_name(self.duck_conn) as anno_features_table_name,
             duckdb_temp_table_name(self.duck_conn) as s3_features_table_name,
             duckdb_temp_table_name(self.duck_conn) as missing_features_table_name,
         ):
-            # Get the annotation data's unique feature paths into a table.
-            self.duck_conn.execute(
-                f"CREATE TABLE {anno_features_table_name} AS"
-                f" SELECT DISTINCT feature_full FROM annotations"
-            )
-
             # Get the S3 feature paths into another table.
             s3_paths_df = pd.DataFrame({"feature_full": list(present_feature_paths)})  # noqa: F841  # pyright: ignore[reportUnusedVariable]  # referenced by name in DuckDB SQL via Python-scope scanning
             self.duck_conn.execute(

--- a/mermaid_classifier/pyspacer/dataset.py
+++ b/mermaid_classifier/pyspacer/dataset.py
@@ -193,17 +193,24 @@ class TrainingDataset:
             with self.section_profiling("Per-class subsampling"):
                 self._apply_subsample(options.subsample)
 
-        if options.include_mermaid:
-            # We'll check the annotation data's image IDs against the
-            # feature vectors that are actually present in S3.
-            # TODO: Also check CoralNet bucket/folder for missing features.
+        if options.include_mermaid or options.coralnet_manifest_uri:
+            # We'll check the annotation data's feature paths against the
+            # feature vectors that are actually present in S3, for every
+            # site that has annotations.
 
             with self.section_profiling("Detecting missing feature vectors"):
-                # First, get the paths present in S3 (this can take a while).
-                mermaid_bucket = settings.mermaid_train_data_bucket
-                mermaid_full_paths_in_s3 = set(self.s3.find(path=f"s3://{mermaid_bucket}/mermaid/"))
+                # First, list the feature paths present in S3 for each site
+                # (this can take a while). The listings return `bucket/key`
+                # strings, which match the `feature_full` we build per row.
+                present: set[str] = set()
+                if options.include_mermaid:
+                    mermaid_bucket = settings.mermaid_train_data_bucket
+                    present |= set(self.s3.find(path=f"s3://{mermaid_bucket}/mermaid/"))
+                if options.coralnet_manifest_uri:
+                    coralnet_bucket = settings.coralnet_train_data_bucket
+                    present |= set(self.s3.find(path=f"s3://{coralnet_bucket}/"))
                 # Check against annotation data.
-                self.handle_missing_feature_vectors(mermaid_full_paths_in_s3)
+                self.handle_missing_feature_vectors(present)
 
         self.labels = self.prep_annotations_for_pyspacer()
 
@@ -521,7 +528,12 @@ class TrainingDataset:
         # Result should be [] if doesn't exist, which 'bools' to False.
         return bool(table_query_result)
 
-    def handle_missing_feature_vectors(self, mermaid_full_paths_in_s3: set[str]) -> None:
+    def handle_missing_feature_vectors(self, present_feature_paths: set[str]) -> None:
+        # Check every site's annotation feature paths against the set of
+        # feature vectors actually present in S3. Annotations whose feature
+        # vector is absent are dropped (and the run aborts if too many are
+        # missing). `present_feature_paths` holds `bucket/key` strings, the
+        # same shape as the `feature_full` we build per annotation row.
 
         # Build the annotation data's full feature paths, in DuckDB.
         self.duck_conn.execute(
@@ -540,18 +552,16 @@ class TrainingDataset:
             self.duck_conn.execute(
                 f"CREATE TABLE {anno_features_table_name} AS"
                 f" SELECT DISTINCT feature_full FROM annotations"
-                f" WHERE site = '{Sites.MERMAID.value}'"
             )
 
             # Get the S3 feature paths into another table.
-            s3_paths_df = pd.DataFrame({"feature_full": list(mermaid_full_paths_in_s3)})  # noqa: F841  # pyright: ignore[reportUnusedVariable]  # referenced by name in DuckDB SQL via Python-scope scanning
+            s3_paths_df = pd.DataFrame({"feature_full": list(present_feature_paths)})  # noqa: F841  # pyright: ignore[reportUnusedVariable]  # referenced by name in DuckDB SQL via Python-scope scanning
             self.duck_conn.execute(
                 f"CREATE TEMP TABLE {s3_features_table_name} AS SELECT * FROM s3_paths_df"
             )
 
             in_annotations_count = self.duck_conn.execute(
-                f"SELECT COUNT(DISTINCT feature_full) FROM annotations"
-                f" WHERE site = '{Sites.MERMAID.value}'"
+                "SELECT COUNT(DISTINCT feature_full) FROM annotations"
             ).fetchall()[0][0]
 
             # Get the annotation feature paths that are missing from S3,
@@ -560,9 +570,8 @@ class TrainingDataset:
                 f"CREATE TABLE {missing_features_table_name} AS"
                 f" SELECT DISTINCT a.feature_full FROM annotations a"
                 f" LEFT JOIN {s3_features_table_name} s USING (feature_full)"
-                # MERMAID annotations whose features are not found in S3.
-                f" WHERE a.site = '{Sites.MERMAID.value}'"
-                f"  AND s.feature_full IS NULL"
+                # Annotations whose features are not found in S3.
+                f" WHERE s.feature_full IS NULL"
             )
 
             missing_count = self.duck_conn.execute(
@@ -579,11 +588,8 @@ class TrainingDataset:
                 f"CREATE OR REPLACE TABLE annotations AS"
                 f" SELECT a.* FROM annotations a"
                 f" LEFT JOIN {s3_features_table_name} s USING (feature_full)"
-                # Keep all non-MERMAID annotations (since we don't yet detect
-                # which of those have features present).
-                f" WHERE a.site != '{Sites.MERMAID.value}'"
-                # Keep MERMAID annotations whose features are found in S3.
-                f"  OR s.feature_full IS NOT NULL"
+                # Keep annotations whose features are found in S3.
+                f" WHERE s.feature_full IS NOT NULL"
             )
 
         # Don't need the feature_full column anymore.

--- a/mermaid_classifier/pyspacer/dataset.py
+++ b/mermaid_classifier/pyspacer/dataset.py
@@ -576,6 +576,21 @@ class TrainingDataset:
             ).fetchall()
             missing_examples = [tup[0] for tup in result_tuples]
 
+            # Abort if too many are missing (check before mutating).
+            examples_str = "\n".join(missing_examples)
+            missing_threshold = (
+                in_annotations_count * settings.training_inputs_percent_missing_allowed / 100
+            )
+            if missing_count > missing_threshold:
+                raise RuntimeError(
+                    f"Too many feature vectors are missing"
+                    f" ({missing_count}), such as:"
+                    f"\n{examples_str}"
+                    f"\nYou can configure the tolerance for missing"
+                    f" feature vectors with the"
+                    f" TRAINING_INPUTS_PERCENT_MISSING_ALLOWED setting."
+                )
+
             # Filter out missing feature vectors from annotations table.
             self.duck_conn.execute(
                 f"CREATE OR REPLACE TABLE annotations AS"
@@ -587,21 +602,6 @@ class TrainingDataset:
 
         # Don't need the feature_full column anymore.
         self.duck_conn.execute("ALTER TABLE annotations DROP feature_full")
-
-        # Abort if too many are missing.
-        examples_str = "\n".join(missing_examples)
-        missing_threshold = (
-            in_annotations_count * settings.training_inputs_percent_missing_allowed / 100
-        )
-        if missing_count > missing_threshold:
-            raise RuntimeError(
-                f"Too many feature vectors are missing"
-                f" ({missing_count}), such as:"
-                f"\n{examples_str}"
-                f"\nYou can configure the tolerance for missing"
-                f" feature vectors with the"
-                f" TRAINING_INPUTS_PERCENT_MISSING_ALLOWED setting."
-            )
 
         # Log a warning if any are missing.
         if missing_count > 0:

--- a/sagemaker/configs/coralnet_all_plus_mermaid/training_config.yaml
+++ b/sagemaker/configs/coralnet_all_plus_mermaid/training_config.yaml
@@ -43,5 +43,9 @@ env:
   WEIGHTS_LOCATION: s3://mermaid-config/classifier/v1/efficientnet_weights.pt
   CORALNET_TRAIN_DATA_BUCKET: 2605-coralnet-public-sources
   MERMAID_TRAIN_DATA_BUCKET: coral-reef-training
-  TRAINING_INPUTS_PERCENT_MISSING_ALLOWED: "5"
+  # The measured upstream gap is ~7.3% of distinct CoralNet feature vectors
+  # (raw images absent upstream — unfixable). The threshold is measured on
+  # distinct feature vectors, so "5" would abort the run; "10" tolerates the
+  # gap and drops the unbacked annotations.
+  TRAINING_INPUTS_PERCENT_MISSING_ALLOWED: "10"
   MLFLOW_HTTP_REQUEST_MAX_RETRIES: "2"

--- a/tests/pyspacer/test_train.py
+++ b/tests/pyspacer/test_train.py
@@ -477,6 +477,105 @@ class HandleMissingFeatureVectorsTest(BaseTrainTest):
         self.assertIn("my-bucket/05.fv", message)
         self.assertIn("You can configure the tolerance for missing feature vectors", message)
 
+    def test_coralnet_missing_filtered(self):
+        """
+        CoralNet annotations whose feature vectors are absent from the
+        present-paths set must now be filtered out (previously they were
+        always kept) and a warning logged.
+        """
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": [Sites.CORALNET.value] * 4,
+                "bucket": ["cn-bucket"] * 4,
+                "feature_vector": [
+                    "s1/features/i01.featurevector",
+                    "s1/features/i01.featurevector",
+                    "s1/features/i02.featurevector",
+                    "s1/features/i02.featurevector",
+                ],
+            }
+        )
+        # S3 doesn't have i02.
+        s3_paths = {
+            "cn-bucket/s1/features/i01.featurevector",
+            "cn-bucket/s1/features/i05.featurevector",
+        }
+
+        dataset = NoInitDataset()
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
+        with (
+            self.assertLogs(logger="train", level="WARN") as warn_cm,
+            override_settings(training_inputs_percent_missing_allowed=50),
+        ):
+            dataset.handle_missing_feature_vectors(s3_paths)
+
+        self.assertListEqual(
+            self.annotations_fvs(dataset),
+            ["s1/features/i01.featurevector", "s1/features/i01.featurevector"],
+            msg="i02 CoralNet feature vector should have been filtered out",
+        )
+
+        self.assertEqual(
+            warn_cm.output[0],
+            "WARNING:train:Skipping 1 feature vector(s) because the files"
+            " aren't in S3. Example(s):"
+            "\ncn-bucket/s1/features/i02.featurevector",
+        )
+
+    def test_mixed_sites_missing_filtered_and_abort(self):
+        """
+        With both MERMAID and CoralNet annotations missing feature vectors,
+        both sites' missing rows are filtered, and the abort triggers when
+        the combined missing count exceeds the threshold (counted over the
+        union of distinct feature vectors across all sites).
+        """
+        annotations_df = pd.DataFrame(  # noqa: F841 — referenced by name in DuckDB SQL via Python-scope scanning
+            {
+                "site": [Sites.MERMAID.value, Sites.MERMAID.value]
+                + [Sites.CORALNET.value, Sites.CORALNET.value],
+                "bucket": ["mm-bucket", "mm-bucket", "cn-bucket", "cn-bucket"],
+                "feature_vector": [
+                    "01.fv",
+                    "02.fv",
+                    "s1/features/i01.featurevector",
+                    "s1/features/i02.featurevector",
+                ],
+            }
+        )
+        # Present: only one MERMAID and one CoralNet feature vector.
+        # Missing: mm 02.fv and cn i02 -> 2 of 4 distinct (50%).
+        s3_paths = {
+            "mm-bucket/01.fv",
+            "cn-bucket/s1/features/i01.featurevector",
+        }
+
+        dataset = NoInitDataset()
+        dataset.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
+        # First, with a generous tolerance: both missing rows filtered, no abort.
+        with (
+            self.assertLogs(logger="train", level="WARN"),
+            override_settings(training_inputs_percent_missing_allowed=60),
+        ):
+            dataset.handle_missing_feature_vectors(s3_paths)
+
+        self.assertListEqual(
+            self.annotations_fvs(dataset),
+            ["01.fv", "s1/features/i01.featurevector"],
+            msg="Both MERMAID and CoralNet missing rows should be filtered out",
+        )
+
+        # Now prove the abort triggers when combined missing exceeds threshold.
+        dataset2 = NoInitDataset()
+        dataset2.duck_conn.execute("CREATE TABLE annotations AS SELECT * FROM annotations_df")
+        with (
+            self.assertRaises(RuntimeError) as error_cm,
+            override_settings(training_inputs_percent_missing_allowed=49),
+        ):
+            dataset2.handle_missing_feature_vectors(s3_paths)
+
+        message = str(error_cm.exception)
+        self.assertIn("Too many feature vectors are missing (2), such as:", message)
+
 
 class LazyLibraryTest(BaseTrainTest):
     """


### PR DESCRIPTION
## Problem
`TrainingDataset.handle_missing_feature_vectors` only validated **MERMAID** feature vectors — it kept every CoralNet annotation regardless of whether its `.featurevector` existed in S3 (there was a `TODO` to fix this). So missing CoralNet feature vectors weren't detected, weren't counted against `TRAINING_INPUTS_PERCENT_MISSING_ALLOWED`, and would surface as failures inside pyspacer mid-training.

This was surfaced by a pre-training audit of the all-sources manifest vs. `2605-coralnet-public-sources`: **52,995 expected feature vectors (7.32% of distinct images) are missing**, concentrated in 9 sources — all unfixable upstream gaps (the underlying raw images are absent from `coralnet-public-images`; a `--skip-existing` re-extraction can't generate them).

## Change
- **`handle_missing_feature_vectors` is now site-agnostic** — it checks every site's annotations against the present-S3-paths set, drops annotations whose feature vector is absent (CoralNet included), and aborts only if the missing fraction exceeds the threshold. MERMAID-only inputs behave identically. (Also removed a dead temp table that did a pointless full scan.)
- **Caller** now builds the present-paths set for each site that applies — `s3.find` over `…/mermaid/` (when `include_mermaid`) and over the CoralNet feature bucket (when `coralnet_manifest_uri` is set) — and runs the detection whenever either site applies.
- **`coralnet_all_plus_mermaid` config**: `TRAINING_INPUTS_PERCENT_MISSING_ALLOWED` raised `5`→`10`. The threshold is measured on distinct feature vectors; the measured upstream gap is ~7.3%, so `5` would abort. `10` tolerates the gap and **drops the unbacked annotations** so the run proceeds (final pool ≈ 21.9M annotations, well above the 7.4M subsample target).

## Tests
Added CoralNet-only and mixed CoralNet+MERMAID missing-feature tests (both would have failed under the old MERMAID-only code); existing MERMAID tests unchanged. Full `unittest` suite green (462), `ruff` + `basedpyright` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)