### PR TITLE
fix(release): require torch/sklearn/pyspacer provenance at release

### DIFF
--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -36,6 +36,12 @@ DEFAULT_WEIGHTS_URI = "s3://mermaid-config/classifier/efficientnet.pt"
 
 _VERSION_RE = re.compile(r"^v\d+$")
 
+# The serving runtime's compat gate (mermaid-inference pyspacer_function/compat.py)
+# refuses to score unless model.json records all three of these in trained_with.
+# Enforce their presence at release so a stale/incomplete MLflow artifact fails
+# here, loudly, instead of only when the Lambda first tries to serve it.
+_REQUIRED_PROVENANCE = ("torch", "sklearn", "pyspacer")
+
 
 def validate_version(version: str) -> None:
     """Raise ValueError unless version matches ^v\\d+$ (e.g. v3)."""
@@ -66,8 +72,14 @@ def validate_artifact(model_pt: Path, model_json: Path) -> dict[str, Any]:
         raise ValueError(f"manifest task={manifest.get('task')!r} != {TASK_NAME!r}")
     if not manifest.get("classes"):
         raise ValueError("manifest has empty/missing 'classes'")
-    if not manifest.get("trained_with"):
-        raise ValueError("manifest missing 'trained_with' provenance")
+    trained_with = manifest.get("trained_with") or {}
+    missing = [k for k in _REQUIRED_PROVENANCE if not trained_with.get(k)]
+    if missing:
+        raise ValueError(
+            "manifest 'trained_with' provenance missing key(s): "
+            f"{', '.join(missing)} — the serving runtime requires "
+            f"{'/'.join(_REQUIRED_PROVENANCE)}"
+        )
     # SCHEMA_VERSION is enforced by load_predictor; assert it stays referenced
     # so a future loader change that drops the check is caught here too.
     if manifest.get("schema_version") != SCHEMA_VERSION:

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -81,6 +81,19 @@ class ValidateArtifactTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 ra.validate_artifact(model_pt, model_json)
 
+    def test_rejects_incomplete_provenance(self):
+        # The v2 regression (issue #91): trained_with is present but missing the
+        # `pyspacer` key. The serving compat gate requires torch/sklearn/pyspacer,
+        # so the release gate must reject it rather than defer the failure to
+        # the Lambda's first invocation.
+        with tempfile.TemporaryDirectory() as tmp:
+            model_pt, model_json = self._export(tmp)
+            m = json.loads(model_json.read_text())
+            del m["trained_with"]["pyspacer"]
+            model_json.write_text(json.dumps(m))
+            with self.assertRaises(ValueError):
+                ra.validate_artifact(model_pt, model_json)
+
     def test_rejects_bad_class_count(self):
         # load_predictor probes the graph: a manifest claiming the wrong class
         # count must raise (ManifestError is a subclass-agnostic failure here).


### PR DESCRIPTION
## Summary

The release gate only checked that `trained_with` was non-empty, so a manifest missing the `pyspacer` key still shipped — the serving compat gate then rejected every request, surfacing the failure only at Lambda invocation (blocked #53). This makes the release fail loudly instead.

## Changes

- `validate_artifact()` now requires all of `torch`/`sklearn`/`pyspacer` in `trained_with`.
- Added a test for the regression (`trained_with` present, `pyspacer` absent).

Fixes #91. Refs #53.